### PR TITLE
feat: shadow inference engine + MCP server

### DIFF
--- a/shadow-agent/src/electron/session-io.ts
+++ b/shadow-agent/src/electron/session-io.ts
@@ -144,7 +144,7 @@ export function buildFixtureSnapshot(): SnapshotPayload {
 }
 
 export async function pickOpenFile(mainWindow: BrowserWindow | null): Promise<string | undefined> {
-  const result = await dialog.showOpenDialog(mainWindow ?? undefined, {
+  const result = await dialog.showOpenDialog(mainWindow ?? null!, {
     title: 'Open transcript or replay file',
     properties: ['openFile'],
     filters: [
@@ -168,7 +168,7 @@ export async function saveReplayFile(
   suggestedFileName = 'shadow-agent-replay.jsonl'
 ): Promise<ExportResult> {
   try {
-    const result = await dialog.showSaveDialog(mainWindow ?? undefined, {
+    const result = await dialog.showSaveDialog(mainWindow ?? null!, {
       title: 'Export replay JSONL',
       defaultPath: suggestedFileName.endsWith('.jsonl') ? suggestedFileName : `${suggestedFileName}.jsonl`,
       filters: [{ name: 'Replay files', extensions: ['jsonl'] }]

--- a/shadow-agent/src/inference/auth.ts
+++ b/shadow-agent/src/inference/auth.ts
@@ -1,0 +1,107 @@
+/**
+ * Credential loader for the inference engine.
+ *
+ * Priority chain:
+ *  1. Already set in process.env (skip — already done)
+ *  2. ~/.shadow-agent/.env (dotenv-style, manual parse to avoid a heavy dep)
+ *  3. ~/.local/share/opencode/auth.json (OpenCode auth store)
+ *
+ * Sets process.env variables so downstream code can use them transparently.
+ * Safe to call multiple times — no-ops if the key is already set.
+ */
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { createLogger } from '../shared/logger';
+
+const logger = createLogger({ minLevel: 'info' });
+
+/** Maps OpenCode provider name → env variable name */
+const PROVIDER_ENV_MAP: Record<string, string> = {
+  anthropic: 'ANTHROPIC_API_KEY',
+  openai: 'OPENAI_API_KEY',
+  openrouter: 'OPENROUTER_API_KEY',
+  google: 'GOOGLE_API_KEY',
+  deepseek: 'DEEPSEEK_API_KEY',
+};
+
+function setIfMissing(key: string, value: string): boolean {
+  if (process.env[key]) return false;
+  process.env[key] = value;
+  return true;
+}
+
+/** Parse a .env file (KEY=VALUE, # comments, blank lines ignored). */
+function parseDotenv(contents: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const line of contents.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx < 1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    let value = trimmed.slice(eqIdx + 1).trim();
+    // Strip surrounding quotes
+    if ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
+async function loadDotenvFile(): Promise<void> {
+  const envPath = join(homedir(), '.shadow-agent', '.env');
+  try {
+    const contents = await readFile(envPath, 'utf8');
+    const pairs = parseDotenv(contents);
+    let loaded = 0;
+    for (const [key, value] of Object.entries(pairs)) {
+      if (setIfMissing(key, value)) loaded++;
+    }
+    if (loaded > 0) {
+      logger.info('inference', 'auth.dotenv_loaded', { path: envPath, keys: loaded });
+    }
+  } catch {
+    // File doesn't exist — that's fine
+  }
+}
+
+async function loadOpencodeAuth(): Promise<void> {
+  const authPath = join(homedir(), '.local', 'share', 'opencode', 'auth.json');
+  try {
+    const raw = await readFile(authPath, 'utf8');
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    let loaded = 0;
+    for (const [provider, envKey] of Object.entries(PROVIDER_ENV_MAP)) {
+      const value = (parsed[provider] as Record<string, string> | undefined)?.key
+        ?? (parsed[provider] as string | undefined);
+      if (typeof value === 'string' && value && setIfMissing(envKey, value)) {
+        loaded++;
+      }
+    }
+    if (loaded > 0) {
+      logger.info('inference', 'auth.opencode_loaded', { path: authPath, keys: loaded });
+    }
+  } catch {
+    // File doesn't exist — that's fine
+  }
+}
+
+/**
+ * Load credentials from all sources. Call once at app startup.
+ * Reports which provider keys are now available (without logging values).
+ */
+export async function loadCredentials(): Promise<void> {
+  await loadDotenvFile();
+  await loadOpencodeAuth();
+
+  const available = Object.values(PROVIDER_ENV_MAP).filter((k) => !!process.env[k]);
+  logger.info('inference', 'auth.credentials_ready', { providers: available });
+}
+
+/** Returns true if any inference provider key is set. */
+export function hasAnyCredential(): boolean {
+  return Object.values(PROVIDER_ENV_MAP).some((k) => !!process.env[k]);
+}

--- a/shadow-agent/src/inference/context-packager.ts
+++ b/shadow-agent/src/inference/context-packager.ts
@@ -1,0 +1,80 @@
+/**
+ * Context packager: builds a ShadowContextPacket from DerivedState + recent events.
+ *
+ * Uses the ShadowContextPacket type defined in prompts.ts (the canonical shape for inference).
+ * Total context budget: ~10,000 tokens. Truncates from the front — recent events are more valuable.
+ */
+import type { CanonicalEvent, DerivedState } from '../shared/schema';
+import type { ShadowContextPacket } from './prompts';
+
+const MAX_RECENT_EVENTS = 30;
+const MAX_TOOL_HISTORY = 20;
+const MAX_TRANSCRIPT_TURNS = 10;
+const MAX_FILE_ATTENTION = 15;
+
+function summarizeArgs(args: unknown): string {
+  if (!args || typeof args !== 'object') return String(args ?? '');
+  const entries = Object.entries(args as Record<string, unknown>).slice(0, 3);
+  return entries.map(([k, v]) => `${k}=${JSON.stringify(v)?.slice(0, 60) ?? ''}`).join(', ');
+}
+
+export function buildContextPacket(
+  state: DerivedState,
+  events: CanonicalEvent[]
+): ShadowContextPacket {
+  const first = events[0];
+  const last = events.at(-1);
+  const sessionDuration = first && last
+    ? Math.round((new Date(last.timestamp).getTime() - new Date(first.timestamp).getTime()) / 1000)
+    : 0;
+
+  // Recent events
+  const recentEvents = events.slice(-MAX_RECENT_EVENTS);
+
+  // Tool call history (match prompts.ts shape: {tool, result, argsSummary})
+  const toolHistory: ShadowContextPacket['toolHistory'] = [];
+  for (const event of events) {
+    if (event.kind === 'tool_started') {
+      const p = event.payload as Record<string, unknown>;
+      toolHistory.push({
+        tool: String(p.toolName ?? 'unknown'),
+        argsSummary: summarizeArgs(p.args),
+        result: 'pending',
+      });
+    } else if (event.kind === 'tool_completed' || event.kind === 'tool_failed') {
+      // Update the last pending tool call
+      for (let i = toolHistory.length - 1; i >= 0; i--) {
+        if (toolHistory[i]!.result === 'pending') {
+          toolHistory[i]!.result = event.kind === 'tool_completed' ? 'success' : 'error';
+          break;
+        }
+      }
+    }
+  }
+
+  // Transcript turns
+  const recentTranscript = state.transcript
+    .slice(-MAX_TRANSCRIPT_TURNS)
+    .map((t) => ({ actor: t.actor, text: t.text.slice(0, 500) }));
+
+  // File attention
+  const fileAttention = state.fileAttention.slice(0, MAX_FILE_ATTENTION);
+
+  // Risk signals (convert string[] → {signal, severity}[])
+  const riskSignals: ShadowContextPacket['riskSignals'] = state.riskSignals.map((s) => ({
+    signal: s,
+    severity: 'medium',
+  }));
+
+  return {
+    sessionId: state.sessionId,
+    observedAgent: 'claude-code',
+    sessionDuration,
+    currentPhase: state.activePhase,
+    recentEvents,
+    toolHistory: toolHistory.slice(-MAX_TOOL_HISTORY),
+    recentTranscript,
+    fileAttention,
+    riskSignals,
+  };
+}

--- a/shadow-agent/src/inference/context-packager.ts
+++ b/shadow-agent/src/inference/context-packager.ts
@@ -11,6 +11,11 @@ const MAX_RECENT_EVENTS = 30;
 const MAX_TOOL_HISTORY = 20;
 const MAX_TRANSCRIPT_TURNS = 10;
 const MAX_FILE_ATTENTION = 15;
+const MAX_CONTEXT_TOKENS = 10_000;
+
+function estimateTokens(value: unknown): number {
+  return Math.ceil(JSON.stringify(value).length / 4);
+}
 
 function summarizeArgs(args: unknown): string {
   if (!args || typeof args !== 'object') return String(args ?? '');
@@ -66,7 +71,7 @@ export function buildContextPacket(
     severity: 'medium',
   }));
 
-  return {
+  const packet: ShadowContextPacket = {
     sessionId: state.sessionId,
     observedAgent: 'claude-code',
     sessionDuration,
@@ -77,4 +82,43 @@ export function buildContextPacket(
     fileAttention,
     riskSignals,
   };
+
+  let approximateTokens = estimateTokens(packet);
+  if (approximateTokens <= MAX_CONTEXT_TOKENS) {
+    return packet;
+  }
+
+  const truncatedPacket: ShadowContextPacket = {
+    ...packet,
+    recentEvents: [...packet.recentEvents],
+    toolHistory: [...packet.toolHistory],
+    recentTranscript: [...packet.recentTranscript],
+    fileAttention: [...packet.fileAttention],
+  };
+
+  const trimOldest = () => {
+    if (truncatedPacket.recentEvents.length > 1) {
+      truncatedPacket.recentEvents = truncatedPacket.recentEvents.slice(1);
+      return true;
+    }
+    if (truncatedPacket.recentTranscript.length > 1) {
+      truncatedPacket.recentTranscript = truncatedPacket.recentTranscript.slice(1);
+      return true;
+    }
+    if (truncatedPacket.toolHistory.length > 1) {
+      truncatedPacket.toolHistory = truncatedPacket.toolHistory.slice(1);
+      return true;
+    }
+    if (truncatedPacket.fileAttention.length > 1) {
+      truncatedPacket.fileAttention = truncatedPacket.fileAttention.slice(0, -1);
+      return true;
+    }
+    return false;
+  };
+
+  while (approximateTokens > MAX_CONTEXT_TOKENS && trimOldest()) {
+    approximateTokens = estimateTokens(truncatedPacket);
+  }
+
+  return truncatedPacket;
 }

--- a/shadow-agent/src/inference/direct-api.ts
+++ b/shadow-agent/src/inference/direct-api.ts
@@ -1,0 +1,69 @@
+/**
+ * Direct Anthropic API client — fallback when OpenCode is unavailable.
+ *
+ * Uses @anthropic-ai/sdk. Does not require session management or polling.
+ * Model: claude-sonnet-4-5, max_tokens: 1024.
+ *
+ * Implements InferenceClient so it's a drop-in alternative to the OpenCode client.
+ */
+import type { InferenceClient, InferenceRequest, InferenceResult } from './inference-client';
+import { createLogger } from '../shared/logger';
+
+const logger = createLogger({ minLevel: 'info' });
+
+const MODEL = 'claude-sonnet-4-5';
+const MAX_TOKENS = 1024;
+
+/**
+ * Create a direct Anthropic API client.
+ * Returns null if the API key is not available or if the SDK is not installed.
+ */
+export async function createDirectApiClient(): Promise<InferenceClient | null> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    logger.warn('inference', 'direct_api.no_key');
+    return null;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let AnthropicClass: new (opts: { apiKey: string }) => any;
+  try {
+    // @ts-expect-error — @anthropic-ai/sdk is an optional runtime dependency
+    const mod = await import('@anthropic-ai/sdk') as { default: new (opts: { apiKey: string }) => any };
+    AnthropicClass = mod.default;
+  } catch {
+    logger.warn('inference', 'direct_api.sdk_not_installed');
+    return null;
+  }
+
+  const client = new AnthropicClass({ apiKey });
+
+  return {
+    provider: 'anthropic' as const,
+
+    async infer(request: InferenceRequest): Promise<InferenceResult> {
+      const start = Date.now();
+      logger.info('inference', 'direct_api.request_start');
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      const response = await client.messages.create({
+        model: MODEL,
+        max_tokens: MAX_TOKENS,
+        system: request.systemPrompt,
+        messages: [{ role: 'user', content: request.userMessage }],
+      }) as { content: Array<{ type: string; text?: string }>; model: string; usage: unknown };
+
+      const latencyMs = Date.now() - start;
+      const content = response.content[0];
+      const text = content?.type === 'text' ? (content.text ?? '') : '';
+
+      logger.info('inference', 'direct_api.request_done', { latencyMs, tokens: response.usage });
+
+      return {
+        text,
+        model: response.model,
+        latencyMs,
+      };
+    },
+  };
+}

--- a/shadow-agent/src/inference/inference-client.ts
+++ b/shadow-agent/src/inference/inference-client.ts
@@ -1,3 +1,5 @@
+import type { CanonicalEvent } from '../shared/schema';
+
 export interface InferenceRequest {
   systemPrompt: string;
   userMessage: string;
@@ -14,4 +16,16 @@ export type Provider = 'opencode' | 'anthropic' | 'fake';
 export interface InferenceClient {
   readonly provider: Provider;
   infer(request: InferenceRequest): Promise<InferenceResult>;
+}
+
+/**
+ * Structural interface for the event buffer.
+ * The concrete implementation lives in src/capture/event-buffer.ts.
+ * Defined here so inference code can depend on the shape without a cross-module import.
+ */
+export interface EventBufferLike {
+  getAll(): CanonicalEvent[];
+  getRecent(n: number): CanonicalEvent[];
+  get size(): number;
+  subscribe(cb: (events: CanonicalEvent[]) => void): () => void;
 }

--- a/shadow-agent/src/inference/prompt-builder.ts
+++ b/shadow-agent/src/inference/prompt-builder.ts
@@ -1,0 +1,15 @@
+/**
+ * Prompt builder: assembles InferenceRequest from a ShadowContextPacket.
+ *
+ * Uses SHADOW_SYSTEM_PROMPT from prompts.ts and buildUserMessage for the user turn.
+ * Deterministic: same packet → same request.
+ */
+import { SHADOW_SYSTEM_PROMPT, buildUserMessage, type ShadowContextPacket } from './prompts';
+import type { InferenceRequest } from './inference-client';
+
+export function buildInferenceRequest(packet: ShadowContextPacket): InferenceRequest {
+  return {
+    systemPrompt: SHADOW_SYSTEM_PROMPT,
+    userMessage: buildUserMessage(packet),
+  };
+}

--- a/shadow-agent/src/inference/response-parser.ts
+++ b/shadow-agent/src/inference/response-parser.ts
@@ -1,0 +1,127 @@
+/**
+ * Response parser: converts the model's raw JSON response text into ShadowInsight[].
+ *
+ * Handles: markdown-fenced JSON, missing fields, malformed output.
+ * Per the plan:
+ *   phase → {kind: 'phase', confidence: phaseConfidence}
+ *   riskSignals[i] → {kind: 'risk'}
+ *   predictedNextAction → {kind: 'next_move'}
+ *   attention.intent → {kind: 'objective'}
+ *   observations[i] → {kind: 'summary'}
+ */
+import type { ShadowInsight, InsightKind } from '../shared/schema';
+import { createLogger } from '../shared/logger';
+
+const logger = createLogger({ minLevel: 'info' });
+
+interface ModelResponse {
+  phase?: string;
+  phaseConfidence?: number;
+  phaseReason?: string;
+  riskLevel?: string;
+  riskSignals?: Array<{ signal?: string; severity?: string; confidence?: number }>;
+  predictedNextAction?: string;
+  predictedNextConfidence?: number;
+  observations?: string[];
+  attention?: { primaryFile?: string | null; intent?: string };
+}
+
+function stripMarkdownFences(text: string): string {
+  return text
+    .replace(/^```(?:json)?\s*/m, '')
+    .replace(/\s*```\s*$/m, '')
+    .trim();
+}
+
+function clamp(n: number): number {
+  return Math.max(0, Math.min(1, n));
+}
+
+function makeInsight(
+  kind: InsightKind,
+  summary: string,
+  confidence: number,
+  structuredPayload?: Record<string, unknown>
+): ShadowInsight {
+  return {
+    kind,
+    confidence: clamp(confidence),
+    scope: 'session',
+    summary,
+    evidenceEventIds: [],
+    structuredPayload,
+  };
+}
+
+export function parseModelResponse(text: string): ShadowInsight[] {
+  const cleaned = stripMarkdownFences(text);
+  let parsed: ModelResponse;
+
+  try {
+    parsed = JSON.parse(cleaned) as ModelResponse;
+  } catch {
+    logger.warn('inference', 'response_parser.json_parse_failed', {
+      preview: cleaned.slice(0, 200),
+    });
+    return [];
+  }
+
+  const insights: ShadowInsight[] = [];
+
+  // Phase
+  if (parsed.phase) {
+    insights.push(
+      makeInsight(
+        'phase',
+        parsed.phaseReason ?? `Phase: ${parsed.phase}`,
+        parsed.phaseConfidence ?? 0.5,
+        { phase: parsed.phase }
+      )
+    );
+  }
+
+  // Risk signals
+  for (const rs of parsed.riskSignals ?? []) {
+    if (!rs.signal) continue;
+    insights.push(
+      makeInsight(
+        'risk',
+        rs.signal,
+        rs.confidence ?? 0.5,
+        { severity: rs.severity ?? 'medium', riskLevel: parsed.riskLevel ?? 'low' }
+      )
+    );
+  }
+
+  // Predicted next action
+  if (parsed.predictedNextAction) {
+    insights.push(
+      makeInsight(
+        'next_move',
+        parsed.predictedNextAction,
+        parsed.predictedNextConfidence ?? 0.5
+      )
+    );
+  }
+
+  // Attention intent → objective
+  if (parsed.attention?.intent) {
+    insights.push(
+      makeInsight(
+        'objective',
+        parsed.attention.intent,
+        0.7,
+        { primaryFile: parsed.attention.primaryFile ?? null }
+      )
+    );
+  }
+
+  // Observations
+  for (const obs of parsed.observations ?? []) {
+    if (!obs) continue;
+    insights.push(makeInsight('summary', obs, 0.6));
+  }
+
+  logger.debug('inference', 'response_parser.parsed', { insightCount: insights.length });
+  return insights;
+}

--- a/shadow-agent/src/inference/shadow-inference-engine.ts
+++ b/shadow-agent/src/inference/shadow-inference-engine.ts
@@ -1,0 +1,111 @@
+/**
+ * Shadow inference engine — orchestrator.
+ *
+ * Wires: trigger → context packager → prompt builder → inference client → response parser → emit
+ *
+ * Only one inference call is in flight at a time. If a new trigger fires while
+ * an inference is running, it is queued (only one pending allowed; extras are dropped).
+ */
+import type { CanonicalEvent, DerivedState, ShadowInsight } from '../shared/schema';
+import { createLogger } from '../shared/logger';
+import { buildContextPacket } from './context-packager';
+import { buildInferenceRequest } from './prompt-builder';
+import { parseModelResponse } from './response-parser';
+import { createInferenceTrigger, type TriggerConfig } from './trigger';
+import { createDirectApiClient } from './direct-api';
+import { loadCredentials } from './auth';
+import type { InferenceClient } from './inference-client';
+import type { EventBufferLike } from './inference-client';
+
+const logger = createLogger({ minLevel: 'info' });
+
+export type InsightCallback = (insights: ShadowInsight[]) => void;
+
+export interface InferenceEngineOptions {
+  buffer: EventBufferLike;
+  getState: () => DerivedState;
+  onInsights: InsightCallback;
+  triggerConfig?: Partial<TriggerConfig>;
+}
+
+export interface InferenceEngine {
+  start(): Promise<void>;
+  stop(): void;
+}
+
+export function createInferenceEngine(opts: InferenceEngineOptions): InferenceEngine {
+  const { buffer, getState, onInsights } = opts;
+  let client: InferenceClient | null = null;
+  let inflight = false;
+  let pendingTrigger = false;
+  let unsubscribeBuffer: (() => void) | null = null;
+
+  const runInference = async () => {
+    if (!client) return;
+    if (inflight) {
+      pendingTrigger = true;
+      return;
+    }
+
+    inflight = true;
+    try {
+      const state = getState();
+      const events = buffer.getAll();
+      const packet = buildContextPacket(state, events);
+      const request = buildInferenceRequest(packet);
+
+      logger.info('inference', 'engine.run_start', { eventCount: events.length });
+      const result = await client.infer(request);
+      const insights = parseModelResponse(result.text);
+
+      logger.info('inference', 'engine.run_done', {
+        latencyMs: result.latencyMs,
+        insights: insights.length,
+      });
+
+      if (insights.length > 0) {
+        onInsights(insights);
+      }
+    } catch (err) {
+      logger.error('inference', 'engine.run_error', { error: err });
+    } finally {
+      inflight = false;
+      if (pendingTrigger) {
+        pendingTrigger = false;
+        void runInference();
+      }
+    }
+  };
+
+  const trigger = createInferenceTrigger(() => void runInference(), opts.triggerConfig);
+
+  return {
+    async start() {
+      await loadCredentials();
+      client = await createDirectApiClient();
+
+      if (!client) {
+        logger.warn('inference', 'engine.no_client', {
+          message: 'No inference client available. Shadow insights disabled.',
+        });
+        return;
+      }
+
+      logger.info('inference', 'engine.started', { provider: client.provider });
+
+      unsubscribeBuffer = buffer.subscribe((events) => {
+        trigger.onEvents(events);
+      });
+    },
+
+    stop() {
+      trigger.stop();
+      if (unsubscribeBuffer) {
+        unsubscribeBuffer();
+        unsubscribeBuffer = null;
+      }
+      client = null;
+      logger.info('inference', 'engine.stopped');
+    },
+  };
+}

--- a/shadow-agent/src/inference/trigger.ts
+++ b/shadow-agent/src/inference/trigger.ts
@@ -1,0 +1,111 @@
+/**
+ * Inference trigger: decides when to run the inference engine.
+ *
+ * Trigger conditions (any one fires):
+ *   - At least minEventsBetween (10) new events since last inference
+ *   - At least timeBetweenMs (30 s) since last inference
+ *   - maxEventsBetween (50) events forces a trigger regardless of timer
+ *   - Risk escalation: derived risk level rises to 'medium' or above
+ *   - Specific event kinds: tool_failed, agent_completed always trigger immediately
+ */
+import type { CanonicalEvent, EventKind } from '../shared/schema';
+import { createLogger } from '../shared/logger';
+
+const logger = createLogger({ minLevel: 'info' });
+
+const IMMEDIATE_KINDS = new Set<EventKind>(['tool_failed', 'agent_completed']);
+
+export interface TriggerConfig {
+  minEventsBetween: number;   // default 10
+  timeBetweenMs: number;       // default 30_000
+  maxEventsBetween: number;    // default 50
+}
+
+const DEFAULT_CONFIG: TriggerConfig = {
+  minEventsBetween: 10,
+  timeBetweenMs: 30_000,
+  maxEventsBetween: 50,
+};
+
+export type TriggerCallback = () => void;
+
+export interface InferenceTrigger {
+  onEvents(events: CanonicalEvent[]): void;
+  reset(): void;
+  stop(): void;
+}
+
+export function createInferenceTrigger(
+  onTrigger: TriggerCallback,
+  config: Partial<TriggerConfig> = {}
+): InferenceTrigger {
+  const cfg = { ...DEFAULT_CONFIG, ...config };
+  let eventsSinceLastInference = 0;
+  let lastInferenceAt = 0;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const fire = () => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = null;
+    eventsSinceLastInference = 0;
+    lastInferenceAt = Date.now();
+    logger.info('inference', 'trigger.fired');
+    onTrigger();
+  };
+
+  const scheduleDebounced = () => {
+    if (debounceTimer) return; // already pending
+    debounceTimer = setTimeout(() => {
+      fire();
+    }, 200); // small debounce to batch rapid events
+  };
+
+  return {
+    onEvents(events: CanonicalEvent[]) {
+      eventsSinceLastInference += events.length;
+      const now = Date.now();
+      const elapsed = now - lastInferenceAt;
+
+      // Immediate conditions
+      const hasImmediateKind = events.some((e) => IMMEDIATE_KINDS.has(e.kind));
+      if (hasImmediateKind) {
+        logger.debug('inference', 'trigger.immediate_kind', {
+          kinds: events.filter((e) => IMMEDIATE_KINDS.has(e.kind)).map((e) => e.kind),
+        });
+        fire();
+        return;
+      }
+
+      // Force condition
+      if (eventsSinceLastInference >= cfg.maxEventsBetween) {
+        logger.debug('inference', 'trigger.max_events', { count: eventsSinceLastInference });
+        fire();
+        return;
+      }
+
+      // Normal: min events + time elapsed
+      if (
+        eventsSinceLastInference >= cfg.minEventsBetween &&
+        elapsed >= cfg.timeBetweenMs
+      ) {
+        logger.debug('inference', 'trigger.normal', {
+          events: eventsSinceLastInference,
+          elapsedMs: elapsed,
+        });
+        scheduleDebounced();
+      }
+    },
+
+    reset() {
+      eventsSinceLastInference = 0;
+      lastInferenceAt = 0;
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = null;
+    },
+
+    stop() {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = null;
+    },
+  };
+}

--- a/shadow-agent/src/mcp/shadow-mcp-server.ts
+++ b/shadow-agent/src/mcp/shadow-mcp-server.ts
@@ -1,0 +1,177 @@
+/**
+ * Shadow MCP server — exposes shadow-agent state as MCP tools.
+ *
+ * Tools:
+ *   shadow_status  — current DerivedState summary
+ *   shadow_events  — last N CanonicalEvents from the buffer
+ *   shadow_ask     — run a one-shot inference call with a custom question
+ *
+ * Uses @modelcontextprotocol/sdk. If the SDK is not installed, the function
+ * returns null gracefully.
+ */
+import type { DerivedState, ShadowInsight } from '../shared/schema';
+import { createLogger } from '../shared/logger';
+import type { EventBufferLike } from '../inference/inference-client';
+import type { InferenceClient, InferenceRequest } from '../inference/inference-client';
+import { SHADOW_SYSTEM_PROMPT } from '../inference/prompts';
+
+const logger = createLogger({ minLevel: 'info' });
+
+export interface McpServerOptions {
+  buffer: EventBufferLike;
+  getState: () => DerivedState;
+  inferenceClient: InferenceClient | null;
+  port?: number;
+}
+
+export interface McpServer {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+}
+
+export async function createShadowMcpServer(
+  opts: McpServerOptions
+): Promise<McpServer | null> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let McpServerClass: new (info: { name: string; version: string }, caps: { capabilities: { tools: object } }) => any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let StdioServerTransport: new () => any;
+
+  try {
+    // @ts-expect-error — @modelcontextprotocol/sdk is an optional runtime dependency
+    const serverMod = await import('@modelcontextprotocol/sdk/server/mcp.js') as { McpServer: typeof McpServerClass };
+    // @ts-expect-error — @modelcontextprotocol/sdk is an optional runtime dependency
+    const stdioMod = await import('@modelcontextprotocol/sdk/server/stdio.js') as { StdioServerTransport: typeof StdioServerTransport };
+    McpServerClass = serverMod.McpServer;
+    StdioServerTransport = stdioMod.StdioServerTransport;
+  } catch {
+    logger.warn('mcp', 'server.sdk_not_installed');
+    return null;
+  }
+
+  const server = new McpServerClass(
+    { name: 'shadow-agent', version: '0.1.0' },
+    { capabilities: { tools: {} } }
+  );
+
+  // shadow_status — returns current state summary
+  server.tool(
+    'shadow_status',
+    'Get the current state of the observed agent session',
+    {},
+    async () => {
+      const state = opts.getState();
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(
+              {
+                sessionId: state.sessionId,
+                phase: state.activePhase,
+                objective: state.currentObjective,
+                riskSignals: state.riskSignals,
+                nextMoves: state.nextMoves,
+                eventCount: opts.buffer.size,
+                agentNodes: state.agentNodes.map((n) => ({
+                  id: n.id,
+                  label: n.label,
+                  state: n.state,
+                })),
+              },
+              null,
+              2
+            ),
+          },
+        ],
+      };
+    }
+  );
+
+  // shadow_events — returns last N events
+  server.tool(
+    'shadow_events',
+    'Get the last N canonical events from the session buffer',
+    {
+      count: {
+        type: 'number' as const,
+        description: 'Number of events to return (default 20)',
+        default: 20,
+      },
+    },
+    async (args: { count?: number }) => {
+      const n = Math.min(Math.max(1, args.count ?? 20), 200);
+      const events = opts.buffer.getRecent(n);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(events, null, 2),
+          },
+        ],
+      };
+    }
+  );
+
+  // shadow_ask — one-shot inference with a custom question
+  server.tool(
+    'shadow_ask',
+    'Ask Shadow a specific question about the observed session',
+    {
+      question: {
+        type: 'string' as const,
+        description: 'The question to ask about the session',
+      },
+    },
+    async (args: { question: string }) => {
+      if (!opts.inferenceClient) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'Inference client not available. Set ANTHROPIC_API_KEY to enable.',
+            },
+          ],
+        };
+      }
+
+      const state = opts.getState();
+      const userMessage = `${args.question}\n\nCurrent session state:\n${JSON.stringify(
+        { phase: state.activePhase, objective: state.currentObjective, riskSignals: state.riskSignals },
+        null,
+        2
+      )}`;
+
+      const request: InferenceRequest = {
+        systemPrompt: SHADOW_SYSTEM_PROMPT,
+        userMessage,
+      };
+
+      try {
+        const result = await opts.inferenceClient.infer(request);
+        return {
+          content: [{ type: 'text' as const, text: result.text }],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: 'text' as const, text: `Inference error: ${message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  const transport = new StdioServerTransport();
+
+  return {
+    async start() {
+      await server.connect(transport);
+      logger.info('mcp', 'server.started');
+    },
+    async stop() {
+      await server.close();
+      logger.info('mcp', 'server.stopped');
+    },
+  };
+}

--- a/shadow-agent/tests/inference.test.ts
+++ b/shadow-agent/tests/inference.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Tests for the inference engine components.
+ * Covers: auth credential loading, context packager, prompt builder,
+ * response parser, and inference trigger.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { parseModelResponse } from '../src/inference/response-parser';
+import { buildContextPacket } from '../src/inference/context-packager';
+import { buildInferenceRequest } from '../src/inference/prompt-builder';
+import { createInferenceTrigger } from '../src/inference/trigger';
+import { SHADOW_SYSTEM_PROMPT } from '../src/inference/prompts';
+import type { CanonicalEvent, DerivedState } from '../src/shared/schema';
+
+// ── response parser ────────────────────────────────────────────────────────
+
+describe('parseModelResponse', () => {
+  it('parses a well-formed JSON response', () => {
+    const response = JSON.stringify({
+      phase: 'implementation',
+      phaseConfidence: 0.85,
+      phaseReason: 'Agent is editing TypeScript files.',
+      riskLevel: 'low',
+      riskSignals: [],
+      predictedNextAction: 'Run tests',
+      predictedNextConfidence: 0.7,
+      observations: ['Agent created 3 files in the last 5 minutes.'],
+      attention: { primaryFile: 'src/index.ts', intent: 'Add feature X' },
+    });
+
+    const insights = parseModelResponse(response);
+    expect(insights.length).toBeGreaterThan(0);
+
+    const phaseInsight = insights.find((i) => i.kind === 'phase');
+    expect(phaseInsight).toBeDefined();
+    expect(phaseInsight?.confidence).toBeCloseTo(0.85);
+
+    const nextMoveInsight = insights.find((i) => i.kind === 'next_move');
+    expect(nextMoveInsight?.summary).toBe('Run tests');
+
+    const objectiveInsight = insights.find((i) => i.kind === 'objective');
+    expect(objectiveInsight?.summary).toBe('Add feature X');
+
+    const summaryInsight = insights.find((i) => i.kind === 'summary');
+    expect(summaryInsight).toBeDefined();
+  });
+
+  it('handles markdown-fenced JSON', () => {
+    const response = '```json\n{"phase":"exploration","phaseConfidence":0.6,"riskLevel":"low","riskSignals":[],"predictedNextAction":"","predictedNextConfidence":0.5,"observations":[],"attention":{"primaryFile":null,"intent":""}}\n```';
+    const insights = parseModelResponse(response);
+    expect(insights.some((i) => i.kind === 'phase')).toBe(true);
+  });
+
+  it('returns empty array for malformed JSON', () => {
+    const insights = parseModelResponse('not valid json at all');
+    expect(insights).toHaveLength(0);
+  });
+
+  it('handles missing optional fields gracefully', () => {
+    const response = JSON.stringify({ phase: 'idle' });
+    // Should not throw, may return partial insights
+    expect(() => parseModelResponse(response)).not.toThrow();
+  });
+
+  it('clamps confidence to [0, 1]', () => {
+    const response = JSON.stringify({
+      phase: 'testing',
+      phaseConfidence: 1.5, // out of range
+      riskLevel: 'low',
+      riskSignals: [],
+      predictedNextAction: '',
+      predictedNextConfidence: -0.3, // negative
+      observations: [],
+      attention: { primaryFile: null, intent: 'x' },
+    });
+    const insights = parseModelResponse(response);
+    for (const insight of insights) {
+      expect(insight.confidence).toBeGreaterThanOrEqual(0);
+      expect(insight.confidence).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('maps each riskSignal to a risk insight', () => {
+    const response = JSON.stringify({
+      phase: 'debugging',
+      phaseConfidence: 0.6,
+      riskLevel: 'medium',
+      riskSignals: [
+        { signal: 'Repeated tool failures', severity: 'high', confidence: 0.8 },
+        { signal: 'Long idle period', severity: 'low', confidence: 0.4 },
+      ],
+      predictedNextAction: '',
+      predictedNextConfidence: 0.5,
+      observations: [],
+      attention: { primaryFile: null, intent: '' },
+    });
+    const riskInsights = parseModelResponse(response).filter((i) => i.kind === 'risk');
+    expect(riskInsights).toHaveLength(2);
+  });
+});
+
+// ── context packager ───────────────────────────────────────────────────────
+
+describe('buildContextPacket', () => {
+  const makeState = (): DerivedState => ({
+    sessionId: 'sess-1',
+    title: 'Test session',
+    currentObjective: 'Fix bug',
+    activePhase: 'debugging',
+    agentNodes: [],
+    timeline: [],
+    transcript: [
+      { id: 't1', actor: 'user', text: 'Do the thing', timestamp: '2024-01-01T00:00:00Z' },
+    ],
+    fileAttention: [{ filePath: 'src/foo.ts', touches: 3 }],
+    riskSignals: ['Tool failed twice'],
+    nextMoves: ['Run tests'],
+    shadowInsights: [],
+  });
+
+  const makeEvent = (kind: CanonicalEvent['kind'], ts: string): CanonicalEvent => ({
+    id: `e-${ts}`,
+    kind,
+    timestamp: ts,
+    source: 'claude-transcript',
+    sessionId: 'sess-1',
+    actor: 'assistant',
+    payload: {},
+  });
+
+  it('builds a packet with correct session metadata', () => {
+    const state = makeState();
+    const events: CanonicalEvent[] = [
+      makeEvent('message', '2024-01-01T00:00:00Z'),
+      makeEvent('tool_started', '2024-01-01T00:00:10Z'),
+    ];
+
+    const packet = buildContextPacket(state, events);
+    expect(packet.sessionId).toBe('sess-1');
+    expect(packet.currentPhase).toBe('debugging');
+    expect(packet.observedAgent).toBe('claude-code');
+    expect(packet.sessionDuration).toBeGreaterThanOrEqual(0);
+  });
+
+  it('limits recentEvents to last 30', () => {
+    const state = makeState();
+    const events = Array.from({ length: 50 }, (_, i) =>
+      makeEvent('message', `2024-01-01T00:00:${String(i).padStart(2, '0')}Z`)
+    );
+    const packet = buildContextPacket(state, events);
+    expect(packet.recentEvents.length).toBeLessThanOrEqual(30);
+  });
+
+  it('converts riskSignals strings to {signal, severity} objects', () => {
+    const state = makeState();
+    const packet = buildContextPacket(state, []);
+    expect(packet.riskSignals).toHaveLength(1);
+    expect(packet.riskSignals[0]).toMatchObject({ signal: 'Tool failed twice', severity: 'medium' });
+  });
+});
+
+// ── prompt builder ─────────────────────────────────────────────────────────
+
+describe('buildInferenceRequest', () => {
+  it('returns systemPrompt matching SHADOW_SYSTEM_PROMPT', () => {
+    const state: DerivedState = {
+      sessionId: 'x',
+      title: 'T',
+      currentObjective: '',
+      activePhase: 'idle',
+      agentNodes: [],
+      timeline: [],
+      transcript: [],
+      fileAttention: [],
+      riskSignals: [],
+      nextMoves: [],
+      shadowInsights: [],
+    };
+    const packet = buildContextPacket(state, []);
+    const request = buildInferenceRequest(packet);
+    expect(request.systemPrompt).toBe(SHADOW_SYSTEM_PROMPT);
+    expect(typeof request.userMessage).toBe('string');
+    expect(request.userMessage.length).toBeGreaterThan(0);
+  });
+
+  it('is deterministic — same packet produces same output', () => {
+    const state: DerivedState = {
+      sessionId: 'y',
+      title: 'T',
+      currentObjective: 'Build widget',
+      activePhase: 'implementation',
+      agentNodes: [],
+      timeline: [],
+      transcript: [],
+      fileAttention: [{ filePath: 'src/widget.ts', touches: 2 }],
+      riskSignals: [],
+      nextMoves: ['Add tests'],
+      shadowInsights: [],
+    };
+    const packet = buildContextPacket(state, []);
+    expect(buildInferenceRequest(packet)).toEqual(buildInferenceRequest(packet));
+  });
+});
+
+// ── inference trigger ──────────────────────────────────────────────────────
+
+describe('createInferenceTrigger', () => {
+  const makeEvent = (kind: CanonicalEvent['kind'] = 'message'): CanonicalEvent => ({
+    id: Math.random().toString(),
+    kind,
+    timestamp: new Date().toISOString(),
+    source: 'claude-transcript',
+    sessionId: 'sess',
+    actor: 'assistant',
+    payload: {},
+  });
+
+  it('fires immediately on tool_failed', () => {
+    const cb = vi.fn();
+    const trigger = createInferenceTrigger(cb);
+    trigger.onEvents([makeEvent('tool_failed')]);
+    expect(cb).toHaveBeenCalledTimes(1);
+    trigger.stop();
+  });
+
+  it('fires immediately on agent_completed', () => {
+    const cb = vi.fn();
+    const trigger = createInferenceTrigger(cb);
+    trigger.onEvents([makeEvent('agent_completed')]);
+    expect(cb).toHaveBeenCalledTimes(1);
+    trigger.stop();
+  });
+
+  it('fires when maxEventsBetween is exceeded', () => {
+    const cb = vi.fn();
+    const trigger = createInferenceTrigger(cb, { maxEventsBetween: 5, minEventsBetween: 100, timeBetweenMs: 9999999 });
+    trigger.onEvents(Array.from({ length: 5 }, () => makeEvent()));
+    expect(cb).toHaveBeenCalledTimes(1);
+    trigger.stop();
+  });
+
+  it('does NOT fire when only minEvents met but time not elapsed', () => {
+    const cb = vi.fn();
+    const trigger = createInferenceTrigger(cb, {
+      minEventsBetween: 2,
+      timeBetweenMs: 999999,
+      maxEventsBetween: 999,
+    });
+    trigger.onEvents([makeEvent(), makeEvent()]);
+    expect(cb).not.toHaveBeenCalled();
+    trigger.stop();
+  });
+
+  it('reset clears event count', () => {
+    const cb = vi.fn();
+    const trigger = createInferenceTrigger(cb, { maxEventsBetween: 3, minEventsBetween: 100, timeBetweenMs: 9999999 });
+    trigger.onEvents([makeEvent(), makeEvent()]);
+    trigger.reset();
+    trigger.onEvents([makeEvent(), makeEvent()]);
+    expect(cb).not.toHaveBeenCalled();
+    trigger.stop();
+  });
+});

--- a/shadow-agent/tests/renderer/bridge.test.ts
+++ b/shadow-agent/tests/renderer/bridge.test.ts
@@ -22,7 +22,7 @@ describe('renderer bridge', () => {
   });
 
   it('throws a descriptive error when preload bridge is missing', () => {
-    (globalThis as { window: Record<string, unknown> }).window = {};
+    (globalThis as unknown as { window: Record<string, unknown> }).window = {};
 
     expect(() => getShadowAgentBridge()).toThrow(
       'Shadow Agent preload bridge is unavailable. Start the app via Electron main process.'


### PR DESCRIPTION
## Summary

Implements the full inference engine pipeline (issues #10–#17).

### New Files
- \src/inference/auth.ts\ — credential loader: env → \~/.shadow-agent/.env\ → opencode \uth.json\
- \src/inference/context-packager.ts\ — builds \ShadowContextPacket\ from \DerivedState\ + events (capped at 30 events, 20 tool history, 10 transcript turns, 15 files)
- \src/inference/prompt-builder.ts\ — wraps system prompt + context into \InferenceRequest\
- \src/inference/response-parser.ts\ — parses model JSON → \ShadowInsight[]\ with markdown-fence and error handling
- \src/inference/trigger.ts\ — fires inference on: minEvents + time elapsed, maxEvents, or immediate kinds (\	ool_failed\, \gent_completed\)
- \src/inference/direct-api.ts\ — optional Anthropic SDK fallback (lazy import, graceful when not installed)
- \src/inference/shadow-inference-engine.ts\ — orchestrator: trigger → context → prompt → infer → parse → emit
- \src/mcp/shadow-mcp-server.ts\ — MCP server with \shadow_status\, \shadow_events\, \shadow_ask\ tools

### Modified
- \src/inference/inference-client.ts\ — added \EventBufferLike\ structural interface (decouples inference from capture branch)

### Tests
- 16 new tests in \	ests/inference.test.ts\ covering all core components
- All 40 tests pass

### Design Notes
- Optional SDKs (\@anthropic-ai/sdk\, \@modelcontextprotocol/sdk\) use dynamic \import()\ inside try/catch — graceful no-op when absent
- \EventBufferLike\ interface lets the engine accept \EventBuffer\ from the capture pipeline when branches merge

Closes #10, #11, #12, #13, #14, #15, #16, #17