### PR TITLE
feat: live transcript capture pipeline

### DIFF
--- a/shadow-agent/src/capture/event-buffer.ts
+++ b/shadow-agent/src/capture/event-buffer.ts
@@ -1,0 +1,83 @@
+/**
+ * In-memory ring buffer for CanonicalEvents.
+ * Supports push, getRecent, getAll, getSince, and subscribe.
+ * Capacity defaults to 2000 events.
+ */
+import type { CanonicalEvent } from '../shared/schema';
+import { createLogger } from '../shared/logger';
+
+const logger = createLogger({ minLevel: 'info' });
+
+const DEFAULT_CAPACITY = 2000;
+
+export type EventSubscriber = (events: CanonicalEvent[]) => void;
+
+export interface EventBuffer {
+  push(events: CanonicalEvent[]): void;
+  getRecent(n: number): CanonicalEvent[];
+  getAll(): CanonicalEvent[];
+  getSince(eventId: string): CanonicalEvent[];
+  subscribe(cb: EventSubscriber): () => void;
+  clear(): void;
+  get size(): number;
+}
+
+export function createEventBuffer(capacity = DEFAULT_CAPACITY): EventBuffer {
+  const ring: CanonicalEvent[] = [];
+  const subscribers = new Set<EventSubscriber>();
+
+  const notify = (events: CanonicalEvent[]) => {
+    for (const sub of subscribers) {
+      try {
+        sub(events);
+      } catch (err) {
+        logger.error('capture', 'buffer.subscriber_error', { error: err });
+      }
+    }
+  };
+
+  return {
+    push(events: CanonicalEvent[]) {
+      for (const event of events) {
+        if (ring.length >= capacity) {
+          ring.shift();
+        }
+        ring.push(event);
+      }
+      if (events.length > 0) {
+        logger.debug('capture', 'buffer.pushed', { count: events.length, total: ring.length });
+        notify(events);
+      }
+    },
+
+    getRecent(n: number): CanonicalEvent[] {
+      return ring.slice(Math.max(0, ring.length - n));
+    },
+
+    getAll(): CanonicalEvent[] {
+      return [...ring];
+    },
+
+    getSince(eventId: string): CanonicalEvent[] {
+      const idx = ring.findIndex((e) => e.id === eventId);
+      if (idx === -1) return [...ring];
+      return ring.slice(idx + 1);
+    },
+
+    subscribe(cb: EventSubscriber): () => void {
+      subscribers.add(cb);
+      return () => {
+        subscribers.delete(cb);
+      };
+    },
+
+    clear() {
+      ring.length = 0;
+      logger.info('capture', 'buffer.cleared');
+    },
+
+    get size() {
+      return ring.length;
+    },
+  };
+}

--- a/shadow-agent/src/capture/incremental-parser.ts
+++ b/shadow-agent/src/capture/incremental-parser.ts
@@ -1,0 +1,44 @@
+/**
+ * Incrementally parses JSONL chunks into raw objects.
+ * Handles partial lines across chunk boundaries using an internal line buffer.
+ */
+import { createLogger } from '../shared/logger';
+
+const logger = createLogger({ minLevel: 'info' });
+
+export type ParsedEntry = Record<string, unknown>;
+export type EntryCallback = (entry: ParsedEntry) => void;
+
+export interface IncrementalParser {
+  push(chunk: string): void;
+  reset(): void;
+}
+
+export function createIncrementalParser(onEntry: EntryCallback): IncrementalParser {
+  let lineBuffer = '';
+
+  return {
+    push(chunk: string) {
+      lineBuffer += chunk;
+      const parts = lineBuffer.split(/\r?\n/);
+      // Last element may be a partial line — keep it in buffer
+      lineBuffer = parts.pop() ?? '';
+
+      for (const line of parts) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const entry = JSON.parse(trimmed) as ParsedEntry;
+          onEntry(entry);
+        } catch {
+          logger.warn('capture', 'parser.malformed_line', { preview: trimmed.slice(0, 80) });
+        }
+      }
+    },
+
+    reset() {
+      lineBuffer = '';
+      logger.debug('capture', 'parser.reset');
+    },
+  };
+}

--- a/shadow-agent/src/capture/ipc-bridge.ts
+++ b/shadow-agent/src/capture/ipc-bridge.ts
@@ -1,0 +1,75 @@
+/**
+ * IPC bridge between the main-process event buffer and the renderer.
+ *
+ * Push (main → renderer): debounced at 150ms, batches new events.
+ * Pull (renderer → main): handles 'shadow:snapshot' and 'shadow:events-since'.
+ */
+import { ipcMain } from 'electron';
+import type { WebContents } from 'electron';
+import type { CanonicalEvent, SnapshotPayload } from '../shared/schema';
+import type { EventBuffer } from './event-buffer';
+import { createLogger } from '../shared/logger';
+
+const logger = createLogger({ minLevel: 'info' });
+
+const PUSH_DEBOUNCE_MS = 150;
+
+export interface IpcBridgeOptions {
+  buffer: EventBuffer;
+  getWebContents: () => WebContents | null;
+  buildSnapshot: () => SnapshotPayload | null;
+}
+
+export interface IpcBridge {
+  start(): () => void; // returns cleanup
+}
+
+export function createIpcBridge(opts: IpcBridgeOptions): IpcBridge {
+  const { buffer, getWebContents, buildSnapshot } = opts;
+
+  return {
+    start() {
+      let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+      const pendingBatch: CanonicalEvent[] = [];
+
+      const flush = () => {
+        debounceTimer = null;
+        const wc = getWebContents();
+        if (!wc || wc.isDestroyed()) return;
+        if (pendingBatch.length === 0) return;
+
+        const batch = [...pendingBatch];
+        pendingBatch.length = 0;
+
+        logger.debug('ipc', 'snapshot.sent', { eventCount: batch.length });
+        wc.send('shadow:events', batch);
+      };
+
+      const unsubscribe = buffer.subscribe((events) => {
+        pendingBatch.push(...events);
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(flush, PUSH_DEBOUNCE_MS);
+      });
+
+      ipcMain.removeHandler('shadow:snapshot');
+      ipcMain.handle('shadow:snapshot', () => {
+        logger.info('ipc', 'snapshot_requested');
+        return buildSnapshot();
+      });
+
+      ipcMain.removeHandler('shadow:events-since');
+      ipcMain.handle('shadow:events-since', (_event, eventId: string) => {
+        logger.debug('ipc', 'events_since_requested', { eventId });
+        return buffer.getSince(eventId);
+      });
+
+      return () => {
+        unsubscribe();
+        if (debounceTimer) clearTimeout(debounceTimer);
+        ipcMain.removeHandler('shadow:snapshot');
+        ipcMain.removeHandler('shadow:events-since');
+        logger.info('ipc', 'bridge.stopped');
+      };
+    },
+  };
+}

--- a/shadow-agent/src/capture/normalizer.ts
+++ b/shadow-agent/src/capture/normalizer.ts
@@ -1,0 +1,115 @@
+/**
+ * Normalizes raw Claude Code transcript entries into CanonicalEvents.
+ * Reuses the same mapping logic as transcript-adapter.ts but operates on
+ * individual entries rather than full files.
+ */
+import { randomUUID } from 'node:crypto';
+import type { CanonicalEvent, EventKind } from '../shared/schema';
+import type { ParsedEntry } from './incremental-parser';
+import { createLogger } from '../shared/logger';
+
+const logger = createLogger({ minLevel: 'info' });
+
+export type NormalizedEvent = CanonicalEvent;
+
+function extractTimestamp(entry: ParsedEntry): string {
+  const ts = entry.timestamp ?? entry.created_at;
+  if (typeof ts === 'string') return ts;
+  return new Date().toISOString();
+}
+
+export function normalizeEntry(
+  entry: ParsedEntry,
+  sessionId: string
+): NormalizedEvent[] {
+  const events: NormalizedEvent[] = [];
+  const timestamp = extractTimestamp(entry);
+  const source = 'claude-transcript' as const;
+
+  const type = typeof entry.type === 'string' ? entry.type : '';
+
+  // Session lifecycle
+  if (type === 'session' || (type === '' && entry.cwd)) {
+    events.push({
+      id: randomUUID(),
+      sessionId,
+      source,
+      timestamp,
+      actor: 'system',
+      kind: 'session_started',
+      payload: { cwd: entry.cwd ?? null },
+    });
+    return events;
+  }
+
+  const message = entry.message as Record<string, unknown> | undefined;
+  if (!message) return events;
+
+  const role = typeof message.role === 'string' ? message.role : 'unknown';
+  const content = message.content;
+
+  if (typeof content === 'string') {
+    events.push({
+      id: randomUUID(),
+      sessionId,
+      source,
+      timestamp,
+      actor: role,
+      kind: 'message',
+      payload: { text: content },
+    });
+    return events;
+  }
+
+  if (!Array.isArray(content)) return events;
+
+  for (const block of content as ParsedEntry[]) {
+    const blockType = typeof block.type === 'string' ? block.type : '';
+
+    if (blockType === 'text' && typeof block.text === 'string') {
+      events.push({
+        id: randomUUID(),
+        sessionId,
+        source,
+        timestamp,
+        actor: role,
+        kind: 'message',
+        payload: { text: block.text },
+      });
+    } else if (blockType === 'tool_use') {
+      events.push({
+        id: randomUUID(),
+        sessionId,
+        source,
+        timestamp,
+        actor: role,
+        kind: 'tool_started',
+        payload: {
+          toolName: block.name ?? 'unknown',
+          toolUseId: block.id ?? randomUUID(),
+          args: block.input ?? {},
+        },
+      });
+    } else if (blockType === 'tool_result') {
+      const isError = block.is_error === true;
+      const kind: EventKind = isError ? 'tool_failed' : 'tool_completed';
+      events.push({
+        id: randomUUID(),
+        sessionId,
+        source,
+        timestamp,
+        actor: role,
+        kind,
+        payload: {
+          toolUseId: block.tool_use_id ?? randomUUID(),
+          output: block.content ?? null,
+          error: isError ? block.content : undefined,
+        },
+      });
+    } else if (blockType !== '') {
+      logger.debug('capture', 'normalizer.unknown_block_type', { blockType });
+    }
+  }
+
+  return events;
+}

--- a/shadow-agent/src/capture/session-discovery.ts
+++ b/shadow-agent/src/capture/session-discovery.ts
@@ -1,0 +1,82 @@
+/**
+ * Scans Claude Code's transcript directories for active sessions.
+ * Returns the path to the most recently modified JSONL file.
+ */
+import { readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { createLogger } from '../shared/logger';
+
+const logger = createLogger({ minLevel: 'info' });
+
+export interface DiscoveredSession {
+  filePath: string;
+  sessionId: string;
+  lastModified: number;
+}
+
+function getClaudeProjectsDir(): string {
+  return path.join(os.homedir(), '.claude', 'projects');
+}
+
+async function findJsonlFiles(dir: string): Promise<Array<{ filePath: string; mtime: number }>> {
+  const results: Array<{ filePath: string; mtime: number }> = [];
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return results;
+  }
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry);
+    try {
+      const info = await stat(fullPath);
+      if (info.isDirectory()) {
+        const nested = await findJsonlFiles(fullPath);
+        results.push(...nested);
+      } else if (entry.endsWith('.jsonl') || entry.endsWith('.ndjson')) {
+        results.push({ filePath: fullPath, mtime: info.mtimeMs });
+      }
+    } catch {
+      // Skip unreadable paths
+    }
+  }
+  return results;
+}
+
+/**
+ * Discover the active Claude Code session.
+ * Returns the most recently modified JSONL file under `~/.claude/projects/`.
+ * If `overridePath` is provided, that path is used directly.
+ */
+export async function discoverActiveSession(
+  overridePath?: string
+): Promise<DiscoveredSession | null> {
+  if (overridePath) {
+    try {
+      const info = await stat(overridePath);
+      const sessionId = path.basename(overridePath, path.extname(overridePath));
+      logger.info('capture', 'session_discovery.override', { filePath: overridePath });
+      return { filePath: overridePath, sessionId, lastModified: info.mtimeMs };
+    } catch {
+      logger.warn('capture', 'session_discovery.override_not_found', { filePath: overridePath });
+      return null;
+    }
+  }
+
+  const projectsDir = getClaudeProjectsDir();
+  logger.debug('capture', 'session_discovery.scan_start', { projectsDir });
+
+  const files = await findJsonlFiles(projectsDir);
+  if (files.length === 0) {
+    logger.info('capture', 'session_discovery.no_sessions_found');
+    return null;
+  }
+
+  const latest = files.sort((a, b) => b.mtime - a.mtime)[0];
+  const sessionId = path.basename(latest.filePath, path.extname(latest.filePath));
+  logger.info('capture', 'session_discovery.found', { filePath: latest.filePath, sessionId });
+
+  return { filePath: latest.filePath, sessionId, lastModified: latest.mtime };
+}

--- a/shadow-agent/src/capture/session-manager.ts
+++ b/shadow-agent/src/capture/session-manager.ts
@@ -1,0 +1,165 @@
+/**
+ * Session manager orchestrates the full capture pipeline:
+ * session discovery → watcher → incremental parser → normalizer → buffer → IPC bridge
+ *
+ * Scans every 30 seconds for new sessions. Tears down the old pipeline when a
+ * new session is detected.
+ */
+import type { WebContents } from 'electron';
+import type { SnapshotPayload, LoadedSource } from '../shared/schema';
+import { deriveState } from '../shared/derive';
+import { discoverActiveSession, type DiscoveredSession } from './session-discovery';
+import { watchTranscript, type TranscriptWatcher } from './transcript-watcher';
+import { createIncrementalParser } from './incremental-parser';
+import { normalizeEntry } from './normalizer';
+import { createEventBuffer, type EventBuffer } from './event-buffer';
+import { createIpcBridge } from './ipc-bridge';
+import { createLogger } from '../shared/logger';
+import { readFile } from 'node:fs/promises';
+
+const logger = createLogger({ minLevel: 'info' });
+
+const REDISCOVERY_INTERVAL_MS = 30_000;
+
+export interface SessionManager {
+  start(overridePath?: string): Promise<void>;
+  stop(): void;
+  getBuffer(): EventBuffer;
+  getCurrentSnapshot(): SnapshotPayload | null;
+}
+
+export function createSessionManager(
+  getWebContents: () => WebContents | null
+): SessionManager {
+  const buffer = createEventBuffer();
+  let activeSession: DiscoveredSession | null = null;
+  let activeWatcher: TranscriptWatcher | null = null;
+  let rediscoveryTimer: ReturnType<typeof setInterval> | null = null;
+  let bridgeCleanup: (() => void) | null = null;
+  let sessionTitle = 'Live session';
+
+  const buildSnapshot = (): SnapshotPayload | null => {
+    const events = buffer.getAll();
+    const state = deriveState(events);
+    const source: LoadedSource = {
+      kind: 'transcript',
+      label: sessionTitle,
+      path: activeSession?.filePath,
+    };
+    const record = {
+      sessionId: state.sessionId || activeSession?.sessionId || 'unknown',
+      title: sessionTitle,
+      startedAt: events[0]?.timestamp ?? new Date().toISOString(),
+      updatedAt: events.at(-1)?.timestamp ?? new Date().toISOString(),
+      source: 'claude-transcript' as const,
+      eventCount: events.length,
+    };
+    return { source, record, state, events };
+  };
+
+  const teardown = () => {
+    if (activeWatcher) {
+      activeWatcher.stop();
+      activeWatcher = null;
+    }
+    activeSession = null;
+  };
+
+  const startSession = async (session: DiscoveredSession) => {
+    teardown();
+    activeSession = session;
+    sessionTitle = `Live: ${session.sessionId.slice(0, 12)}`;
+
+    logger.info('capture', 'session_manager.start_session', {
+      filePath: session.filePath,
+      sessionId: session.sessionId,
+    });
+
+    // Catch-up: read the entire existing file first
+    try {
+      const raw = await readFile(session.filePath, 'utf8');
+      const lines = raw.split(/\r?\n/).filter((l) => l.trim());
+      const catchupEvents = lines.flatMap((line) => {
+        try {
+          const entry = JSON.parse(line) as Record<string, unknown>;
+          return normalizeEntry(entry, session.sessionId);
+        } catch {
+          return [];
+        }
+      });
+      if (catchupEvents.length > 0) {
+        buffer.push(catchupEvents);
+        logger.info('capture', 'session_manager.catchup', { count: catchupEvents.length });
+      }
+    } catch (err) {
+      logger.warn('capture', 'session_manager.catchup_failed', { error: err });
+    }
+
+    // Then watch for incremental updates
+    const parser = createIncrementalParser((entry) => {
+      const events = normalizeEntry(entry, session.sessionId);
+      if (events.length > 0) {
+        buffer.push(events);
+      }
+    });
+
+    activeWatcher = watchTranscript(session.filePath, (chunk) => {
+      parser.push(chunk);
+    });
+  };
+
+  const runRediscovery = async (overridePath?: string) => {
+    const found = await discoverActiveSession(overridePath);
+    if (!found) return;
+
+    const isNewSession = !activeSession || found.filePath !== activeSession.filePath;
+    if (isNewSession) {
+      logger.info('capture', 'session_manager.new_session_detected', {
+        filePath: found.filePath,
+      });
+      buffer.clear();
+      await startSession(found);
+    }
+  };
+
+  return {
+    async start(overridePath?: string) {
+      // Start the IPC bridge
+      const bridge = createIpcBridge({
+        buffer,
+        getWebContents,
+        buildSnapshot,
+      });
+      bridgeCleanup = bridge.start();
+
+      // Initial discovery
+      await runRediscovery(overridePath);
+
+      // Periodic re-discovery
+      rediscoveryTimer = setInterval(() => {
+        void runRediscovery(overridePath);
+      }, REDISCOVERY_INTERVAL_MS);
+    },
+
+    stop() {
+      if (rediscoveryTimer) {
+        clearInterval(rediscoveryTimer);
+        rediscoveryTimer = null;
+      }
+      teardown();
+      if (bridgeCleanup) {
+        bridgeCleanup();
+        bridgeCleanup = null;
+      }
+      logger.info('capture', 'session_manager.stopped');
+    },
+
+    getBuffer() {
+      return buffer;
+    },
+
+    getCurrentSnapshot() {
+      return buildSnapshot();
+    },
+  };
+}

--- a/shadow-agent/src/capture/transcript-watcher.ts
+++ b/shadow-agent/src/capture/transcript-watcher.ts
@@ -1,0 +1,98 @@
+/**
+ * Watches a single JSONL transcript file for new lines, handles truncation and rotation.
+ * Emits raw string chunks to registered callbacks.
+ */
+import { open, stat } from 'node:fs/promises';
+import type { FileHandle } from 'node:fs/promises';
+import fs from 'node:fs';
+import { createLogger } from '../shared/logger';
+
+const logger = createLogger({ minLevel: 'info' });
+
+export type ChunkCallback = (chunk: string) => void;
+
+export interface TranscriptWatcher {
+  stop(): void;
+}
+
+const DEBOUNCE_MS = 100;
+const READ_CHUNK = 65_536; // 64 KB
+
+export function watchTranscript(filePath: string, onChunk: ChunkCallback): TranscriptWatcher {
+  let offset = 0;
+  let handle: FileHandle | null = null;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
+
+  const readNew = async () => {
+    try {
+      const info = await stat(filePath);
+
+      // File was truncated or rotated → reset
+      if (info.size < offset) {
+        logger.info('capture', 'watcher.truncated', { filePath, oldOffset: offset });
+        if (handle) {
+          await handle.close().catch(() => undefined);
+          handle = null;
+        }
+        offset = 0;
+      }
+
+      if (info.size <= offset) return;
+
+      if (!handle) {
+        handle = await open(filePath, 'r');
+      }
+
+      const toRead = info.size - offset;
+      const buf = Buffer.allocUnsafe(Math.min(toRead, READ_CHUNK));
+      const { bytesRead } = await handle.read(buf, 0, buf.length, offset);
+      if (bytesRead > 0) {
+        offset += bytesRead;
+        onChunk(buf.subarray(0, bytesRead).toString('utf8'));
+        // If there's more data, schedule another read immediately
+        if (bytesRead === READ_CHUNK) {
+          scheduleRead(0);
+        }
+      }
+    } catch (err) {
+      logger.error('capture', 'watcher.read_error', { filePath, error: err });
+      if (handle) {
+        await handle.close().catch(() => undefined);
+        handle = null;
+      }
+    }
+  };
+
+  const scheduleRead = (delay = DEBOUNCE_MS) => {
+    if (stopped) return;
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      void readNew();
+    }, delay);
+  };
+
+  const watcher = fs.watch(filePath, { persistent: false }, () => {
+    scheduleRead();
+  });
+
+  watcher.on('error', (err) => {
+    logger.error('capture', 'watcher.fs_error', { filePath, error: err });
+  });
+
+  // Initial read — catch up on existing content
+  void readNew();
+
+  return {
+    stop() {
+      stopped = true;
+      if (debounceTimer) clearTimeout(debounceTimer);
+      watcher.close();
+      if (handle) {
+        void handle.close().catch(() => undefined);
+        handle = null;
+      }
+      logger.info('capture', 'watcher.stopped', { filePath });
+    },
+  };
+}

--- a/shadow-agent/src/electron/start-main-process.ts
+++ b/shadow-agent/src/electron/start-main-process.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import type { CanonicalEvent } from '../shared/schema';
 import { createLogger } from '../shared/logger';
 import { buildFixtureSnapshot, loadSnapshotFromFile, pickOpenFile, saveReplayFile } from './session-io';
+import { createSessionManager } from '../capture/session-manager';
 
 const APP_TITLE = 'Shadow Agent';
 const logger = createLogger({ minLevel: 'info' });
@@ -102,6 +103,7 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null): 
 
 export function startMainProcess(): void {
   let mainWindow: BrowserWindow | null = null;
+  const sessionManager = createSessionManager(() => mainWindow?.webContents ?? null);
 
   app
     .whenReady()
@@ -112,6 +114,8 @@ export function startMainProcess(): void {
         mainWindow.on('closed', () => {
           mainWindow = null;
         });
+        // Start live transcript capture (non-blocking; falls back gracefully if no session found)
+        void sessionManager.start();
         logger.info('app', 'ready');
       } catch (error) {
         logger.error('app', 'window_create_failed_on_ready', { error });
@@ -141,6 +145,7 @@ export function startMainProcess(): void {
   app.on('window-all-closed', () => {
     if (process.platform !== 'darwin') {
       logger.info('app', 'quit_on_window_all_closed');
+      sessionManager.stop();
       app.quit();
     }
   });

--- a/shadow-agent/tests/capture.test.ts
+++ b/shadow-agent/tests/capture.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for the event capture pipeline.
+ * Covers: incremental parser, event buffer, session discovery, and session manager roundtrip.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createIncrementalParser } from '../src/capture/incremental-parser';
+import { createEventBuffer } from '../src/capture/event-buffer';
+import type { CanonicalEvent } from '../src/shared/schema';
+import { normalizeEntry } from '../src/capture/normalizer';
+import { discoverActiveSession } from '../src/capture/session-discovery';
+import * as fs from 'node:fs/promises';
+
+// ── incremental parser ─────────────────────────────────────────────────────
+
+describe('createIncrementalParser', () => {
+  it('emits complete lines and holds partial tail', () => {
+    const received: Record<string, unknown>[] = [];
+    const parser = createIncrementalParser((entry) => received.push(entry));
+
+    parser.push('{"type":"message","role":"user"}\n{"type":"tool_use"');
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({ type: 'message', role: 'user' });
+
+    parser.push(',"name":"bash"}\n');
+    expect(received).toHaveLength(2);
+    expect(received[1]).toMatchObject({ type: 'tool_use', name: 'bash' });
+  });
+
+  it('handles CRLF line endings', () => {
+    const received: Record<string, unknown>[] = [];
+    const parser = createIncrementalParser((entry) => received.push(entry));
+    parser.push('{"type":"a"}\r\n{"type":"b"}\r\n');
+    expect(received).toHaveLength(2);
+  });
+
+  it('skips invalid JSON lines without throwing', () => {
+    const received: Record<string, unknown>[] = [];
+    const parser = createIncrementalParser((entry) => received.push(entry));
+    parser.push('not-json\n{"type":"ok"}\n');
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({ type: 'ok' });
+  });
+
+  it('reset clears buffered partial line', () => {
+    const received: Record<string, unknown>[] = [];
+    const parser = createIncrementalParser((entry) => received.push(entry));
+    parser.push('{"type":"partial"');
+    parser.reset();
+    parser.push('{"type":"fresh"}\n');
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({ type: 'fresh' });
+  });
+});
+
+// ── normalizer ─────────────────────────────────────────────────────────────
+
+describe('normalizeEntry', () => {
+  const SESSION_ID = 'test-session-abc';
+
+  it('maps a message entry to a CanonicalEvent', () => {
+    // Claude Code transcript format: role/content nested under entry.message
+    const raw = {
+      type: 'say',
+      timestamp: '2024-01-01T00:00:00.000Z',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'hello' }],
+      },
+    };
+    const events = normalizeEntry(raw, SESSION_ID);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      kind: 'message',
+      source: 'claude-transcript',
+      sessionId: SESSION_ID,
+    });
+  });
+
+  it('maps a tool_use entry', () => {
+    const raw = {
+      type: 'say',
+      timestamp: '2024-01-01T00:00:01.000Z',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'tool_use', name: 'bash', id: 'tu_1', input: { command: 'ls' } }],
+      },
+    };
+    const events = normalizeEntry(raw, SESSION_ID);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe('tool_started');
+  });
+
+  it('maps a tool_result entry', () => {
+    const raw = {
+      type: 'say',
+      timestamp: '2024-01-01T00:00:02.000Z',
+      message: {
+        role: 'tool',
+        content: [{ type: 'tool_result', tool_use_id: 'tu_1', content: 'output' }],
+      },
+    };
+    const events = normalizeEntry(raw, SESSION_ID);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe('tool_completed');
+  });
+
+  it('returns empty array for unknown entry types', () => {
+    const raw = { type: 'unknown_type', data: {} };
+    expect(normalizeEntry(raw, SESSION_ID)).toHaveLength(0);
+  });
+});
+
+// ── event buffer ───────────────────────────────────────────────────────────
+
+describe('createEventBuffer', () => {
+  const makeEvent = (id: string): CanonicalEvent => ({
+    id,
+    kind: 'message',
+    timestamp: new Date().toISOString(),
+    source: 'claude-transcript',
+    sessionId: 'sess',
+    payload: {},
+  });
+
+  it('pushes events and returns them via getAll', () => {
+    const buf = createEventBuffer();
+    buf.push([makeEvent('a'), makeEvent('b')]);
+    expect(buf.getAll()).toHaveLength(2);
+    expect(buf.size).toBe(2);
+  });
+
+  it('evicts oldest events when capacity is exceeded', () => {
+    const buf = createEventBuffer(3);
+    buf.push([makeEvent('x'), makeEvent('y'), makeEvent('z')]);
+    buf.push([makeEvent('w')]);
+    const all = buf.getAll();
+    expect(all).toHaveLength(3);
+    expect(all[0].id).toBe('y');
+    expect(all[2].id).toBe('w');
+  });
+
+  it('getRecent returns last n events', () => {
+    const buf = createEventBuffer();
+    buf.push([makeEvent('1'), makeEvent('2'), makeEvent('3')]);
+    const recent = buf.getRecent(2);
+    expect(recent).toHaveLength(2);
+    expect(recent[0].id).toBe('2');
+    expect(recent[1].id).toBe('3');
+  });
+
+  it('getSince returns events after a given id', () => {
+    const buf = createEventBuffer();
+    buf.push([makeEvent('a'), makeEvent('b'), makeEvent('c')]);
+    expect(buf.getSince('b')).toHaveLength(1);
+    expect(buf.getSince('b')[0].id).toBe('c');
+  });
+
+  it('getSince returns all events when id not found', () => {
+    const buf = createEventBuffer();
+    buf.push([makeEvent('a'), makeEvent('b')]);
+    expect(buf.getSince('missing')).toHaveLength(2);
+  });
+
+  it('subscribe is notified on push', () => {
+    const buf = createEventBuffer();
+    const calls: CanonicalEvent[][] = [];
+    buf.subscribe((evts) => calls.push(evts));
+    buf.push([makeEvent('e1')]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toHaveLength(1);
+  });
+
+  it('unsubscribe stops notifications', () => {
+    const buf = createEventBuffer();
+    const calls: number[] = [];
+    const unsub = buf.subscribe(() => calls.push(1));
+    buf.push([makeEvent('e1')]);
+    unsub();
+    buf.push([makeEvent('e2')]);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('clear empties the buffer', () => {
+    const buf = createEventBuffer();
+    buf.push([makeEvent('a')]);
+    buf.clear();
+    expect(buf.size).toBe(0);
+    expect(buf.getAll()).toHaveLength(0);
+  });
+});
+
+// ── session discovery ──────────────────────────────────────────────────────
+
+describe('discoverActiveSession', () => {
+  it('returns null when no JSONL files exist in override path', async () => {
+    const result = await discoverActiveSession('/nonexistent/path/that/does/not/exist');
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Implements the full live transcript capture pipeline (issue #9).

## What's included

### New files: \shadow-agent/src/capture/\
| File | Purpose |
|------|---------|
| \session-discovery.ts\ | Scans \~/.claude/projects/**/*.jsonl\, returns most recently modified file |
| \	ranscript-watcher.ts\ | \s.watch\ on a JSONL file with byte-offset reads; handles truncation/rotation |
| \incremental-parser.ts\ | Stateful line buffer — splits incoming chunks on \\\n\, JSON-parses complete lines |
| \
ormalizer.ts\ | Maps raw transcript entries to \CanonicalEvent[]\ (message, tool_started, tool_completed, session_started) |
| \vent-buffer.ts\ | Ring buffer (capacity 2000) with \push\, \getRecent\, \getAll\, \getSince\, \subscribe\ |
| \ipc-bridge.ts\ | Debounced push at 150ms + \shadow:snapshot\ / \shadow:events-since\ IPC handlers |
| \session-manager.ts\ | Orchestrates the full pipeline with 30s re-discovery and catch-up read on session start |

### Modified
- \start-main-process.ts\ — wires \SessionManager\ into \pp.whenReady()\
- \session-io.ts\ — fix TypeScript strict-null dialog argument
- \	ests/renderer/bridge.test.ts\ — fix TypeScript cast

### Tests
17 new tests in \	ests/capture.test.ts\ covering:
- Incremental parser (line splitting, CRLF, invalid JSON, reset)
- Normalizer (message, tool_use, tool_result, unknown type)
- Event buffer (push, eviction, getRecent, getSince, subscribe, unsubscribe, clear)
- Session discovery (graceful null return for missing path)

All 41 tests pass. Zero TypeScript errors.

Closes #9