### PR TITLE
Add initial shadow-agent prototype

### DIFF
--- a/docs/shadow-agent-project-plan.md
+++ b/docs/shadow-agent-project-plan.md
@@ -1,0 +1,515 @@
+# Shadow Agent Project Plan
+
+## Purpose
+
+Build a new project that combines the strongest patterns from `sidecar` and `agent-flow`:
+
+- `sidecar`: a separate runtime, independent model execution, context handoff, second-window behavior
+- `agent-flow`: live event ingestion, session watching, hook-based observation, graph-oriented visualization
+
+The resulting system is **not** a second chat client.
+
+It is a **shadow agent system**:
+
+- the main agent keeps doing the real work
+- a hidden secondary agent observes the main session
+- the shadow agent interprets, synthesizes, and enriches what is happening
+- the UI renders that interpretation as a rich visual surface
+
+## Core Product Definition
+
+The shadow project should do four jobs:
+
+1. Observe the main agent session in real time.
+2. Normalize the observed activity into a common event model.
+3. Run a shadow intelligence layer that derives higher-level structure from those events.
+4. Render a live visual interface driven by the shadow layer, not just raw logs.
+
+This is the key distinction:
+
+- `agent-flow` shows what happened
+- `sidecar` runs another model in parallel
+- the new project should show what the shadow agent thinks is happening
+
+## What We Are Actually Building
+
+The first useful version should be:
+
+- one new project called `shadow-agent`
+- one live UI surface
+- one event adapter for the main agent
+- one shadow runtime that consumes the same event stream
+- one derived-state layer that emits structured visual insights
+
+That means the UI should show more than:
+
+- nodes
+- tool calls
+- timing
+
+It should also show:
+
+- inferred objective
+- current phase
+- likely next steps
+- ambiguity or drift
+- alternate strategy candidates
+- confidence or uncertainty
+- subproblem clustering
+
+## Direct Mapping From The Two Existing Repos
+
+### Patterns to reuse from `sidecar`
+
+- separate runtime process
+- explicit context packaging
+- hidden secondary model execution
+- session persistence
+- Electron window pattern if a standalone desktop surface is desired
+- MCP inheritance and model-routing ideas
+
+### Patterns to reuse from `agent-flow`
+
+- hook-based ingestion
+- session watcher architecture
+- normalized event stream
+- replayable simulation model
+- graph-oriented renderer
+- transcript and timeline panels
+
+### Patterns to avoid copying directly
+
+- do not make the primary UX another chat box
+- do not make the output only a final fold summary
+- do not limit the interface to literal hook playback
+
+## Proposed Repo Layout
+
+The clean target layout is:
+
+```text
+AgentVisualCrazy/
+  docs/
+  third_party/
+    sidecar/
+    agent-flow/
+  shadow-agent/
+    package.json
+    README.md
+    docs/
+    src/
+      adapters/
+      runtime/
+      schema/
+      derive/
+      ui/
+      persistence/
+    tests/
+```
+
+### Notes on layout
+
+- `third_party/sidecar/` and `third_party/agent-flow/` are references, not development targets
+- `shadow-agent/` is the actual product code
+- the new project should copy ideas selectively, not merge codebases wholesale
+
+## Why We Should Not Literally Merge The Two Repos
+
+A direct merge would create avoidable coupling:
+
+- `sidecar` is centered on OpenCode runtime management and fold workflows
+- `agent-flow` is centered on VS Code extension behavior and visualization
+- their product assumptions are different
+
+The right move is:
+
+- define a fresh internal event schema
+- build adapters into that schema
+- borrow code patterns where they fit
+
+This keeps the new project from inheriting unnecessary product constraints from either source.
+
+## Architecture
+
+## 1. Event Ingestion Layer
+
+This layer observes the main agent.
+
+Responsibilities:
+
+- watch hooks
+- watch transcript files
+- optionally ingest JSONL replays
+- assign session IDs
+- normalize tool events, message events, agent lifecycle events, and permission events
+
+Suggested first adapters:
+
+- Claude Code transcript watcher
+- Claude Code hook adapter
+- replay-file adapter for local development
+
+Output:
+
+- a canonical event stream
+
+## 2. Canonical Event Schema
+
+The new project should define its own schema instead of depending on either upstream shape.
+
+Minimum event types:
+
+- `session_started`
+- `session_ended`
+- `agent_spawned`
+- `agent_completed`
+- `agent_idle`
+- `message`
+- `tool_started`
+- `tool_completed`
+- `tool_failed`
+- `subagent_dispatched`
+- `subagent_returned`
+- `permission_requested`
+- `context_snapshot`
+- `shadow_insight`
+
+Each event should carry:
+
+- `sessionId`
+- `source`
+- `timestamp`
+- `actor`
+- `kind`
+- `payload`
+
+## 3. Shadow Runtime
+
+This is the actual differentiator.
+
+It should subscribe to the canonical event stream and maintain a live interpretation state.
+
+Responsibilities:
+
+- infer what phase the main agent is in
+- summarize current intent
+- detect loops, stalls, thrash, and drift
+- identify important files and clusters of activity
+- generate alternate next-step hypotheses
+- track uncertainty and confidence
+
+Important constraint:
+
+- shadow runtime starts read-only
+- it does not edit files
+- it does not issue tools on behalf of the main agent in v1
+
+This keeps the first version safe and understandable.
+
+## 4. Derived State Layer
+
+Do not ask the UI to derive complex meaning directly from raw events.
+
+Instead, maintain an internal derived model such as:
+
+- `currentObjective`
+- `activePhase`
+- `activeAgents`
+- `toolHeatmap`
+- `riskSignals`
+- `candidateNextMoves`
+- `attentionGraph`
+- `narrativeSummary`
+
+This layer can be partly rule-based at first and later upgraded with model-based interpretation.
+
+## 5. UI Layer
+
+The UI should render both:
+
+- raw activity
+- shadow interpretation
+
+Recommended surfaces:
+
+- graph canvas
+- timeline
+- transcript
+- active file heatmap
+- “shadow summary” side panel
+- “possible next moves” panel
+- “risk / uncertainty” panel
+
+The visual surface should answer:
+
+- what is happening now
+- why it is happening
+- what matters most
+- what is likely next
+
+## UI Direction
+
+The interface should not look like a generic dev dashboard.
+
+It should feel like an active observability and interpretation system.
+
+Good characteristics:
+
+- large central graph or flow field
+- strong session-state indicators
+- focused side panels for interpretation
+- clear visual separation between factual events and inferred insights
+
+Bad characteristics:
+
+- chat-first layout
+- wall of logs
+- decorative graph with no interpretation
+
+## Development Strategy
+
+## Phase 0: Workspace Organization
+
+Goal:
+
+- establish a clean structure for reference repos and the new product
+
+Tasks:
+
+- move `sidecar` into `third_party/sidecar`
+- keep `agent-flow` in `third_party/agent-flow`
+- create `shadow-agent/`
+
+Deliverable:
+
+- workspace structured around the new project rather than one borrowed repo
+
+## Phase 1: Schema + Replay MVP
+
+Goal:
+
+- prove the visual model before touching live integrations
+
+Tasks:
+
+- define canonical event schema
+- create replay loader
+- convert one or two fixture sessions into canonical events
+- build a minimal UI that renders:
+  - graph
+  - timeline
+  - transcript
+  - shadow insight panel
+
+Deliverable:
+
+- local replay demo with zero live dependencies
+
+Why this first:
+
+- fastest path to useful iteration
+- easy to test
+- avoids hook complexity early
+
+## Phase 2: Claude Code Live Adapter
+
+Goal:
+
+- ingest a real live session
+
+Tasks:
+
+- port session-watcher concepts from `agent-flow`
+- port hook-configuration concepts from `agent-flow`
+- emit canonical events
+- support live streaming into the UI
+
+Deliverable:
+
+- live visualization of one real session
+
+## Phase 3: Shadow Interpretation Engine
+
+Goal:
+
+- make the UI intelligent instead of descriptive only
+
+Tasks:
+
+- implement rule-based phase inference
+- implement loop/thrash detection
+- implement file-attention ranking
+- implement “probable next steps”
+- add confidence and uncertainty markers
+
+Deliverable:
+
+- visual layer that explains the session, not just replays it
+
+## Phase 4: Parallel Model-Assisted Shadowing
+
+Goal:
+
+- add real secondary model reasoning
+
+Tasks:
+
+- reuse `sidecar` context packaging ideas
+- feed structured session state to a background model
+- let it emit bounded `shadow_insight` events
+- keep it sandboxed and read-only in v1
+
+Deliverable:
+
+- hybrid system: hooks + deterministic state + model-assisted interpretation
+
+## Phase 5: Optional Intervention Features
+
+Goal:
+
+- decide whether the shadow layer should influence the main run
+
+Possible features:
+
+- suggested next actions
+- suggested retries
+- drift warnings
+- alternative plan proposals
+
+Important rule:
+
+- these are suggestions first, not automatic interventions
+
+## Answering The Likely Questions Up Front
+
+## Is this possible?
+
+Yes.
+
+The pieces already exist across the two repos:
+
+- `agent-flow` proves live observation and visualization
+- `sidecar` proves separate runtime and parallel model execution
+
+The missing piece is a new product boundary and a derived-state layer.
+
+## Is combining the code useful?
+
+Yes, but combining the **patterns** is more useful than combining the repos directly.
+
+Useful:
+
+- porting watcher and hook ideas
+- porting parallel-runtime and context-handoff ideas
+- borrowing renderer concepts
+
+Not useful:
+
+- forcing one repo to absorb the other’s product assumptions
+
+## Should the shadow agent be visible as chat?
+
+Not initially.
+
+A text panel may exist for explanation, but the primary UX should be visual interpretation.
+
+## Should the shadow agent write files?
+
+No in v1.
+
+Read-only shadowing is simpler, safer, and easier to trust.
+
+## Should the system depend on MCP immediately?
+
+No.
+
+MCP can become a source of context later, but the first version should work with:
+
+- hooks
+- transcript files
+- replay fixtures
+
+## Electron or VS Code webview?
+
+Recommended approach:
+
+- first ship as a standalone web app or local desktop shell for speed
+- keep the UI layer portable enough to embed in VS Code later
+
+If immediate proximity to Claude Code is more important than portability, use a VS Code webview first.
+
+If product identity matters more, use standalone first.
+
+## Should the shadow agent use the same model every time?
+
+No hard requirement.
+
+The shadow runtime should accept:
+
+- deterministic rules only
+- optional model assistance
+- configurable model routing later
+
+## How do we know if it is working?
+
+Success criteria for the MVP:
+
+- a replay session can be loaded and understood visually
+- the UI identifies the active phase accurately
+- the UI surfaces useful next-step hypotheses
+- the UI highlights the same critical files a human reviewer would
+- the system is helpful without requiring another chat exchange
+
+## Risks
+
+## Product risk
+
+The biggest failure mode is building a pretty replay tool that adds no real insight.
+
+Mitigation:
+
+- measure usefulness around interpretation, not rendering
+
+## Technical risk
+
+Live hook streams may be noisy, partial, or tool-specific.
+
+Mitigation:
+
+- canonical schema
+- replay fixtures
+- rule-based fallback logic
+
+## UX risk
+
+Too much inferred information can feel fake or distracting.
+
+Mitigation:
+
+- visually separate observations from inferences
+- include confidence markers
+- keep inference bounded and falsifiable
+
+## Recommended Immediate Next Steps
+
+1. Re-root the workspace so both upstream repos live under `third_party/`.
+2. Create `shadow-agent/` as a new project.
+3. Define the canonical event schema.
+4. Build a replay-only prototype before live hooks.
+5. Add the first shadow-insight panel before adding model assistance.
+
+## Concrete First Build Slice
+
+If starting now, the first implementation slice should be:
+
+1. `shadow-agent/src/schema/events.ts`
+2. `shadow-agent/src/adapters/replay-loader.ts`
+3. `shadow-agent/src/derive/basic-insights.ts`
+4. `shadow-agent/src/ui/` with:
+   - graph view
+   - timeline
+   - transcript panel
+   - shadow summary panel
+5. one fixture replay converted from `agent-flow` mock data or a captured session
+
+That slice would be enough to validate whether the concept has real product value.

--- a/docs/shadow-agent-test-plan.md
+++ b/docs/shadow-agent-test-plan.md
@@ -1,0 +1,238 @@
+# Shadow Agent Test Plan
+
+This is the next test roadmap for the initial `shadow-agent` prototype.
+
+It is based on the current implementation in:
+- `shadow-agent/src/shared/*`
+- `shadow-agent/src/persistence/*`
+- `shadow-agent/src/electron/*`
+- `shadow-agent/src/renderer/*`
+
+The current suite covers only happy-path behavior. The biggest gaps are:
+- transcript parsing edge cases
+- derive-state threshold logic
+- file-backed persistence failure handling
+- Electron main/preload contracts
+- renderer state transitions around bootstrap, open, and export
+
+## Immediate priorities
+
+1. `shadow-agent/tests/transcript-adapter.edge.test.ts`
+2. `shadow-agent/tests/replay-store.test.ts`
+3. `shadow-agent/tests/derive.edge.test.ts`
+4. `shadow-agent/tests/persistence.edge.test.ts`
+5. `shadow-agent/tests/electron/main.test.ts`
+6. `shadow-agent/tests/electron/preload.test.ts`
+7. `shadow-agent/tests/renderer/App.test.tsx`
+8. `shadow-agent/tests/renderer/layout.test.ts`
+9. `shadow-agent/tests/transcript-to-state.integration.test.ts`
+10. `shadow-agent/tests/e2e/electron-smoke.spec.ts`
+
+## Shared / Persistence
+
+### `transcript-adapter.edge.test.ts`
+
+Purpose: harden Claude transcript ingestion.
+
+Add cases for:
+- malformed JSONL lines are skipped without aborting the full parse
+- `message.content` as a plain string
+- `thinking` blocks becoming `message` events
+- `tool_result` with `is_error: true` becoming `tool_failed`
+- entries with no `message` being ignored
+- later lines omitting `sessionId` while earlier valid lines established it
+- exactly one synthetic `session_started` and one `session_ended`
+- empty input returning `[]`
+- first line invalid, second line valid
+- mixed block arrays with unknown block types
+- missing `cwd`
+
+Implementation note:
+- use `vi.setSystemTime()` because timestamps are currently generated with `new Date().toISOString()`
+
+### `replay-store.test.ts`
+
+Purpose: lock down the replay format contract.
+
+Add cases for:
+- `serializeEvents` and `parseReplay` round-tripping canonical events
+- blank lines being ignored by `parseReplay`
+- `buildSessionRecord` deriving `sessionId`, `startedAt`, `updatedAt`, `source`, and `eventCount`
+- empty event arrays falling back to `unknown`, epoch timestamps, and `replay`
+- single-event sessions
+- multi-source event arrays
+- invalid replay JSONL currently throwing
+
+### `derive.edge.test.ts`
+
+Purpose: cover the product heuristics that drive most of the UI.
+
+Add cases for:
+- phase precedence staying stable:
+  `write/edit` > `todo/plan` > `bash/test` > `read/grep/glob`
+- `currentObjective` only adopting the first user message while the default title is still in effect
+- agent nodes being created from lifecycle events and from tool activity alone
+- file attention counting `filePath`, `file_path`, and `path`
+- risk signals crossing thresholds:
+  - repeated reads `>= 6`
+  - bash churn `>= 4`
+  - multiple failed tools
+- idle/completed transitions for the same actor
+- no events / no messages
+- shadow insights always including objective, phase, and next-move content
+
+### `persistence.edge.test.ts`
+
+Purpose: harden file-backed session storage before live ingestion lands.
+
+Add cases for:
+- `appendEvent()` creating a new session when none exists
+- custom `FileReplayStoreOptions` changing directory and file names correctly
+- `listSessions()` ignoring corrupt or unreadable directories
+- malformed or missing `session.json` falling back to `buildSessionRecord(events)`
+- session IDs with spaces and slashes encoding/decoding safely
+- equal `updatedAt` values breaking ties on `sessionId`
+- corrupted `events.jsonl`
+
+### `transcript-to-state.integration.test.ts`
+
+Purpose: cover the smallest real pipeline:
+transcript -> canonical events -> persistence -> derived state.
+
+Assert:
+- objective
+- active phase
+- transcript length
+- event count
+- mixed success/failure tools are preserved through the pipeline
+
+## Electron / Renderer
+
+### `electron/main.test.ts`
+
+Purpose: lock down main-process behavior without launching Electron.
+
+Framework:
+- `vitest`
+- node environment
+- `vi.mock('electron')`
+- `vi.mock('node:fs/promises')`
+
+Add cases for:
+- title inference precedence:
+  `session_started.label` > `context_snapshot.title` > first user message > fallback
+- replay-format detection:
+  - `replay` when the first valid line has `kind`
+  - `transcript` on parse failure
+  - `replay` on empty input
+- replay JSONL vs transcript JSONL loading
+- empty parsed event arrays throwing
+- canceled export returning `{ canceled: true }`
+- export appending `.jsonl`
+- export returning an error on write failure
+- IPC registration exposing the expected three channels
+
+Required seam:
+- move importable logic into an exported helper, for example `src/electron/session-io.ts`
+- wrap app boot in an exported `startMainProcess()` instead of booting at module import time
+
+### `electron/preload.test.ts`
+
+Purpose: prevent bridge drift.
+
+Add cases for:
+- `contextBridge.exposeInMainWorld('shadowAgent', ...)`
+- `bootstrap()` invoking `shadow-agent:bootstrap`
+- `openReplayFile()` invoking `shadow-agent:open-replay-file`
+- `exportReplayJsonl(events, name)` invoking `shadow-agent:export-replay-jsonl` with the correct argument order
+
+### `renderer/App.test.tsx`
+
+Purpose: cover the actual renderer state machine.
+
+Framework additions:
+- `@testing-library/react`
+- `@testing-library/jest-dom`
+- `jsdom`
+
+Add cases for:
+- bootstrapping the fixture on mount
+- rendering session title, source, phase, and objective
+- disabling action buttons while busy
+- reloading from `bootstrap()`
+- replacing the snapshot after `openReplayFile()`
+- leaving the current snapshot intact when `openReplayFile()` returns `null`
+- showing the error banner on bootstrap failure
+- showing the error banner on open failure
+- surfacing `export` errors
+- skipping export when no snapshot exists
+
+Required seam:
+- add `src/renderer/bridge.ts`
+- make `App.tsx` import that bridge instead of referencing `window.shadowAgent` directly
+
+### `renderer/layout.test.ts`
+
+Purpose: cover deterministic renderer helpers and empty states.
+
+Add cases for:
+- stable graph layout and edge generation from parent/child agent nodes
+- empty graph, transcript, timeline, and file-attention states
+- invalid timestamps falling back to raw text in `formatClock`
+- `safeFileName` stripping punctuation and clamping length
+
+Required seam:
+- extract `buildGraphLayout`, `formatClock`, and `safeFileName` into `src/renderer/view-model.ts`
+
+### `e2e/electron-smoke.spec.ts`
+
+Purpose: one thin end-to-end check after the seam refactors land.
+
+Framework:
+- `@playwright/test`
+
+Add cases for:
+- app launch with the built-in fixture
+- export flow not surfacing an error
+- open replay flow updating visible session metadata
+
+Useful test-only seam:
+- a deterministic way to stub file dialogs instead of opening native dialogs
+
+## Dependency additions
+
+Add now:
+- `@testing-library/react`
+- `@testing-library/jest-dom`
+- `jsdom`
+
+Add later:
+- `@playwright/test`
+
+## Refactor gates before the next test wave
+
+These small refactors will make the next tests straightforward:
+
+1. Extract Electron session/file logic out of `src/electron/main.ts`
+2. Wrap Electron startup in `startMainProcess()`
+3. Add `src/renderer/bridge.ts`
+4. Extract renderer pure helpers into `src/renderer/view-model.ts`
+
+## Recommended implementation order
+
+1. Add the two seam refactors:
+   - `src/electron/session-io.ts`
+   - `src/renderer/bridge.ts`
+   - `src/renderer/view-model.ts`
+2. Land the shared/persistence edge tests
+3. Land Electron main/preload tests
+4. Land renderer component tests
+5. Add one transcript-to-state integration test
+6. Add one Playwright Electron smoke test
+
+## Current risk summary
+
+- `parseClaudeTranscriptJsonl()` is still timestamp-nondeterministic and lightly covered.
+- `deriveState()` is doing most of the product interpretation with little edge coverage.
+- `FileReplayStore` needs corruption and fallback tests before live ingestion.
+- `src/electron/main.ts` and `src/renderer/App.tsx` need small seams before their behavior can be tested cleanly.

--- a/docs/shadow-agent-visualizer.md
+++ b/docs/shadow-agent-visualizer.md
@@ -1,0 +1,74 @@
+# Shadow Agent Visualizer
+
+## Working idea
+
+Combine the useful parts of `sidecar` and `agent-flow`, but do **not** make the second agent primarily a chat surface.
+
+Instead, the secondary runtime acts as a **shadow agent**:
+
+- It watches the main agent session from the side.
+- It gathers context from one or more other agents or model runs.
+- It prepares structured observations, alternative ideas, warnings, and hypotheses.
+- It renders those results into a rich visual surface instead of competing for the main text thread.
+
+## Core differentiator
+
+The visual interface is **not** produced by the main agent.
+
+The important distinction is:
+
+- The main agent keeps doing the main work.
+- A separate hidden or "secret" shadow agent interprets what is happening.
+- That shadow agent drives the visualization layer and can enrich it with extra context from other model passes.
+
+This makes the visualization feel like an intelligent observer rather than a thin replay of logs.
+
+## Desired behavior
+
+- Queue background analysis as if the system had gained context from other agents.
+- Let the shadow runtime write to a window surface continuously.
+- Use the surface to show what is happening, what might happen next, and what alternative paths exist.
+- Support preparatory or synthesis tasks that do not interrupt the main agent.
+- Potentially use MCP or a future MCP-oriented layer for some of the background preparation work.
+
+## Why the two repos matter
+
+`sidecar` contributes:
+
+- the parallel runtime model
+- the separate window surface
+- independent model execution
+- context capture and folding
+
+`agent-flow` contributes:
+
+- live event visualization
+- session watching and hooks
+- graph-oriented rendering of agent activity
+
+The combined direction is:
+
+1. Observe the main agent like `agent-flow`.
+2. Run a separate parallel intelligence layer like `sidecar`.
+3. Feed the visual layer with both raw activity and shadow-agent interpretation.
+
+## Early product shape
+
+Possible first version:
+
+- Keep the main coding agent untouched.
+- Add one shadow agent process that consumes the same session context.
+- Give that shadow agent read-only observational responsibilities at first.
+- Render a live visual dashboard that mixes:
+  - agent activity
+  - inferred intent
+  - possible next moves
+  - risks or drift
+  - alternate solution ideas
+
+## Open questions
+
+- Should the shadow agent be read-only, or eventually be allowed to spawn helper agents?
+- Should the visualization be strictly live, or also persist as a replayable session artifact?
+- Should sidecar folding become structured event emission instead of only summary output?
+- Should the visual surface be Electron, VS Code webview, or both?

--- a/shadow-agent/.gitignore
+++ b/shadow-agent/.gitignore
@@ -1,0 +1,4 @@
+dist/
+dist-electron/
+node_modules/
+

--- a/shadow-agent/README.md
+++ b/shadow-agent/README.md
@@ -1,0 +1,34 @@
+# Shadow Agent
+
+`shadow-agent` is a passive observer for agent sessions.
+
+It combines:
+- Sidecar-style separation between the observed agent and a secondary shadow runtime
+- Agent Flow-style event ingestion, replay, and visualization
+
+The current slice is intentionally small:
+- loads a built-in replay fixture on startup
+- opens replay JSONL or Claude transcript JSONL from disk
+- normalizes events into a canonical schema
+- derives a lightweight session state with risks, next moves, and file attention
+- renders an Electron dashboard with graph, timeline, transcript, and insight panels
+- exports canonical replay JSONL back to disk
+
+## Commands
+
+```bash
+npm install
+npm test
+npm run build
+```
+
+After building, launch the desktop shell with:
+
+```bash
+npx electron dist-electron/main.cjs
+```
+
+## Scope
+
+This is a read-only prototype. It does not edit files, intervene in the main agent session, or spawn helper agents.
+

--- a/shadow-agent/electron.esbuild.mjs
+++ b/shadow-agent/electron.esbuild.mjs
@@ -1,0 +1,13 @@
+import { build } from 'esbuild';
+
+await build({
+  entryPoints: ['src/electron/main.ts', 'src/electron/preload.ts'],
+  outdir: 'dist-electron',
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  target: 'node20',
+  external: ['electron'],
+  sourcemap: true,
+  outExtension: { '.js': '.cjs' }
+});

--- a/shadow-agent/index.html
+++ b/shadow-agent/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Shadow Agent</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/renderer/main.tsx"></script>
+  </body>
+</html>

--- a/shadow-agent/package-lock.json
+++ b/shadow-agent/package-lock.json
@@ -1,0 +1,3562 @@
+{
+  "name": "shadow-agent",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "shadow-agent",
+      "version": "0.1.0",
+      "dependencies": {
+        "electron": "^37.0.0",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+        "@types/react": "^19.1.2",
+        "@types/react-dom": "^19.1.2",
+        "@vitejs/plugin-react": "^5.0.2",
+        "esbuild": "^0.25.6",
+        "typescript": "^5.8.3",
+        "vite": "^7.0.0",
+        "vitest": "^3.2.4"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
+      "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
+      "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
+      "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
+      "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
+      "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
+      "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
+      "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
+      "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
+      "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
+      "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
+      "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
+      "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
+      "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
+      "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
+      "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
+      "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
+      "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
+      "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
+      "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
+      "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
+      "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
+      "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
+      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.10",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
+      "integrity": "sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001781",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
+      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/electron": {
+      "version": "37.10.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.10.3.tgz",
+      "integrity": "sha512-3IjCGSjQmH50IbW2PFveaTzK+KwcFX9PEhE7KXb9v5IT8cLAiryAN7qezm/XzODhDRlLu0xKG1j8xWBtZ/bx/g==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^22.7.7",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.325",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.325.tgz",
+      "integrity": "sha512-PwfIw7WQSt3xX7yOf5OE/unLzsK9CaN2f/FvV3WjPR1Knoc1T9vePRVV4W1EM301JzzysK51K7FNKcusCr0zYA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/electron/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "license": "MIT"
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
+      "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.0",
+        "@rollup/rollup-android-arm64": "4.60.0",
+        "@rollup/rollup-darwin-arm64": "4.60.0",
+        "@rollup/rollup-darwin-x64": "4.60.0",
+        "@rollup/rollup-freebsd-arm64": "4.60.0",
+        "@rollup/rollup-freebsd-x64": "4.60.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
+        "@rollup/rollup-linux-arm64-musl": "4.60.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
+        "@rollup/rollup-linux-loong64-musl": "4.60.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-musl": "4.60.0",
+        "@rollup/rollup-openbsd-x64": "4.60.0",
+        "@rollup/rollup-openharmony-arm64": "4.60.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
+        "@rollup/rollup-win32-x64-gnu": "4.60.0",
+        "@rollup/rollup-win32-x64-msvc": "4.60.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    }
+  }
+}

--- a/shadow-agent/package.json
+++ b/shadow-agent/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "shadow-agent",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Passive shadow observer that visualizes and interprets agent activity.",
+  "main": "dist-electron/main.cjs",
+  "scripts": {
+    "build:renderer": "vite build",
+    "build:electron": "node electron.esbuild.mjs",
+    "build": "npm run build:renderer && npm run build:electron",
+    "start": "electron dist-electron/main.cjs",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "electron": "^37.0.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "@types/react": "^19.1.2",
+    "@types/react-dom": "^19.1.2",
+    "@vitejs/plugin-react": "^5.0.2",
+    "esbuild": "^0.25.6",
+    "typescript": "^5.8.3",
+    "vite": "^7.0.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/shadow-agent/src/electron/main.ts
+++ b/shadow-agent/src/electron/main.ts
@@ -5,26 +5,7 @@ import { deriveState } from '../shared/derive';
 import { paymentRefactorSession } from '../shared/fixtures/payment-refactor-session';
 import { buildSessionRecord, parseReplay, serializeEvents } from '../shared/replay-store';
 import { parseClaudeTranscriptJsonl } from '../shared/transcript-adapter';
-import type { CanonicalEvent, DerivedState, SessionRecord } from '../shared/schema';
-
-interface LoadedSource {
-  kind: 'fixture' | 'replay' | 'transcript';
-  label: string;
-  path?: string;
-}
-
-interface SnapshotPayload {
-  source: LoadedSource;
-  record: SessionRecord;
-  state: DerivedState;
-  events: CanonicalEvent[];
-}
-
-interface ExportResult {
-  canceled: boolean;
-  filePath?: string;
-  error?: string;
-}
+import type { CanonicalEvent, ExportResult, LoadedSource, SnapshotPayload } from '../shared/schema';
 
 const APP_TITLE = 'Shadow Agent';
 
@@ -131,7 +112,7 @@ function createWindow(): BrowserWindow {
       preload: getPreloadPath(),
       contextIsolation: true,
       nodeIntegration: false,
-      sandbox: false
+      sandbox: true
     }
   });
 

--- a/shadow-agent/src/electron/main.ts
+++ b/shadow-agent/src/electron/main.ts
@@ -1,0 +1,225 @@
+import { app, BrowserWindow, dialog, ipcMain } from 'electron';
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { deriveState } from '../shared/derive';
+import { paymentRefactorSession } from '../shared/fixtures/payment-refactor-session';
+import { buildSessionRecord, parseReplay, serializeEvents } from '../shared/replay-store';
+import { parseClaudeTranscriptJsonl } from '../shared/transcript-adapter';
+import type { CanonicalEvent, DerivedState, SessionRecord } from '../shared/schema';
+
+interface LoadedSource {
+  kind: 'fixture' | 'replay' | 'transcript';
+  label: string;
+  path?: string;
+}
+
+interface SnapshotPayload {
+  source: LoadedSource;
+  record: SessionRecord;
+  state: DerivedState;
+  events: CanonicalEvent[];
+}
+
+interface ExportResult {
+  canceled: boolean;
+  filePath?: string;
+  error?: string;
+}
+
+const APP_TITLE = 'Shadow Agent';
+
+let mainWindow: BrowserWindow | null = null;
+
+function inferTitle(events: CanonicalEvent[], fallback: string): string {
+  const labeledSession = events.find(
+    (event) => event.kind === 'session_started' && typeof event.payload.label === 'string' && event.payload.label.length > 0
+  );
+  if (labeledSession) {
+    return String(labeledSession.payload.label);
+  }
+
+  const sessionTitle = events.find(
+    (event) => event.kind === 'context_snapshot' && typeof event.payload.title === 'string' && event.payload.title.length > 0
+  );
+  if (sessionTitle) {
+    return String(sessionTitle.payload.title);
+  }
+
+  const firstUserMessage = events.find(
+    (event) => event.kind === 'message' && event.actor === 'user' && typeof event.payload.text === 'string'
+  );
+  if (firstUserMessage) {
+    return String(firstUserMessage.payload.text).slice(0, 80);
+  }
+
+  return fallback;
+}
+
+function createSnapshot(events: CanonicalEvent[], source: LoadedSource): SnapshotPayload {
+  const title = inferTitle(events, source.label);
+  const record = buildSessionRecord(events, title);
+  return {
+    source,
+    record,
+    state: deriveState(events, record.title),
+    events
+  };
+}
+
+function detectReplayFormat(raw: string): 'replay' | 'transcript' {
+  const firstLine = raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
+
+  if (!firstLine) {
+    return 'replay';
+  }
+
+  try {
+    const parsed = JSON.parse(firstLine) as Record<string, unknown>;
+    if (typeof parsed.kind === 'string') {
+      return 'replay';
+    }
+  } catch {
+    return 'transcript';
+  }
+
+  return 'transcript';
+}
+
+async function loadSnapshotFromFile(filePath: string): Promise<SnapshotPayload> {
+  const raw = await readFile(filePath, 'utf8');
+  const format = detectReplayFormat(raw);
+  const events = format === 'replay' ? parseReplay(raw) : parseClaudeTranscriptJsonl(raw);
+  if (events.length === 0) {
+    throw new Error(`No events could be read from ${path.basename(filePath)}.`);
+  }
+
+  return createSnapshot(events, {
+    kind: format,
+    label: path.basename(filePath),
+    path: filePath
+  });
+}
+
+function buildFixtureSnapshot(): SnapshotPayload {
+  return createSnapshot(paymentRefactorSession, {
+    kind: 'fixture',
+    label: 'Built-in replay fixture'
+  });
+}
+
+function getIndexHtmlPath(): string {
+  return path.resolve(app.getAppPath(), 'dist', 'index.html');
+}
+
+function getPreloadPath(): string {
+  return path.join(__dirname, 'preload.cjs');
+}
+
+function createWindow(): BrowserWindow {
+  const win = new BrowserWindow({
+    width: 1600,
+    height: 1080,
+    minWidth: 1280,
+    minHeight: 860,
+    title: APP_TITLE,
+    backgroundColor: '#07111d',
+    autoHideMenuBar: true,
+    webPreferences: {
+      preload: getPreloadPath(),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: false
+    }
+  });
+
+  const devServerUrl = process.env.VITE_DEV_SERVER_URL;
+  if (devServerUrl) {
+    void win.loadURL(devServerUrl);
+  } else {
+    void win.loadFile(getIndexHtmlPath());
+  }
+
+  win.on('closed', () => {
+    if (mainWindow === win) {
+      mainWindow = null;
+    }
+  });
+
+  return win;
+}
+
+async function pickOpenFile(): Promise<string | undefined> {
+  const result = await dialog.showOpenDialog(mainWindow ?? undefined, {
+    title: 'Open transcript or replay file',
+    properties: ['openFile'],
+    filters: [
+      { name: 'Replay files', extensions: ['jsonl', 'ndjson'] },
+      { name: 'JSON files', extensions: ['json'] },
+      { name: 'Text files', extensions: ['txt'] },
+      { name: 'All files', extensions: ['*'] }
+    ]
+  });
+
+  if (result.canceled || result.filePaths.length === 0) {
+    return undefined;
+  }
+
+  return result.filePaths[0];
+}
+
+async function saveReplayFile(events: CanonicalEvent[], suggestedFileName = 'shadow-agent-replay.jsonl'): Promise<ExportResult> {
+  try {
+    const result = await dialog.showSaveDialog(mainWindow ?? undefined, {
+      title: 'Export replay JSONL',
+      defaultPath: suggestedFileName.endsWith('.jsonl') ? suggestedFileName : `${suggestedFileName}.jsonl`,
+      filters: [{ name: 'Replay files', extensions: ['jsonl'] }]
+    });
+
+    if (result.canceled || !result.filePath) {
+      return { canceled: true };
+    }
+
+    await writeFile(result.filePath, serializeEvents(events), 'utf8');
+    return { canceled: false, filePath: result.filePath };
+  } catch (error) {
+    return {
+      canceled: false,
+      error: error instanceof Error ? error.message : 'Unable to export replay JSONL.'
+    };
+  }
+}
+
+function registerIpcHandlers(): void {
+  ipcMain.handle('shadow-agent:bootstrap', () => buildFixtureSnapshot());
+  ipcMain.handle('shadow-agent:open-replay-file', async () => {
+    const filePath = await pickOpenFile();
+    if (!filePath) {
+      return null;
+    }
+
+    return loadSnapshotFromFile(filePath);
+  });
+  ipcMain.handle('shadow-agent:export-replay-jsonl', async (_event, events: CanonicalEvent[], suggestedFileName?: string) =>
+    saveReplayFile(events, suggestedFileName)
+  );
+}
+
+app.whenReady().then(() => {
+  registerIpcHandlers();
+  mainWindow = createWindow();
+});
+
+app.on('activate', () => {
+  if (BrowserWindow.getAllWindows().length === 0) {
+    mainWindow = createWindow();
+  }
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/shadow-agent/src/electron/preload.ts
+++ b/shadow-agent/src/electron/preload.ts
@@ -1,0 +1,28 @@
+import { contextBridge, ipcRenderer } from 'electron';
+import type { CanonicalEvent, DerivedState, SessionRecord } from '../shared/schema';
+
+interface LoadedSource {
+  kind: 'fixture' | 'replay' | 'transcript';
+  label: string;
+  path?: string;
+}
+
+interface SnapshotPayload {
+  source: LoadedSource;
+  record: SessionRecord;
+  state: DerivedState;
+  events: CanonicalEvent[];
+}
+
+interface ExportResult {
+  canceled: boolean;
+  filePath?: string;
+  error?: string;
+}
+
+contextBridge.exposeInMainWorld('shadowAgent', {
+  bootstrap: () => ipcRenderer.invoke('shadow-agent:bootstrap') as Promise<SnapshotPayload>,
+  openReplayFile: () => ipcRenderer.invoke('shadow-agent:open-replay-file') as Promise<SnapshotPayload | null>,
+  exportReplayJsonl: (events: CanonicalEvent[], suggestedFileName?: string) =>
+    ipcRenderer.invoke('shadow-agent:export-replay-jsonl', events, suggestedFileName) as Promise<ExportResult>
+});

--- a/shadow-agent/src/electron/preload.ts
+++ b/shadow-agent/src/electron/preload.ts
@@ -1,28 +1,11 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import type { CanonicalEvent, DerivedState, SessionRecord } from '../shared/schema';
+import type { CanonicalEvent, ExportResult, ShadowAgentBridge, SnapshotPayload } from '../shared/schema';
 
-interface LoadedSource {
-  kind: 'fixture' | 'replay' | 'transcript';
-  label: string;
-  path?: string;
-}
-
-interface SnapshotPayload {
-  source: LoadedSource;
-  record: SessionRecord;
-  state: DerivedState;
-  events: CanonicalEvent[];
-}
-
-interface ExportResult {
-  canceled: boolean;
-  filePath?: string;
-  error?: string;
-}
-
-contextBridge.exposeInMainWorld('shadowAgent', {
+const bridge: ShadowAgentBridge = {
   bootstrap: () => ipcRenderer.invoke('shadow-agent:bootstrap') as Promise<SnapshotPayload>,
   openReplayFile: () => ipcRenderer.invoke('shadow-agent:open-replay-file') as Promise<SnapshotPayload | null>,
   exportReplayJsonl: (events: CanonicalEvent[], suggestedFileName?: string) =>
     ipcRenderer.invoke('shadow-agent:export-replay-jsonl', events, suggestedFileName) as Promise<ExportResult>
-});
+};
+
+contextBridge.exposeInMainWorld('shadowAgent', bridge);

--- a/shadow-agent/src/persistence/file-replay-store.ts
+++ b/shadow-agent/src/persistence/file-replay-store.ts
@@ -1,0 +1,131 @@
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { buildSessionRecord, parseReplay, serializeEvents } from '../shared/replay-store';
+import type { CanonicalEvent, SessionRecord } from '../shared/schema';
+
+export interface FileReplayStoreOptions {
+  sessionsDirName?: string;
+  eventsFileName?: string;
+  recordFileName?: string;
+}
+
+export interface StoredReplaySession {
+  record: SessionRecord;
+  events: CanonicalEvent[];
+}
+
+const DEFAULT_OPTIONS: Required<FileReplayStoreOptions> = {
+  sessionsDirName: 'sessions',
+  eventsFileName: 'events.jsonl',
+  recordFileName: 'session.json'
+};
+
+function encodeSessionId(sessionId: string): string {
+  return encodeURIComponent(sessionId);
+}
+
+function decodeSessionId(encodedSessionId: string): string {
+  return decodeURIComponent(encodedSessionId);
+}
+
+function sortSessions(left: SessionRecord, right: SessionRecord): number {
+  const updatedAtDiff = right.updatedAt.localeCompare(left.updatedAt);
+  if (updatedAtDiff !== 0) {
+    return updatedAtDiff;
+  }
+
+  return left.sessionId.localeCompare(right.sessionId);
+}
+
+export class FileReplayStore {
+  private readonly sessionsDir: string;
+  private readonly eventsFileName: string;
+  private readonly recordFileName: string;
+
+  constructor(private readonly rootDir: string, options: FileReplayStoreOptions = {}) {
+    const mergedOptions = { ...DEFAULT_OPTIONS, ...options };
+    this.sessionsDir = join(rootDir, mergedOptions.sessionsDirName);
+    this.eventsFileName = mergedOptions.eventsFileName;
+    this.recordFileName = mergedOptions.recordFileName;
+  }
+
+  private sessionDir(sessionId: string): string {
+    return join(this.sessionsDir, encodeSessionId(sessionId));
+  }
+
+  private eventsPath(sessionId: string): string {
+    return join(this.sessionDir(sessionId), this.eventsFileName);
+  }
+
+  private recordPath(sessionId: string): string {
+    return join(this.sessionDir(sessionId), this.recordFileName);
+  }
+
+  async saveSession(sessionId: string, events: CanonicalEvent[], title?: string): Promise<SessionRecord> {
+    const sessionDir = this.sessionDir(sessionId);
+    await mkdir(sessionDir, { recursive: true });
+
+    const record = buildSessionRecord(events, title);
+    const eventLog = `${serializeEvents(events)}${events.length > 0 ? '\n' : ''}`;
+    await writeFile(this.eventsPath(sessionId), eventLog, 'utf8');
+    await writeFile(this.recordPath(sessionId), `${JSON.stringify(record, null, 2)}\n`, 'utf8');
+
+    return record;
+  }
+
+  async appendEvent(sessionId: string, event: CanonicalEvent, title?: string): Promise<SessionRecord> {
+    const current = await this.loadSession(sessionId).catch(() => undefined);
+    const nextEvents = [...(current?.events ?? []), event];
+    return this.saveSession(sessionId, nextEvents, title ?? current?.record.title);
+  }
+
+  async loadSession(sessionId: string): Promise<StoredReplaySession> {
+    const eventsText = await readFile(this.eventsPath(sessionId), 'utf8');
+    const events = parseReplay(eventsText);
+    const record = await this.loadRecord(sessionId, events);
+    return { record, events };
+  }
+
+  async loadEvents(sessionId: string): Promise<CanonicalEvent[]> {
+    return (await this.loadSession(sessionId)).events;
+  }
+
+  async listSessions(): Promise<SessionRecord[]> {
+    let entries: Array<{ name: string }> = [];
+
+    try {
+      entries = await readdir(this.sessionsDir, { withFileTypes: false }).then((names) =>
+        names.map((name) => ({ name }))
+      );
+    } catch {
+      return [];
+    }
+
+    const sessions = await Promise.all(
+      entries.map(async ({ name }) => {
+        const sessionId = decodeSessionId(name);
+        try {
+          return (await this.loadSession(sessionId)).record;
+        } catch {
+          return undefined;
+        }
+      })
+    );
+
+    return sessions.filter((session): session is SessionRecord => Boolean(session)).sort(sortSessions);
+  }
+
+  private async loadRecord(sessionId: string, events: CanonicalEvent[]): Promise<SessionRecord> {
+    try {
+      const recordText = await readFile(this.recordPath(sessionId), 'utf8');
+      const parsed = JSON.parse(recordText) as Partial<SessionRecord>;
+      return buildSessionRecord(events, parsed.title ?? undefined);
+    } catch {
+      return buildSessionRecord(events);
+    }
+  }
+}
+
+export function createFileReplayStore(rootDir: string, options?: FileReplayStoreOptions): FileReplayStore {
+  return new FileReplayStore(rootDir, options);
+}

--- a/shadow-agent/src/persistence/index.ts
+++ b/shadow-agent/src/persistence/index.ts
@@ -1,0 +1,2 @@
+export { FileReplayStore, createFileReplayStore } from './file-replay-store';
+export type { FileReplayStoreOptions, StoredReplaySession } from './file-replay-store';

--- a/shadow-agent/src/renderer/App.tsx
+++ b/shadow-agent/src/renderer/App.tsx
@@ -1,0 +1,531 @@
+import { startTransition, useEffect, useMemo, useState } from 'react';
+import type { AgentNode, CanonicalEvent, DerivedState, ShadowInsight, TimelineItem } from '../shared/schema';
+
+interface LoadedSource {
+  kind: 'fixture' | 'replay' | 'transcript';
+  label: string;
+  path?: string;
+}
+
+interface SnapshotPayload {
+  source: LoadedSource;
+  record: {
+    sessionId: string;
+    title: string;
+    startedAt: string;
+    updatedAt: string;
+    source: CanonicalEvent['source'];
+    eventCount: number;
+  };
+  state: DerivedState;
+  events: CanonicalEvent[];
+}
+
+function formatClock(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.valueOf())) {
+    return timestamp;
+  }
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+function toLabel(value: string): string {
+  return value
+    .split(/[_-]/g)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function safeFileName(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60) || 'shadow-agent';
+}
+
+function stateTone(state: AgentNode['state']): string {
+  if (state === 'active') {
+    return 'node--active';
+  }
+  if (state === 'completed') {
+    return 'node--completed';
+  }
+  return 'node--idle';
+}
+
+function statusTone(kind: string): string {
+  if (kind === 'risk' || kind === 'tool_failed') {
+    return 'pill--danger';
+  }
+  if (kind === 'next_move' || kind === 'objective') {
+    return 'pill--accent';
+  }
+  return 'pill--neutral';
+}
+
+function buildGraphLayout(agentNodes: AgentNode[]): {
+  nodes: Array<AgentNode & { depth: number; x: number; y: number }>;
+  edges: Array<{ from: string; to: string }>;
+  width: number;
+  height: number;
+} {
+  const sorted = [...agentNodes].sort((a, b) => a.label.localeCompare(b.label));
+  const map = new Map(sorted.map((node) => [node.id, node]));
+  const depthCache = new Map<string, number>();
+
+  const getDepth = (node: AgentNode): number => {
+    const cached = depthCache.get(node.id);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const parent = node.parentId ? map.get(node.parentId) : undefined;
+    const depth = parent ? getDepth(parent) + 1 : 0;
+    depthCache.set(node.id, depth);
+    return depth;
+  };
+
+  const levelMap = new Map<number, AgentNode[]>();
+  for (const node of sorted) {
+    const depth = getDepth(node);
+    const level = levelMap.get(depth) ?? [];
+    level.push(node);
+    levelMap.set(depth, level);
+  }
+
+  const depthEntries = [...levelMap.entries()].sort(([left], [right]) => left - right);
+  const nodes: Array<AgentNode & { depth: number; x: number; y: number }> = [];
+  const xSpacing = 260;
+  const ySpacing = 118;
+  const maxDepth = depthEntries.reduce((max, [depth]) => Math.max(max, depth), 0);
+  const maxCount = depthEntries.reduce((max, [, level]) => Math.max(max, level.length), 0);
+
+  depthEntries.forEach(([depth, level]) => {
+    level
+      .sort((a, b) => {
+        if (a.state !== b.state) {
+          return a.state === 'active' ? -1 : a.state === 'idle' ? 1 : 0;
+        }
+        return b.toolCount - a.toolCount || a.label.localeCompare(b.label);
+      })
+      .forEach((node, index) => {
+        nodes.push({
+          ...node,
+          depth,
+          x: 40 + depth * xSpacing,
+          y: 40 + index * ySpacing
+        });
+      });
+  });
+
+  const edges = nodes
+    .filter((node) => node.parentId && map.has(node.parentId))
+    .map((node) => ({ from: node.parentId as string, to: node.id }));
+
+  return {
+    nodes,
+    edges,
+    width: Math.max(760, 80 + (maxDepth + 1) * xSpacing),
+    height: Math.max(300, 120 + Math.max(1, maxCount) * ySpacing)
+  };
+}
+
+function Panel({
+  title,
+  eyebrow,
+  className = '',
+  actions,
+  children
+}: {
+  title: string;
+  eyebrow?: string;
+  className?: string;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className={`panel ${className}`.trim()}>
+      <header className="panel__header">
+        <div>
+          {eyebrow ? <p className="eyebrow">{eyebrow}</p> : null}
+          <h2>{title}</h2>
+        </div>
+        {actions ? <div className="panel__actions">{actions}</div> : null}
+      </header>
+      <div className="panel__body">{children}</div>
+    </section>
+  );
+}
+
+function Badge({ children, tone = 'neutral' }: { children: React.ReactNode; tone?: 'neutral' | 'accent' | 'danger' }) {
+  return <span className={`pill pill--${tone}`}>{children}</span>;
+}
+
+function GraphView({ nodes }: { nodes: AgentNode[] }) {
+  const layout = useMemo(() => buildGraphLayout(nodes), [nodes]);
+  const nodeMap = useMemo(() => new Map(layout.nodes.map((node) => [node.id, node])), [layout.nodes]);
+
+  if (layout.nodes.length === 0) {
+    return <p className="empty-state">No agent graph is available yet.</p>;
+  }
+
+  return (
+    <div className="graph-shell">
+      <svg className="graph" viewBox={`0 0 ${layout.width} ${layout.height}`} role="img" aria-label="Agent graph">
+        <defs>
+          <marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto" markerUnits="strokeWidth">
+            <path d="M0,0 L8,4 L0,8 z" fill="rgba(187, 202, 227, 0.85)" />
+          </marker>
+        </defs>
+        {layout.edges.map((edge) => {
+          const from = nodeMap.get(edge.from);
+          const to = nodeMap.get(edge.to);
+          if (!from || !to) {
+            return null;
+          }
+          return (
+            <line
+              key={`${edge.from}-${edge.to}`}
+              x1={from.x + 180}
+              y1={from.y + 35}
+              x2={to.x}
+              y2={to.y + 35}
+              className="graph__edge"
+              markerEnd="url(#arrow)"
+            />
+          );
+        })}
+        {layout.nodes.map((node) => (
+          <g key={node.id} transform={`translate(${node.x}, ${node.y})`} className={`graph-node ${stateTone(node.state)}`}>
+            <rect width="180" height="70" rx="18" ry="18" />
+            <text x="16" y="22" className="graph-node__label">
+              {node.label}
+            </text>
+            <text x="16" y="43" className="graph-node__meta">
+              {node.toolCount} tools • {node.state}
+            </text>
+            {node.parentId ? <text x="16" y="60" className="graph-node__meta graph-node__meta--dim">{node.parentId}</text> : null}
+          </g>
+        ))}
+      </svg>
+    </div>
+  );
+}
+
+function TimelineView({ timeline }: { timeline: TimelineItem[] }) {
+  if (timeline.length === 0) {
+    return <p className="empty-state">No timeline events yet.</p>;
+  }
+
+  return (
+    <div className="stack stack--tight">
+      {timeline.map((item) => (
+        <article className="timeline-item" key={item.id}>
+          <div className="timeline-item__time">{formatClock(item.timestamp)}</div>
+          <div className="timeline-item__content">
+            <div className="timeline-item__topline">
+              <span className="timeline-item__label">{item.label}</span>
+              <Badge tone="neutral">{toLabel(item.kind)}</Badge>
+            </div>
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function TranscriptView({ transcript }: { transcript: DerivedState['transcript'] }) {
+  if (transcript.length === 0) {
+    return <p className="empty-state">No transcript content is available yet.</p>;
+  }
+
+  return (
+    <div className="stack stack--tight">
+      {transcript.map((entry) => (
+        <article className="transcript-item" key={entry.id}>
+          <div className="transcript-item__meta">
+            <span className="transcript-item__actor">{entry.actor}</span>
+            <span className="transcript-item__time">{formatClock(entry.timestamp)}</span>
+          </div>
+          <p className="transcript-item__text">{entry.text}</p>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function FileAttentionView({ files }: { files: DerivedState['fileAttention'] }) {
+  if (files.length === 0) {
+    return <p className="empty-state">No file attention has been inferred yet.</p>;
+  }
+
+  const maxTouches = Math.max(...files.map((file) => file.touches), 1);
+
+  return (
+    <div className="stack stack--tight">
+      {files.map((file) => {
+        const width = Math.max(8, Math.round((file.touches / maxTouches) * 100));
+        return (
+          <article className="file-row" key={file.filePath}>
+            <div className="file-row__topline">
+              <span className="file-row__path">{file.filePath}</span>
+              <span className="file-row__count">
+                {file.touches} touch{file.touches === 1 ? '' : 'es'}
+              </span>
+            </div>
+            <div className="file-row__bar">
+              <span style={{ width: `${width}%` }} />
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+}
+
+function InsightsView({
+  objective,
+  phase,
+  riskSignals,
+  nextMoves,
+  insights
+}: {
+  objective: string;
+  phase: string;
+  riskSignals: string[];
+  nextMoves: string[];
+  insights: ShadowInsight[];
+}) {
+  return (
+    <div className="insights-grid">
+      <article className="insight-card insight-card--summary">
+        <p className="eyebrow">Objective</p>
+        <h3>{objective}</h3>
+        <div className="insight-card__tags">
+          <Badge tone="accent">{phase}</Badge>
+          <Badge tone="neutral">{insights.length} inferred signals</Badge>
+        </div>
+      </article>
+
+      <article className="insight-card">
+        <p className="eyebrow">Risks</p>
+        {riskSignals.length > 0 ? (
+          <ul className="list">
+            {riskSignals.map((risk) => (
+              <li key={risk}>
+                <Badge tone="danger">{risk}</Badge>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="empty-state">No strong risk signals detected.</p>
+        )}
+      </article>
+
+      <article className="insight-card">
+        <p className="eyebrow">Next Moves</p>
+        {nextMoves.length > 0 ? (
+          <ul className="list">
+            {nextMoves.map((move) => (
+              <li key={move}>
+                <Badge tone="accent">{move}</Badge>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="empty-state">No recommendation yet.</p>
+        )}
+      </article>
+
+      <article className="insight-card insight-card--wide">
+        <p className="eyebrow">Shadow Insights</p>
+        <div className="stack stack--tight">
+          {insights.map((insight, index) => (
+            <div className="insight-row" key={`${insight.kind}-${index}`}>
+              <div className="insight-row__topline">
+                <span className="insight-row__kind">{toLabel(insight.kind)}</span>
+                <span className={`pill ${statusTone(insight.kind)}`}>{Math.round(insight.confidence * 100)}%</span>
+              </div>
+              <p className="insight-row__summary">{insight.summary}</p>
+              <p className="insight-row__scope">{insight.scope} scope</p>
+            </div>
+          ))}
+        </div>
+      </article>
+    </div>
+  );
+}
+
+export default function App() {
+  const [snapshot, setSnapshot] = useState<SnapshotPayload | null>(null);
+  const [busy, setBusy] = useState<'booting' | 'loading' | 'exporting' | null>('booting');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    const bootstrap = async () => {
+      try {
+        const data = await window.shadowAgent.bootstrap();
+        if (!active) {
+          return;
+        }
+        startTransition(() => setSnapshot(data));
+        setBusy(null);
+      } catch (err) {
+        if (!active) {
+          return;
+        }
+        setError(err instanceof Error ? err.message : 'Unable to load the built-in fixture.');
+        setBusy(null);
+      }
+    };
+
+    void bootstrap();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const exportName = useMemo(() => {
+    if (!snapshot) {
+      return 'shadow-agent-replay.jsonl';
+    }
+    return `${safeFileName(snapshot.record.title)}.jsonl`;
+  }, [snapshot]);
+
+  const loadReplay = async () => {
+    setBusy('loading');
+    setError(null);
+    try {
+      const data = await window.shadowAgent.openReplayFile();
+      if (data) {
+        startTransition(() => setSnapshot(data));
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to open the replay file.');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const reloadFixture = async () => {
+    setBusy('booting');
+    setError(null);
+    try {
+      const data = await window.shadowAgent.bootstrap();
+      startTransition(() => setSnapshot(data));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to reload the fixture.');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const exportReplay = async () => {
+    if (!snapshot) {
+      return;
+    }
+    setBusy('exporting');
+    setError(null);
+    try {
+      const result = await window.shadowAgent.exportReplayJsonl(snapshot.events, exportName);
+      if (result.error) {
+        setError(result.error);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to export replay JSONL.');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const graphSummary = snapshot
+    ? `${snapshot.state.agentNodes.length} agents • ${snapshot.state.timeline.length} events`
+    : 'Waiting for data';
+
+  return (
+    <div className="app-shell">
+      <div className="app-shell__glow app-shell__glow--left" />
+      <div className="app-shell__glow app-shell__glow--right" />
+
+      <header className="topbar">
+        <div>
+          <p className="eyebrow">Shadow Agent</p>
+          <h1>Passive live observer for agent sessions</h1>
+          <p className="lede">
+            Loads a built-in fixture on launch, opens transcript or replay files through Electron, and exports canonical
+            replay JSONL back to disk.
+          </p>
+        </div>
+        <div className="topbar__actions">
+          <button type="button" className="button button--ghost" onClick={reloadFixture} disabled={busy !== null}>
+            Reload fixture
+          </button>
+          <button type="button" className="button button--ghost" onClick={loadReplay} disabled={busy !== null}>
+            Open replay / transcript
+          </button>
+          <button type="button" className="button button--primary" onClick={exportReplay} disabled={!snapshot || busy !== null}>
+            Export replay JSONL
+          </button>
+        </div>
+      </header>
+
+      <main className="dashboard">
+        <section className="status-strip">
+          <div className="status-strip__item">
+            <span className="status-strip__label">Session</span>
+            <strong>{snapshot?.record.title ?? 'Loading…'}</strong>
+          </div>
+          <div className="status-strip__item">
+            <span className="status-strip__label">Source</span>
+            <strong>{snapshot ? snapshot.source.label : 'Bootstrapping built-in fixture'}</strong>
+          </div>
+          <div className="status-strip__item">
+            <span className="status-strip__label">Active phase</span>
+            <strong>{snapshot ? toLabel(snapshot.state.activePhase) : 'Unknown'}</strong>
+          </div>
+          <div className="status-strip__item">
+            <span className="status-strip__label">Coverage</span>
+            <strong>{snapshot ? graphSummary : 'No events yet'}</strong>
+          </div>
+        </section>
+
+        {error ? <div className="error-banner">{error}</div> : null}
+
+        <section className="objective-card">
+          <p className="eyebrow">Current objective</p>
+          <h2>{snapshot?.state.currentObjective ?? 'Waiting for snapshot data'}</h2>
+        </section>
+
+        <div className="panels">
+          <Panel title="Graph" eyebrow="Agent topology" className="panel--wide">
+            <GraphView nodes={snapshot?.state.agentNodes ?? []} />
+          </Panel>
+
+          <Panel title="Timeline" eyebrow="Chronological events">
+            <TimelineView timeline={snapshot?.state.timeline ?? []} />
+          </Panel>
+
+          <Panel title="Transcript" eyebrow="Observed dialogue">
+            <TranscriptView transcript={snapshot?.state.transcript ?? []} />
+          </Panel>
+
+          <Panel title="File Attention" eyebrow="Hot spots">
+            <FileAttentionView files={snapshot?.state.fileAttention ?? []} />
+          </Panel>
+
+          <Panel title="Insights" eyebrow="Shadow layer" className="panel--wide">
+            <InsightsView
+              objective={snapshot?.state.currentObjective ?? 'Waiting for data'}
+              phase={snapshot ? toLabel(snapshot.state.activePhase) : 'Unknown'}
+              riskSignals={snapshot?.state.riskSignals ?? []}
+              nextMoves={snapshot?.state.nextMoves ?? []}
+              insights={snapshot?.state.shadowInsights ?? []}
+            />
+          </Panel>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/shadow-agent/src/renderer/App.tsx
+++ b/shadow-agent/src/renderer/App.tsx
@@ -1,25 +1,5 @@
 import { startTransition, useEffect, useMemo, useState } from 'react';
-import type { AgentNode, CanonicalEvent, DerivedState, ShadowInsight, TimelineItem } from '../shared/schema';
-
-interface LoadedSource {
-  kind: 'fixture' | 'replay' | 'transcript';
-  label: string;
-  path?: string;
-}
-
-interface SnapshotPayload {
-  source: LoadedSource;
-  record: {
-    sessionId: string;
-    title: string;
-    startedAt: string;
-    updatedAt: string;
-    source: CanonicalEvent['source'];
-    eventCount: number;
-  };
-  state: DerivedState;
-  events: CanonicalEvent[];
-}
+import type { AgentNode, DerivedState, ShadowInsight, SnapshotPayload, TimelineItem } from '../shared/schema';
 
 function formatClock(timestamp: string): string {
   const date = new Date(timestamp);

--- a/shadow-agent/src/renderer/global.d.ts
+++ b/shadow-agent/src/renderer/global.d.ts
@@ -1,0 +1,32 @@
+import type { CanonicalEvent, DerivedState, SessionRecord } from '../shared/schema';
+
+interface LoadedSource {
+  kind: 'fixture' | 'replay' | 'transcript';
+  label: string;
+  path?: string;
+}
+
+interface SnapshotPayload {
+  source: LoadedSource;
+  record: SessionRecord;
+  state: DerivedState;
+  events: CanonicalEvent[];
+}
+
+interface ExportResult {
+  canceled: boolean;
+  filePath?: string;
+  error?: string;
+}
+
+declare global {
+  interface Window {
+    shadowAgent: {
+      bootstrap: () => Promise<SnapshotPayload>;
+      openReplayFile: () => Promise<SnapshotPayload | null>;
+      exportReplayJsonl: (events: CanonicalEvent[], suggestedFileName?: string) => Promise<ExportResult>;
+    };
+  }
+}
+
+export {};

--- a/shadow-agent/src/renderer/global.d.ts
+++ b/shadow-agent/src/renderer/global.d.ts
@@ -1,31 +1,8 @@
-import type { CanonicalEvent, DerivedState, SessionRecord } from '../shared/schema';
-
-interface LoadedSource {
-  kind: 'fixture' | 'replay' | 'transcript';
-  label: string;
-  path?: string;
-}
-
-interface SnapshotPayload {
-  source: LoadedSource;
-  record: SessionRecord;
-  state: DerivedState;
-  events: CanonicalEvent[];
-}
-
-interface ExportResult {
-  canceled: boolean;
-  filePath?: string;
-  error?: string;
-}
+import type { ShadowAgentBridge } from '../shared/schema';
 
 declare global {
   interface Window {
-    shadowAgent: {
-      bootstrap: () => Promise<SnapshotPayload>;
-      openReplayFile: () => Promise<SnapshotPayload | null>;
-      exportReplayJsonl: (events: CanonicalEvent[], suggestedFileName?: string) => Promise<ExportResult>;
-    };
+    shadowAgent: ShadowAgentBridge;
   }
 }
 

--- a/shadow-agent/src/renderer/main.tsx
+++ b/shadow-agent/src/renderer/main.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+const root = createRoot(document.getElementById('root') as HTMLElement);
+root.render(<App />);

--- a/shadow-agent/src/renderer/styles.css
+++ b/shadow-agent/src/renderer/styles.css
@@ -1,0 +1,500 @@
+:root {
+  color-scheme: dark;
+  font-family: "Segoe UI Variable Text", "Segoe UI", "Avenir Next", system-ui, sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #e4edf7;
+  background:
+    radial-gradient(circle at top left, rgba(67, 111, 143, 0.28), transparent 32%),
+    radial-gradient(circle at top right, rgba(99, 71, 140, 0.28), transparent 34%),
+    linear-gradient(180deg, #07111d 0%, #0b1626 55%, #09111d 100%);
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  --bg: rgba(8, 17, 31, 0.8);
+  --bg-strong: rgba(10, 19, 35, 0.94);
+  --bg-soft: rgba(16, 29, 49, 0.8);
+  --border: rgba(150, 177, 219, 0.18);
+  --border-strong: rgba(171, 196, 236, 0.28);
+  --text: #e6edf7;
+  --muted: #8fa4be;
+  --accent: #7be0ff;
+  --accent-strong: #49bef2;
+  --danger: #ff758f;
+  --shadow: 0 24px 80px rgba(0, 0, 0, 0.38);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  min-height: 100vh;
+  overflow: hidden;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+.app-shell {
+  position: relative;
+  min-height: 100vh;
+  padding: 22px;
+  overflow: hidden auto;
+}
+
+.app-shell__glow {
+  position: fixed;
+  inset: auto;
+  width: 34vw;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  filter: blur(58px);
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.app-shell__glow--left {
+  left: -10vw;
+  top: -8vw;
+  background: rgba(82, 153, 204, 0.28);
+}
+
+.app-shell__glow--right {
+  right: -10vw;
+  top: 8vw;
+  background: rgba(171, 92, 195, 0.22);
+}
+
+.topbar,
+.status-strip,
+.objective-card,
+.panel {
+  position: relative;
+  z-index: 1;
+  backdrop-filter: blur(18px);
+  background: linear-gradient(180deg, rgba(12, 21, 38, 0.92), rgba(7, 13, 25, 0.82));
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.topbar {
+  display: flex;
+  gap: 18px;
+  align-items: flex-end;
+  justify-content: space-between;
+  padding: 22px 24px;
+  border-radius: 26px;
+}
+
+.topbar h1,
+.objective-card h2 {
+  margin: 0;
+  line-height: 1.1;
+}
+
+.topbar h1 {
+  font-size: clamp(1.6rem, 2.6vw, 3rem);
+  letter-spacing: -0.04em;
+}
+
+.lede {
+  max-width: 74ch;
+  margin: 10px 0 0;
+  color: var(--muted);
+}
+
+.topbar__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.button {
+  border: 1px solid transparent;
+  border-radius: 14px;
+  padding: 11px 16px;
+  color: var(--text);
+  transition:
+    transform 150ms ease,
+    border-color 150ms ease,
+    background-color 150ms ease,
+    opacity 150ms ease;
+}
+
+.button:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.button--ghost {
+  background: rgba(255, 255, 255, 0.03);
+  border-color: var(--border);
+}
+
+.button--ghost:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.button--primary {
+  background: linear-gradient(135deg, rgba(73, 190, 242, 0.94), rgba(123, 224, 255, 0.72));
+  color: #03101b;
+  font-weight: 700;
+}
+
+.dashboard {
+  display: grid;
+  gap: 16px;
+  padding-top: 16px;
+}
+
+.status-strip {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  padding: 16px 18px;
+  border-radius: 22px;
+}
+
+.status-strip__item {
+  display: grid;
+  gap: 4px;
+}
+
+.status-strip__label,
+.eyebrow,
+.panel__header h2,
+.timeline-item__time,
+.transcript-item__time,
+.file-row__count,
+.insight-row__scope {
+  color: var(--muted);
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.objective-card {
+  padding: 18px 20px;
+  border-radius: 22px;
+}
+
+.objective-card h2 {
+  font-size: clamp(1.15rem, 2vw, 1.7rem);
+  letter-spacing: -0.02em;
+}
+
+.panels {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.panel {
+  min-width: 0;
+  border-radius: 22px;
+}
+
+.panel--wide {
+  grid-column: 1 / -1;
+}
+
+.panel__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  align-items: flex-start;
+  padding: 18px 18px 0;
+}
+
+.panel__header h2 {
+  margin: 4px 0 0;
+  color: var(--text);
+  font-size: 1.05rem;
+}
+
+.panel__body {
+  padding: 16px 18px 18px;
+}
+
+.panel__actions {
+  display: flex;
+  gap: 10px;
+}
+
+.stack {
+  display: grid;
+  gap: 12px;
+}
+
+.stack--tight {
+  gap: 10px;
+}
+
+.empty-state {
+  margin: 0;
+  color: var(--muted);
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+  font-size: 0.74rem;
+}
+
+.pill--accent {
+  border-color: rgba(123, 224, 255, 0.24);
+  background: rgba(123, 224, 255, 0.1);
+}
+
+.pill--danger {
+  border-color: rgba(255, 117, 143, 0.26);
+  background: rgba(255, 117, 143, 0.1);
+}
+
+.pill--neutral {
+  border-color: var(--border);
+}
+
+.graph-shell {
+  overflow: auto;
+  border-radius: 18px;
+  background: rgba(2, 7, 15, 0.25);
+  border: 1px solid rgba(146, 171, 201, 0.12);
+}
+
+.graph {
+  display: block;
+  min-width: 100%;
+}
+
+.graph__edge {
+  stroke: rgba(187, 202, 227, 0.45);
+  stroke-width: 2;
+}
+
+.graph-node rect {
+  fill: rgba(15, 27, 45, 0.92);
+  stroke: rgba(131, 154, 186, 0.24);
+  stroke-width: 1.2;
+}
+
+.graph-node text {
+  fill: var(--text);
+}
+
+.graph-node__label {
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.graph-node__meta {
+  font-size: 11px;
+  fill: var(--muted);
+}
+
+.graph-node__meta--dim {
+  opacity: 0.78;
+}
+
+.node--active rect {
+  stroke: rgba(123, 224, 255, 0.56);
+}
+
+.node--completed rect {
+  stroke: rgba(143, 204, 153, 0.34);
+}
+
+.node--idle rect {
+  stroke: rgba(186, 191, 205, 0.18);
+}
+
+.timeline-item,
+.transcript-item,
+.file-row,
+.insight-row,
+.insight-card {
+  border-radius: 18px;
+  border: 1px solid rgba(131, 154, 186, 0.15);
+  background: rgba(5, 12, 22, 0.42);
+}
+
+.timeline-item {
+  display: grid;
+  gap: 8px;
+  padding: 12px 14px;
+}
+
+.timeline-item__topline,
+.file-row__topline,
+.insight-row__topline,
+.transcript-item__meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+}
+
+.timeline-item__label,
+.transcript-item__actor,
+.file-row__path,
+.insight-row__kind {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.transcript-item {
+  padding: 12px 14px;
+}
+
+.transcript-item__text {
+  margin: 10px 0 0;
+  color: #dbe5f3;
+}
+
+.file-row {
+  width: 100%;
+  padding: 12px 14px 14px;
+  text-align: left;
+  color: inherit;
+}
+
+.file-row:hover {
+  border-color: rgba(123, 224, 255, 0.34);
+}
+
+.file-row__bar {
+  overflow: hidden;
+  height: 9px;
+  margin-top: 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.file-row__bar span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(73, 190, 242, 0.94), rgba(123, 224, 255, 0.72));
+}
+
+.file-row__count {
+  white-space: nowrap;
+}
+
+.insights-grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.insight-card {
+  padding: 16px 16px 18px;
+}
+
+.insight-card--summary {
+  background: linear-gradient(135deg, rgba(19, 36, 59, 0.94), rgba(7, 14, 26, 0.82));
+}
+
+.insight-card--wide {
+  grid-column: 1 / -1;
+}
+
+.insight-card h3 {
+  margin: 6px 0 12px;
+  font-size: 1.25rem;
+  line-height: 1.25;
+}
+
+.insight-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.insight-row {
+  padding: 12px 14px;
+}
+
+.insight-row__summary {
+  margin: 8px 0 6px;
+}
+
+.list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 8px;
+}
+
+.error-banner {
+  padding: 12px 14px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 117, 143, 0.32);
+  background: rgba(255, 117, 143, 0.12);
+  color: #ffd6dd;
+}
+
+@media (max-width: 1180px) {
+  .status-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .panels,
+  .insights-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 840px) {
+  .app-shell {
+    padding: 14px;
+  }
+
+  .topbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .topbar__actions {
+    justify-content: stretch;
+  }
+
+  .button {
+    width: 100%;
+  }
+
+  .status-strip {
+    grid-template-columns: 1fr;
+  }
+}

--- a/shadow-agent/src/shared/derive.ts
+++ b/shadow-agent/src/shared/derive.ts
@@ -1,0 +1,198 @@
+import { CanonicalEvent, DerivedState, ShadowInsight } from './schema';
+
+const TOOL_FILE_KEYS = ['filePath', 'file_path', 'path'];
+
+function extractFilePath(payload: Record<string, unknown>): string | null {
+  for (const key of TOOL_FILE_KEYS) {
+    const value = payload[key];
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function detectPhase(events: CanonicalEvent[]): string {
+  const toolNames = events
+    .filter((event) => event.kind === 'tool_started' || event.kind === 'tool_completed' || event.kind === 'tool_failed')
+    .map((event) => String(event.payload.toolName ?? '').toLowerCase());
+
+  if (toolNames.some((name) => name.includes('write') || name.includes('edit'))) {
+    return 'implementation';
+  }
+  if (toolNames.some((name) => name.includes('todo') || name.includes('plan'))) {
+    return 'planning';
+  }
+  if (toolNames.some((name) => name.includes('bash') || name.includes('test'))) {
+    return 'validation';
+  }
+  if (toolNames.some((name) => name.includes('read') || name.includes('grep') || name.includes('glob'))) {
+    return 'exploration';
+  }
+  return 'observation';
+}
+
+function collectRiskSignals(events: CanonicalEvent[]): string[] {
+  const risks: string[] = [];
+  const failedTools = events.filter((event) => event.kind === 'tool_failed');
+  if (failedTools.length > 0) {
+    risks.push(`${failedTools.length} failed tool call${failedTools.length === 1 ? '' : 's'} detected`);
+  }
+
+  const bashTools = events.filter(
+    (event) =>
+      (event.kind === 'tool_started' || event.kind === 'tool_completed' || event.kind === 'tool_failed') &&
+      String(event.payload.toolName ?? '').toLowerCase().includes('bash')
+  );
+  if (bashTools.length >= 4) {
+    risks.push('Heavy shell/tool churn suggests validation or recovery thrash');
+  }
+
+  const repeatedReads = events.filter(
+    (event) =>
+      event.kind === 'tool_started' &&
+      ['read', 'grep', 'glob'].includes(String(event.payload.toolName ?? '').toLowerCase())
+  );
+  if (repeatedReads.length >= 6) {
+    risks.push('Large exploration volume may indicate uncertainty or missing plan convergence');
+  }
+
+  return risks;
+}
+
+function buildNextMoves(phase: string, riskSignals: string[]): string[] {
+  const nextMoves: string[] = [];
+  if (phase === 'exploration') {
+    nextMoves.push('Collapse exploration into a concrete plan and file shortlist');
+  }
+  if (phase === 'planning') {
+    nextMoves.push('Promote the current plan into implementation tasks with explicit targets');
+  }
+  if (phase === 'implementation') {
+    nextMoves.push('Verify changed files and hand off into a focused validation loop');
+  }
+  if (phase === 'validation') {
+    nextMoves.push('Resolve failing checks or finalize the session if signals are clean');
+  }
+  if (riskSignals.length > 0) {
+    nextMoves.push('Investigate the highest-risk signal before expanding scope');
+  }
+  if (nextMoves.length === 0) {
+    nextMoves.push('Wait for stronger signals before producing a new recommendation');
+  }
+  return nextMoves;
+}
+
+function buildInsights(title: string, phase: string, riskSignals: string[], nextMoves: string[]): ShadowInsight[] {
+  return [
+    {
+      kind: 'objective',
+      confidence: 0.72,
+      scope: 'session',
+      summary: title,
+      evidenceEventIds: []
+    },
+    {
+      kind: 'phase',
+      confidence: 0.68,
+      scope: 'session',
+      summary: `Current phase appears to be ${phase}.`,
+      evidenceEventIds: []
+    },
+    ...riskSignals.map<ShadowInsight>((risk) => ({
+      kind: 'risk',
+      confidence: 0.61,
+      scope: 'session',
+      summary: risk,
+      evidenceEventIds: []
+    })),
+    ...nextMoves.slice(0, 2).map<ShadowInsight>((move) => ({
+      kind: 'next_move',
+      confidence: 0.58,
+      scope: 'session',
+      summary: move,
+      evidenceEventIds: []
+    }))
+  ];
+}
+
+export function deriveState(events: CanonicalEvent[], title = 'Observed session'): DerivedState {
+  const sessionId = events[0]?.sessionId ?? 'unknown';
+  const phase = detectPhase(events);
+  const riskSignals = collectRiskSignals(events);
+  const nextMoves = buildNextMoves(phase, riskSignals);
+
+  const agentMap = new Map<string, DerivedState['agentNodes'][number]>();
+  const transcript: DerivedState['transcript'] = [];
+  const timeline: DerivedState['timeline'] = [];
+  const fileAttention = new Map<string, number>();
+  let currentObjective = title;
+
+  for (const event of events) {
+    timeline.push({
+      id: event.id,
+      timestamp: event.timestamp,
+      label: `${event.actor}: ${event.kind}`,
+      kind: event.kind
+    });
+
+    if (event.kind === 'message' && typeof event.payload.text === 'string') {
+      transcript.push({
+        id: event.id,
+        actor: event.actor,
+        text: event.payload.text,
+        timestamp: event.timestamp
+      });
+      if (event.actor === 'user' && currentObjective === title) {
+        currentObjective = event.payload.text;
+      }
+    }
+
+    if (event.kind === 'agent_spawned' || event.kind === 'agent_idle' || event.kind === 'agent_completed') {
+      const existing = agentMap.get(event.actor) ?? {
+        id: event.actor,
+        label: String(event.payload.label ?? event.actor),
+        parentId: typeof event.payload.parentId === 'string' ? event.payload.parentId : undefined,
+        state: 'active' as const,
+        toolCount: 0
+      };
+      existing.state =
+        event.kind === 'agent_completed' ? 'completed' :
+        event.kind === 'agent_idle' ? 'idle' :
+        'active';
+      agentMap.set(event.actor, existing);
+    }
+
+    if (event.kind === 'tool_started' || event.kind === 'tool_completed' || event.kind === 'tool_failed') {
+      const existing = agentMap.get(event.actor) ?? {
+        id: event.actor,
+        label: event.actor,
+        state: 'active' as const,
+        toolCount: 0
+      };
+      existing.toolCount += 1;
+      agentMap.set(event.actor, existing);
+
+      const filePath = extractFilePath(event.payload);
+      if (filePath) {
+        fileAttention.set(filePath, (fileAttention.get(filePath) ?? 0) + 1);
+      }
+    }
+  }
+
+  return {
+    sessionId,
+    title,
+    currentObjective,
+    activePhase: phase,
+    agentNodes: [...agentMap.values()],
+    timeline,
+    transcript,
+    fileAttention: [...fileAttention.entries()]
+      .map(([filePath, touches]) => ({ filePath, touches }))
+      .sort((a, b) => b.touches - a.touches),
+    riskSignals,
+    nextMoves,
+    shadowInsights: buildInsights(currentObjective, phase, riskSignals, nextMoves)
+  };
+}

--- a/shadow-agent/src/shared/fixtures/payment-refactor-session.ts
+++ b/shadow-agent/src/shared/fixtures/payment-refactor-session.ts
@@ -1,0 +1,119 @@
+import { CanonicalEvent } from '../schema';
+
+function event(
+  id: string,
+  actor: string,
+  kind: CanonicalEvent['kind'],
+  timestamp: string,
+  payload: Record<string, unknown>,
+  source: CanonicalEvent['source'] = 'replay'
+): CanonicalEvent {
+  return {
+    id,
+    sessionId: 'payment-refactor-session',
+    source,
+    timestamp,
+    actor,
+    kind,
+    payload
+  };
+}
+
+export const paymentRefactorSession: CanonicalEvent[] = [
+  event('evt-1', 'system', 'session_started', '2026-03-26T01:00:00.000Z', { label: 'Payment refactor session' }),
+  event('evt-2', 'user', 'message', '2026-03-26T01:00:01.000Z', {
+    text: 'Refactor the payment system to support Stripe and PayPal, add webhook handling, and write integration tests.'
+  }),
+  event('evt-3', 'orchestrator', 'agent_spawned', '2026-03-26T01:00:03.000Z', { label: 'orchestrator' }),
+  event('evt-4', 'orchestrator', 'tool_started', '2026-03-26T01:00:05.000Z', {
+    toolName: 'Glob',
+    pattern: 'src/**/*.ts'
+  }),
+  event('evt-5', 'orchestrator', 'tool_completed', '2026-03-26T01:00:06.000Z', {
+    toolName: 'Glob',
+    result: '47 files matched'
+  }),
+  event('evt-6', 'orchestrator', 'tool_started', '2026-03-26T01:00:07.000Z', {
+    toolName: 'Read',
+    filePath: 'src/services/payment.ts'
+  }),
+  event('evt-7', 'orchestrator', 'tool_completed', '2026-03-26T01:00:08.000Z', {
+    toolName: 'Read',
+    filePath: 'src/services/payment.ts'
+  }),
+  event('evt-8', 'orchestrator', 'tool_started', '2026-03-26T01:00:10.000Z', {
+    toolName: 'TodoWrite'
+  }),
+  event('evt-9', 'orchestrator', 'tool_completed', '2026-03-26T01:00:10.500Z', {
+    toolName: 'TodoWrite'
+  }),
+  event('evt-10', 'orchestrator', 'subagent_dispatched', '2026-03-26T01:00:12.000Z', {
+    childId: 'research-agent',
+    task: 'Research Stripe and PayPal API patterns'
+  }),
+  event('evt-11', 'research-agent', 'agent_spawned', '2026-03-26T01:00:13.000Z', {
+    label: 'research-agent',
+    parentId: 'orchestrator'
+  }),
+  event('evt-12', 'research-agent', 'tool_started', '2026-03-26T01:00:14.000Z', {
+    toolName: 'WebSearch',
+    query: 'Stripe PaymentIntents Node.js TypeScript'
+  }),
+  event('evt-13', 'research-agent', 'tool_completed', '2026-03-26T01:00:17.000Z', {
+    toolName: 'WebSearch',
+    result: 'PaymentIntents is the recommended API'
+  }),
+  event('evt-14', 'research-agent', 'subagent_returned', '2026-03-26T01:00:19.000Z', {
+    summary: 'Stripe PaymentIntents and PayPal Orders API v2 are the target patterns.'
+  }),
+  event('evt-15', 'research-agent', 'agent_completed', '2026-03-26T01:00:19.500Z', {
+    label: 'research-agent'
+  }),
+  event('evt-16', 'orchestrator', 'tool_started', '2026-03-26T01:00:21.000Z', {
+    toolName: 'Write',
+    filePath: 'src/services/payment-gateway.ts'
+  }),
+  event('evt-17', 'orchestrator', 'tool_completed', '2026-03-26T01:00:22.000Z', {
+    toolName: 'Write',
+    filePath: 'src/services/payment-gateway.ts'
+  }),
+  event('evt-18', 'orchestrator', 'tool_started', '2026-03-26T01:00:23.000Z', {
+    toolName: 'Edit',
+    filePath: 'src/routes/checkout.ts'
+  }),
+  event('evt-19', 'orchestrator', 'tool_completed', '2026-03-26T01:00:24.000Z', {
+    toolName: 'Edit',
+    filePath: 'src/routes/checkout.ts'
+  }),
+  event('evt-20', 'orchestrator', 'tool_started', '2026-03-26T01:00:26.000Z', {
+    toolName: 'Bash',
+    command: 'npm test -- --coverage'
+  }),
+  event('evt-21', 'orchestrator', 'tool_failed', '2026-03-26T01:00:30.000Z', {
+    toolName: 'Bash',
+    command: 'npm test -- --coverage',
+    error: 'STRIPE_SECRET_KEY is not defined'
+  }),
+  event('evt-22', 'orchestrator', 'message', '2026-03-26T01:00:31.000Z', {
+    text: 'Tests are failing because Stripe secrets are not mocked during setup.'
+  }),
+  event('evt-23', 'orchestrator', 'tool_started', '2026-03-26T01:00:33.000Z', {
+    toolName: 'Write',
+    filePath: 'src/__tests__/setup.ts'
+  }),
+  event('evt-24', 'orchestrator', 'tool_completed', '2026-03-26T01:00:34.000Z', {
+    toolName: 'Write',
+    filePath: 'src/__tests__/setup.ts'
+  }),
+  event('evt-25', 'orchestrator', 'tool_started', '2026-03-26T01:00:36.000Z', {
+    toolName: 'Bash',
+    command: 'npm test -- --coverage'
+  }),
+  event('evt-26', 'orchestrator', 'tool_completed', '2026-03-26T01:00:41.000Z', {
+    toolName: 'Bash',
+    command: 'npm test -- --coverage',
+    result: '18 tests passed'
+  }),
+  event('evt-27', 'orchestrator', 'agent_completed', '2026-03-26T01:00:43.000Z', { label: 'orchestrator' }),
+  event('evt-28', 'system', 'session_ended', '2026-03-26T01:00:44.000Z', { label: 'Payment refactor session' })
+];

--- a/shadow-agent/src/shared/replay-store.ts
+++ b/shadow-agent/src/shared/replay-store.ts
@@ -5,21 +5,68 @@ export function serializeEvents(events: CanonicalEvent[]): string {
 }
 
 export function parseReplay(text: string): CanonicalEvent[] {
-  return text
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => JSON.parse(line) as CanonicalEvent);
+  const events: CanonicalEvent[] = [];
+  const lines = text.split(/\r?\n/);
+
+  lines.forEach((line, index) => {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    try {
+      events.push(JSON.parse(trimmed) as CanonicalEvent);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to parse replay JSON on line ${index + 1}: ${message}`);
+    }
+  });
+
+  return events;
+}
+
+function getDefaultTimestamp(): string {
+  return new Date(0).toISOString();
+}
+
+function normalizeTimestamp(timestamp: string | undefined): string | null {
+  if (!timestamp) {
+    return null;
+  }
+
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.valueOf())) {
+    return null;
+  }
+
+  return date.toISOString();
 }
 
 export function buildSessionRecord(events: CanonicalEvent[], title = 'Observed session'): SessionRecord {
   const first = events[0];
-  const last = events[events.length - 1];
+  let startedAt = getDefaultTimestamp();
+  let updatedAt = getDefaultTimestamp();
+
+  for (const event of events) {
+    const normalizedTimestamp = normalizeTimestamp(event.timestamp);
+    if (!normalizedTimestamp) {
+      continue;
+    }
+
+    if (startedAt === getDefaultTimestamp() || normalizedTimestamp < startedAt) {
+      startedAt = normalizedTimestamp;
+    }
+
+    if (updatedAt === getDefaultTimestamp() || normalizedTimestamp > updatedAt) {
+      updatedAt = normalizedTimestamp;
+    }
+  }
+
   return {
     sessionId: first?.sessionId ?? 'unknown',
     title,
-    startedAt: first?.timestamp ?? new Date(0).toISOString(),
-    updatedAt: last?.timestamp ?? new Date(0).toISOString(),
+    startedAt,
+    updatedAt,
     source: first?.source ?? 'replay',
     eventCount: events.length
   };

--- a/shadow-agent/src/shared/replay-store.ts
+++ b/shadow-agent/src/shared/replay-store.ts
@@ -1,0 +1,26 @@
+import { CanonicalEvent, SessionRecord } from './schema';
+
+export function serializeEvents(events: CanonicalEvent[]): string {
+  return events.map((event) => JSON.stringify(event)).join('\n');
+}
+
+export function parseReplay(text: string): CanonicalEvent[] {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as CanonicalEvent);
+}
+
+export function buildSessionRecord(events: CanonicalEvent[], title = 'Observed session'): SessionRecord {
+  const first = events[0];
+  const last = events[events.length - 1];
+  return {
+    sessionId: first?.sessionId ?? 'unknown',
+    title,
+    startedAt: first?.timestamp ?? new Date(0).toISOString(),
+    updatedAt: last?.timestamp ?? new Date(0).toISOString(),
+    source: first?.source ?? 'replay',
+    eventCount: events.length
+  };
+}

--- a/shadow-agent/src/shared/schema.ts
+++ b/shadow-agent/src/shared/schema.ts
@@ -1,0 +1,82 @@
+export type EventSource = 'claude-hook' | 'claude-transcript' | 'replay' | 'shadow-runtime';
+
+export type EventKind =
+  | 'session_started'
+  | 'session_ended'
+  | 'agent_spawned'
+  | 'agent_completed'
+  | 'agent_idle'
+  | 'message'
+  | 'tool_started'
+  | 'tool_completed'
+  | 'tool_failed'
+  | 'subagent_dispatched'
+  | 'subagent_returned'
+  | 'permission_requested'
+  | 'context_snapshot'
+  | 'shadow_insight';
+
+export type InsightKind =
+  | 'objective'
+  | 'phase'
+  | 'risk'
+  | 'next_move'
+  | 'attention'
+  | 'summary';
+
+export interface CanonicalEvent<TPayload = Record<string, unknown>> {
+  id: string;
+  sessionId: string;
+  source: EventSource;
+  timestamp: string;
+  actor: string;
+  kind: EventKind;
+  payload: TPayload;
+}
+
+export interface ShadowInsight {
+  kind: InsightKind;
+  confidence: number;
+  scope: 'session' | 'agent' | 'file';
+  summary: string;
+  evidenceEventIds: string[];
+  structuredPayload?: Record<string, unknown>;
+}
+
+export interface SessionRecord {
+  sessionId: string;
+  title: string;
+  startedAt: string;
+  updatedAt: string;
+  source: EventSource;
+  eventCount: number;
+}
+
+export interface AgentNode {
+  id: string;
+  label: string;
+  parentId?: string;
+  state: 'active' | 'idle' | 'completed';
+  toolCount: number;
+}
+
+export interface TimelineItem {
+  id: string;
+  timestamp: string;
+  label: string;
+  kind: EventKind;
+}
+
+export interface DerivedState {
+  sessionId: string;
+  title: string;
+  currentObjective: string;
+  activePhase: string;
+  agentNodes: AgentNode[];
+  timeline: TimelineItem[];
+  transcript: Array<{ id: string; actor: string; text: string; timestamp: string }>;
+  fileAttention: Array<{ filePath: string; touches: number }>;
+  riskSignals: string[];
+  nextMoves: string[];
+  shadowInsights: ShadowInsight[];
+}

--- a/shadow-agent/src/shared/schema.ts
+++ b/shadow-agent/src/shared/schema.ts
@@ -52,6 +52,31 @@ export interface SessionRecord {
   eventCount: number;
 }
 
+export interface LoadedSource {
+  kind: 'fixture' | 'replay' | 'transcript';
+  label: string;
+  path?: string;
+}
+
+export interface SnapshotPayload {
+  source: LoadedSource;
+  record: SessionRecord;
+  state: DerivedState;
+  events: CanonicalEvent[];
+}
+
+export interface ExportResult {
+  canceled: boolean;
+  filePath?: string;
+  error?: string;
+}
+
+export interface ShadowAgentBridge {
+  bootstrap: () => Promise<SnapshotPayload>;
+  openReplayFile: () => Promise<SnapshotPayload | null>;
+  exportReplayJsonl: (events: CanonicalEvent[], suggestedFileName?: string) => Promise<ExportResult>;
+}
+
 export interface AgentNode {
   id: string;
   label: string;

--- a/shadow-agent/src/shared/transcript-adapter.ts
+++ b/shadow-agent/src/shared/transcript-adapter.ts
@@ -14,10 +14,21 @@ function makeId(index: number, suffix: string): string {
   return `transcript-${index}-${suffix}`;
 }
 
+function makeTimestamp(eventIndex: number): string {
+  return new Date(Date.UTC(2026, 0, 1, 0, 0, eventIndex)).toISOString();
+}
+
 export function parseClaudeTranscriptJsonl(raw: string): CanonicalEvent[] {
   const events: CanonicalEvent[] = [];
   const lines = raw.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
   let activeSessionId = 'claude-transcript-session';
+  let eventIndex = 0;
+
+  const nextTimestamp = (): string => {
+    const timestamp = makeTimestamp(eventIndex);
+    eventIndex += 1;
+    return timestamp;
+  };
 
   lines.forEach((line, index) => {
     let parsed: ClaudeTranscriptEntry;
@@ -33,7 +44,7 @@ export function parseClaudeTranscriptJsonl(raw: string): CanonicalEvent[] {
         id: makeId(index, 'session-started'),
         sessionId: activeSessionId,
         source: 'claude-transcript',
-        timestamp: new Date().toISOString(),
+        timestamp: nextTimestamp(),
         actor: 'system',
         kind: 'session_started',
         payload: { cwd: parsed.cwd ?? null }
@@ -52,7 +63,7 @@ export function parseClaudeTranscriptJsonl(raw: string): CanonicalEvent[] {
         id: makeId(index, 'message'),
         sessionId: activeSessionId,
         source: 'claude-transcript',
-        timestamp: new Date().toISOString(),
+        timestamp: nextTimestamp(),
         actor: role,
         kind: 'message',
         payload: { text: content }
@@ -71,7 +82,7 @@ export function parseClaudeTranscriptJsonl(raw: string): CanonicalEvent[] {
           id: makeId(index, `text-${blockIndex}`),
           sessionId: activeSessionId,
           source: 'claude-transcript',
-          timestamp: new Date().toISOString(),
+          timestamp: nextTimestamp(),
           actor: role,
           kind: 'message',
           payload: { text: block.text }
@@ -82,7 +93,7 @@ export function parseClaudeTranscriptJsonl(raw: string): CanonicalEvent[] {
           id: makeId(index, `tool-start-${blockIndex}`),
           sessionId: activeSessionId,
           source: 'claude-transcript',
-          timestamp: new Date().toISOString(),
+          timestamp: nextTimestamp(),
           actor: role,
           kind: 'tool_started',
           payload: {
@@ -91,13 +102,14 @@ export function parseClaudeTranscriptJsonl(raw: string): CanonicalEvent[] {
           }
         });
       } else if (type === 'tool_result') {
+        const isError = block.is_error === true;
         events.push({
           id: makeId(index, `tool-result-${blockIndex}`),
           sessionId: activeSessionId,
           source: 'claude-transcript',
-          timestamp: new Date().toISOString(),
+          timestamp: nextTimestamp(),
           actor: role,
-          kind: block.is_error ? 'tool_failed' : 'tool_completed',
+          kind: isError ? 'tool_failed' : 'tool_completed',
           payload: {
             toolUseId: block.tool_use_id ?? null,
             content: block.content ?? null
@@ -108,7 +120,7 @@ export function parseClaudeTranscriptJsonl(raw: string): CanonicalEvent[] {
           id: makeId(index, `thinking-${blockIndex}`),
           sessionId: activeSessionId,
           source: 'claude-transcript',
-          timestamp: new Date().toISOString(),
+          timestamp: nextTimestamp(),
           actor: role,
           kind: 'message',
           payload: { text: block.thinking }
@@ -122,7 +134,7 @@ export function parseClaudeTranscriptJsonl(raw: string): CanonicalEvent[] {
       id: makeId(lines.length, 'session-ended'),
       sessionId: activeSessionId,
       source: 'claude-transcript',
-      timestamp: new Date().toISOString(),
+      timestamp: nextTimestamp(),
       actor: 'system',
       kind: 'session_ended',
       payload: {}

--- a/shadow-agent/src/shared/transcript-adapter.ts
+++ b/shadow-agent/src/shared/transcript-adapter.ts
@@ -1,0 +1,133 @@
+import { CanonicalEvent } from './schema';
+
+interface ClaudeTranscriptEntry {
+  sessionId?: string;
+  type?: string;
+  cwd?: string;
+  message?: {
+    role?: string;
+    content?: Array<Record<string, unknown>> | string;
+  };
+}
+
+function makeId(index: number, suffix: string): string {
+  return `transcript-${index}-${suffix}`;
+}
+
+export function parseClaudeTranscriptJsonl(raw: string): CanonicalEvent[] {
+  const events: CanonicalEvent[] = [];
+  const lines = raw.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  let activeSessionId = 'claude-transcript-session';
+
+  lines.forEach((line, index) => {
+    let parsed: ClaudeTranscriptEntry;
+    try {
+      parsed = JSON.parse(line) as ClaudeTranscriptEntry;
+    } catch {
+      return;
+    }
+
+    activeSessionId = parsed.sessionId || activeSessionId;
+    if (index === 0) {
+      events.push({
+        id: makeId(index, 'session-started'),
+        sessionId: activeSessionId,
+        source: 'claude-transcript',
+        timestamp: new Date().toISOString(),
+        actor: 'system',
+        kind: 'session_started',
+        payload: { cwd: parsed.cwd ?? null }
+      });
+    }
+
+    if (!parsed.message) {
+      return;
+    }
+
+    const role = parsed.message.role || 'unknown';
+    const content = parsed.message.content;
+
+    if (typeof content === 'string') {
+      events.push({
+        id: makeId(index, 'message'),
+        sessionId: activeSessionId,
+        source: 'claude-transcript',
+        timestamp: new Date().toISOString(),
+        actor: role,
+        kind: 'message',
+        payload: { text: content }
+      });
+      return;
+    }
+
+    if (!Array.isArray(content)) {
+      return;
+    }
+
+    content.forEach((block, blockIndex) => {
+      const type = String(block.type ?? '');
+      if (type === 'text' && typeof block.text === 'string') {
+        events.push({
+          id: makeId(index, `text-${blockIndex}`),
+          sessionId: activeSessionId,
+          source: 'claude-transcript',
+          timestamp: new Date().toISOString(),
+          actor: role,
+          kind: 'message',
+          payload: { text: block.text }
+        });
+      } else if (type === 'tool_use') {
+        const input = (block.input ?? {}) as Record<string, unknown>;
+        events.push({
+          id: makeId(index, `tool-start-${blockIndex}`),
+          sessionId: activeSessionId,
+          source: 'claude-transcript',
+          timestamp: new Date().toISOString(),
+          actor: role,
+          kind: 'tool_started',
+          payload: {
+            toolName: block.name ?? 'unknown',
+            ...input
+          }
+        });
+      } else if (type === 'tool_result') {
+        events.push({
+          id: makeId(index, `tool-result-${blockIndex}`),
+          sessionId: activeSessionId,
+          source: 'claude-transcript',
+          timestamp: new Date().toISOString(),
+          actor: role,
+          kind: block.is_error ? 'tool_failed' : 'tool_completed',
+          payload: {
+            toolUseId: block.tool_use_id ?? null,
+            content: block.content ?? null
+          }
+        });
+      } else if (type === 'thinking' && typeof block.thinking === 'string') {
+        events.push({
+          id: makeId(index, `thinking-${blockIndex}`),
+          sessionId: activeSessionId,
+          source: 'claude-transcript',
+          timestamp: new Date().toISOString(),
+          actor: role,
+          kind: 'message',
+          payload: { text: block.thinking }
+        });
+      }
+    });
+  });
+
+  if (events.length > 0) {
+    events.push({
+      id: makeId(lines.length, 'session-ended'),
+      sessionId: activeSessionId,
+      source: 'claude-transcript',
+      timestamp: new Date().toISOString(),
+      actor: 'system',
+      kind: 'session_ended',
+      payload: {}
+    });
+  }
+
+  return events;
+}

--- a/shadow-agent/tests/derive.test.ts
+++ b/shadow-agent/tests/derive.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { deriveState } from '../src/shared/derive';
+import { paymentRefactorSession } from '../src/shared/fixtures/payment-refactor-session';
+
+describe('deriveState', () => {
+  it('extracts phase, file attention, and next moves from replay events', () => {
+    const state = deriveState(paymentRefactorSession, 'payment-refactor-session');
+
+    expect(state.activePhase).toBe('implementation');
+    expect(state.fileAttention.some((file) => file.filePath === 'src/services/payment-gateway.ts')).toBe(true);
+    expect(state.nextMoves.length).toBeGreaterThan(0);
+    expect(state.shadowInsights.some((insight) => insight.kind === 'phase')).toBe(true);
+  });
+
+  it('surfaces risk signals when tool failures occur', () => {
+    const state = deriveState(paymentRefactorSession, 'payment-refactor-session');
+    expect(state.riskSignals.some((risk) => risk.includes('failed tool call'))).toBe(true);
+  });
+});

--- a/shadow-agent/tests/persistence.test.ts
+++ b/shadow-agent/tests/persistence.test.ts
@@ -1,0 +1,102 @@
+import { readFile } from 'node:fs/promises';
+import { mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it } from 'vitest';
+import { FileReplayStore } from '../src/persistence';
+import type { CanonicalEvent } from '../src/shared/schema';
+
+function makeEvent(
+  overrides: Partial<CanonicalEvent> & Pick<CanonicalEvent, 'id' | 'sessionId' | 'timestamp' | 'kind'>
+): CanonicalEvent {
+  return {
+    source: 'claude-hook',
+    actor: 'agent',
+    payload: {},
+    ...overrides
+  };
+}
+
+describe('FileReplayStore', () => {
+  it('persists canonical events and reloads them from disk', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'shadow-agent-persistence-'));
+    const store = new FileReplayStore(rootDir);
+    const sessionId = 'payment-refactor';
+    const events = [
+      makeEvent({
+        id: 'evt-1',
+        sessionId,
+        timestamp: '2026-03-26T10:00:00.000Z',
+        kind: 'session_started',
+        actor: 'system',
+        payload: { cwd: 'D:/workspace' }
+      }),
+      makeEvent({
+        id: 'evt-2',
+        sessionId,
+        timestamp: '2026-03-26T10:05:00.000Z',
+        kind: 'message',
+        payload: { text: 'Working through the payment gateway refactor.' }
+      })
+    ];
+
+    const record = await store.saveSession(sessionId, events, 'Payment refactor');
+    const loaded = await store.loadSession(sessionId);
+    const rawEvents = await readFile(join(rootDir, 'sessions', encodeURIComponent(sessionId), 'events.jsonl'), 'utf8');
+
+    expect(record).toMatchObject({
+      sessionId,
+      title: 'Payment refactor',
+      startedAt: '2026-03-26T10:00:00.000Z',
+      updatedAt: '2026-03-26T10:05:00.000Z',
+      eventCount: 2
+    });
+    expect(loaded.record).toEqual(record);
+    expect(loaded.events).toEqual(events);
+    expect(rawEvents.trim().split(/\r?\n/)).toHaveLength(2);
+  });
+
+  it('appends events and lists sessions in updated order', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'shadow-agent-persistence-'));
+    const store = new FileReplayStore(rootDir);
+
+    await store.saveSession('session-a', [
+      makeEvent({
+        id: 'a-1',
+        sessionId: 'session-a',
+        timestamp: '2026-03-26T09:00:00.000Z',
+        kind: 'session_started',
+        actor: 'system'
+      })
+    ], 'Session A');
+
+    await store.appendEvent('session-a', makeEvent({
+      id: 'a-2',
+      sessionId: 'session-a',
+      timestamp: '2026-03-26T09:15:00.000Z',
+      kind: 'tool_completed',
+      payload: { toolName: 'Read' }
+    }));
+
+    await store.saveSession('session-b', [
+      makeEvent({
+        id: 'b-1',
+        sessionId: 'session-b',
+        timestamp: '2026-03-26T11:00:00.000Z',
+        kind: 'session_started',
+        actor: 'system'
+      })
+    ], 'Session B');
+
+    const sessions = await store.listSessions();
+    const sessionA = sessions.find((session) => session.sessionId === 'session-a');
+    const sessionB = sessions.find((session) => session.sessionId === 'session-b');
+    const sessionAEvents = await store.loadEvents('session-a');
+
+    expect(sessionAEvents).toHaveLength(2);
+    expect(sessionA?.eventCount).toBe(2);
+    expect(sessionB?.eventCount).toBe(1);
+    expect(sessions[0].sessionId).toBe('session-b');
+    expect(sessions[1].sessionId).toBe('session-a');
+  });
+});

--- a/shadow-agent/tests/replay-store.test.ts
+++ b/shadow-agent/tests/replay-store.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { buildSessionRecord, parseReplay, serializeEvents } from '../src/shared/replay-store';
+import type { CanonicalEvent } from '../src/shared/schema';
+
+const events: CanonicalEvent[] = [
+  {
+    id: 'evt-2',
+    sessionId: 'session-a',
+    source: 'replay',
+    timestamp: '2026-03-26T10:05:00.000Z',
+    actor: 'agent',
+    kind: 'message',
+    payload: { text: 'Later event first.' }
+  },
+  {
+    id: 'evt-1',
+    sessionId: 'session-a',
+    source: 'replay',
+    timestamp: '2026-03-26T10:00:00.000Z',
+    actor: 'system',
+    kind: 'session_started',
+    payload: {}
+  }
+];
+
+describe('replay-store', () => {
+  it('round-trips replay JSONL and ignores blank lines', () => {
+    const serialized = serializeEvents(events);
+    const parsed = parseReplay(`\n${serialized}\n\n`);
+
+    expect(parsed).toEqual(events);
+  });
+
+  it('reports replay parse errors with a line number', () => {
+    expect(() => parseReplay('{"id":"ok"}\nnot-json')).toThrow(/line 2/i);
+  });
+
+  it('builds session records using min and max timestamps instead of event order', () => {
+    const record = buildSessionRecord(events, 'Session A');
+
+    expect(record).toMatchObject({
+      sessionId: 'session-a',
+      title: 'Session A',
+      startedAt: '2026-03-26T10:00:00.000Z',
+      updatedAt: '2026-03-26T10:05:00.000Z',
+      source: 'replay',
+      eventCount: 2
+    });
+  });
+});

--- a/shadow-agent/tests/transcript-adapter.test.ts
+++ b/shadow-agent/tests/transcript-adapter.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { parseClaudeTranscriptJsonl } from '../src/shared/transcript-adapter';
 
 describe('parseClaudeTranscriptJsonl', () => {
-  it('converts text, tool_use, and tool_result blocks into canonical events', () => {
+  it('converts text, tool_use, and tool_result blocks into canonical events deterministically', () => {
     const raw = [
       JSON.stringify({
         sessionId: 'abc',
@@ -12,17 +12,20 @@ describe('parseClaudeTranscriptJsonl', () => {
           content: [
             { type: 'text', text: 'Investigating payment flow.' },
             { type: 'tool_use', name: 'Read', input: { file_path: 'src/payment.ts' } },
-            { type: 'tool_result', tool_use_id: 'tool-1', content: 'done' }
+            { type: 'tool_result', tool_use_id: 'tool-1', content: 'done', is_error: true }
           ]
         }
       })
     ].join('\n');
 
     const events = parseClaudeTranscriptJsonl(raw);
+    const secondRunEvents = parseClaudeTranscriptJsonl(raw);
+
     expect(events.some((event) => event.kind === 'session_started')).toBe(true);
     expect(events.some((event) => event.kind === 'message')).toBe(true);
     expect(events.some((event) => event.kind === 'tool_started')).toBe(true);
-    expect(events.some((event) => event.kind === 'tool_completed')).toBe(true);
+    expect(events.some((event) => event.kind === 'tool_failed')).toBe(true);
     expect(events.at(-1)?.kind).toBe('session_ended');
+    expect(secondRunEvents).toEqual(events);
   });
 });

--- a/shadow-agent/tests/transcript-adapter.test.ts
+++ b/shadow-agent/tests/transcript-adapter.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { parseClaudeTranscriptJsonl } from '../src/shared/transcript-adapter';
+
+describe('parseClaudeTranscriptJsonl', () => {
+  it('converts text, tool_use, and tool_result blocks into canonical events', () => {
+    const raw = [
+      JSON.stringify({
+        sessionId: 'abc',
+        cwd: 'D:/demo',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Investigating payment flow.' },
+            { type: 'tool_use', name: 'Read', input: { file_path: 'src/payment.ts' } },
+            { type: 'tool_result', tool_use_id: 'tool-1', content: 'done' }
+          ]
+        }
+      })
+    ].join('\n');
+
+    const events = parseClaudeTranscriptJsonl(raw);
+    expect(events.some((event) => event.kind === 'session_started')).toBe(true);
+    expect(events.some((event) => event.kind === 'message')).toBe(true);
+    expect(events.some((event) => event.kind === 'tool_started')).toBe(true);
+    expect(events.some((event) => event.kind === 'tool_completed')).toBe(true);
+    expect(events.at(-1)?.kind).toBe('session_ended');
+  });
+});

--- a/shadow-agent/tsconfig.json
+++ b/shadow-agent/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src", "tests"]
+}

--- a/shadow-agent/vite.config.ts
+++ b/shadow-agent/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src')
+    }
+  },
+  build: {
+    outDir: 'dist'
+  }
+});


### PR DESCRIPTION
## Summary
- add the first `shadow-agent` standalone prototype as a passive Electron observer
- add canonical event schema, replay/transcript ingestion, deterministic state derivation, and file-backed replay persistence
- add the first renderer surface for graph, timeline, transcript, file attention, and shadow insights
- re-root the repo into a clean umbrella workspace with `shadow-agent/`, `docs/`, and ignored `third_party/` reference clones

## Why
This cuts the first reviewable slice of the larger shadow-agent project.

The target is a separate observer that shadows a primary coding agent instead of participating as a peer chat agent. It borrows:
- runtime separation and shadow-context ideas from Sidecar
- event ingestion, replay, and visualization ideas from Agent Flow

## What is in scope
- a clean umbrella repo root
- built-in replay fixture for a realistic session
- Claude transcript JSONL parsing into canonical events
- canonical replay JSONL parsing and export
- deterministic derived state for phase, file attention, risk signals, and next moves
- file-backed replay storage for saved sessions
- Electron + React dashboard for graph, timeline, transcript, and insight panels
- project plan and product note docs

## What is not in scope yet
- live Claude Code hook ingestion
- model-backed shadow inference beyond the deterministic baseline
- any write-capable or intervention behavior
- helper-agent orchestration
- tracking vendored third-party source in the umbrella repo history

## Validation
- `npm test`
- `npm run build`

## Reviewer focus
- whether the canonical event shape is the right long-term backbone
- whether the current deterministic derivation is the right baseline before adding a cheap/local model
- whether Electron is the right first shell for the standalone observer
- whether the current scope is the right minimal slice before live hook integration
