### PR TITLE
test: fixture corpus + Phase 1 edge coverage

### DIFF
--- a/shadow-agent/tests/derive.test.ts
+++ b/shadow-agent/tests/derive.test.ts
@@ -1,6 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { deriveState } from '../src/shared/derive';
 import { paymentRefactorSession } from '../src/shared/fixtures/payment-refactor-session';
+import { parseReplay } from '../src/shared/replay-store';
+import type { CanonicalEvent } from '../src/shared/schema';
+
+const REPLAY_FIXTURES = join(import.meta.dirname, 'fixtures/replays');
+
+function makeEvent(
+  kind: CanonicalEvent['kind'],
+  overrides: Partial<CanonicalEvent> = {}
+): CanonicalEvent {
+  return {
+    id: Math.random().toString(36).slice(2),
+    sessionId: 'test-session',
+    source: 'replay',
+    timestamp: new Date().toISOString(),
+    actor: 'assistant',
+    kind,
+    payload: {},
+    ...overrides,
+  };
+}
 
 describe('deriveState', () => {
   it('extracts phase, file attention, and next moves from replay events', () => {
@@ -15,5 +37,188 @@ describe('deriveState', () => {
   it('surfaces risk signals when tool failures occur', () => {
     const state = deriveState(paymentRefactorSession, 'payment-refactor-session');
     expect(state.riskSignals.some((risk) => risk.includes('failed tool call'))).toBe(true);
+  });
+
+  // ── empty / minimal state ─────────────────────────────────────────────────
+
+  it('handles empty event array gracefully', () => {
+    const state = deriveState([]);
+    expect(state.sessionId).toBe('unknown');
+    expect(state.activePhase).toBe('observation');
+    expect(state.agentNodes).toHaveLength(0);
+    expect(state.fileAttention).toHaveLength(0);
+    expect(state.riskSignals).toHaveLength(0);
+    expect(state.nextMoves.length).toBeGreaterThan(0);
+  });
+
+  it('uses custom title as initial objective', () => {
+    const state = deriveState([], 'My Session Title');
+    expect(state.title).toBe('My Session Title');
+    expect(state.currentObjective).toBe('My Session Title');
+  });
+
+  it('captures first user message as currentObjective', () => {
+    const events: CanonicalEvent[] = [
+      makeEvent('session_started', { actor: 'system' }),
+      makeEvent('message', { actor: 'user', payload: { text: 'Build the feature.' } }),
+      makeEvent('message', { actor: 'assistant', payload: { text: 'OK.' } }),
+    ];
+    const state = deriveState(events, 'default title');
+    expect(state.currentObjective).toBe('Build the feature.');
+  });
+
+  // ── phase detection priority ──────────────────────────────────────────────
+
+  it('detects implementation phase when Write/Edit tools are used', () => {
+    const events = [
+      makeEvent('tool_started', { payload: { toolName: 'Write' } }),
+      makeEvent('tool_started', { payload: { toolName: 'Read' } }),
+    ];
+    expect(deriveState(events).activePhase).toBe('implementation');
+  });
+
+  it('detects planning phase from TodoRead or Plan tools (not TodoWrite which contains "write")', () => {
+    // 'TodoWrite' lowercased contains 'write' → implementation wins over planning
+    // Use a pure plan-style name that doesn't trigger the write/edit check
+    const events = [makeEvent('tool_started', { payload: { toolName: 'PlanCreate' } })];
+    expect(deriveState(events).activePhase).toBe('planning');
+  });
+
+  it('detects validation phase from Bash tools (no write/plan tools)', () => {
+    const events = [makeEvent('tool_started', { payload: { toolName: 'Bash' } })];
+    expect(deriveState(events).activePhase).toBe('validation');
+  });
+
+  it('detects exploration phase from Read/Grep/Glob (no higher-priority tools)', () => {
+    const events = [
+      makeEvent('tool_started', { payload: { toolName: 'Grep' } }),
+      makeEvent('tool_started', { payload: { toolName: 'Glob' } }),
+    ];
+    expect(deriveState(events).activePhase).toBe('exploration');
+  });
+
+  it('implementation > planning > validation > exploration precedence', () => {
+    // All tool types present — Write should win
+    const events = [
+      makeEvent('tool_started', { payload: { toolName: 'Edit' } }),
+      makeEvent('tool_started', { payload: { toolName: 'TodoWrite' } }),
+      makeEvent('tool_started', { payload: { toolName: 'Bash' } }),
+      makeEvent('tool_started', { payload: { toolName: 'Read' } }),
+    ];
+    expect(deriveState(events).activePhase).toBe('implementation');
+  });
+
+  // ── risk signals ──────────────────────────────────────────────────────────
+
+  it('surfaces bash-churn risk when ≥4 bash calls', () => {
+    const events = Array.from({ length: 4 }, () =>
+      makeEvent('tool_started', { payload: { toolName: 'Bash' } })
+    );
+    const state = deriveState(events);
+    expect(state.riskSignals.some((r) => r.toLowerCase().includes('churn'))).toBe(true);
+  });
+
+  it('does not flag bash churn for 3 bash calls', () => {
+    const events = Array.from({ length: 3 }, () =>
+      makeEvent('tool_started', { payload: { toolName: 'Bash' } })
+    );
+    const state = deriveState(events);
+    expect(state.riskSignals.some((r) => r.toLowerCase().includes('churn'))).toBe(false);
+  });
+
+  it('surfaces exploration-volume risk when ≥6 read/grep/glob calls', () => {
+    const tools = ['Read', 'Grep', 'Glob', 'Read', 'Grep', 'Glob'];
+    const events = tools.map((t) => makeEvent('tool_started', { payload: { toolName: t } }));
+    const state = deriveState(events);
+    expect(state.riskSignals.some((r) => r.toLowerCase().includes('exploration'))).toBe(true);
+  });
+
+  // ── file attention ────────────────────────────────────────────────────────
+
+  it('counts file attention using filePath payload key', () => {
+    const events = [
+      makeEvent('tool_started', { payload: { toolName: 'Read', filePath: 'src/foo.ts' } }),
+      makeEvent('tool_completed', { payload: { toolName: 'Read', filePath: 'src/foo.ts' } }),
+    ];
+    const state = deriveState(events);
+    const foo = state.fileAttention.find((f) => f.filePath === 'src/foo.ts');
+    expect(foo?.touches).toBe(2);
+  });
+
+  it('counts file attention using file_path payload key', () => {
+    const events = [
+      makeEvent('tool_started', { payload: { toolName: 'Read', file_path: 'src/bar.ts' } }),
+    ];
+    const foo = deriveState(events).fileAttention.find((f) => f.filePath === 'src/bar.ts');
+    expect(foo?.touches).toBe(1);
+  });
+
+  it('counts file attention using path payload key', () => {
+    const events = [
+      makeEvent('tool_started', { payload: { toolName: 'Read', path: 'src/baz.ts' } }),
+    ];
+    const foo = deriveState(events).fileAttention.find((f) => f.filePath === 'src/baz.ts');
+    expect(foo?.touches).toBe(1);
+  });
+
+  it('sorts file attention descending by touch count', () => {
+    const events = [
+      makeEvent('tool_started', { payload: { toolName: 'Read', filePath: 'once.ts' } }),
+      makeEvent('tool_started', { payload: { toolName: 'Read', filePath: 'thrice.ts' } }),
+      makeEvent('tool_started', { payload: { toolName: 'Read', filePath: 'thrice.ts' } }),
+      makeEvent('tool_started', { payload: { toolName: 'Read', filePath: 'thrice.ts' } }),
+    ];
+    const fa = deriveState(events).fileAttention;
+    expect(fa[0]?.filePath).toBe('thrice.ts');
+    expect(fa[1]?.filePath).toBe('once.ts');
+  });
+
+  // ── agent nodes ───────────────────────────────────────────────────────────
+
+  it('tracks agent state transitions spawned→idle→completed', () => {
+    const events = [
+      makeEvent('agent_spawned', { actor: 'orchestrator', payload: { label: 'orchestrator' } }),
+      makeEvent('agent_idle', { actor: 'orchestrator', payload: { label: 'orchestrator' } }),
+      makeEvent('agent_completed', { actor: 'orchestrator', payload: { label: 'orchestrator' } }),
+    ];
+    const state = deriveState(events);
+    const node = state.agentNodes.find((n) => n.id === 'orchestrator');
+    expect(node?.state).toBe('completed');
+  });
+
+  it('increments toolCount when an agent uses tools', () => {
+    const events = [
+      makeEvent('agent_spawned', { actor: 'agent-1', payload: { label: 'agent-1' } }),
+      makeEvent('tool_started', { actor: 'agent-1', payload: { toolName: 'Read' } }),
+      makeEvent('tool_completed', { actor: 'agent-1', payload: { toolName: 'Read' } }),
+    ];
+    const node = deriveState(events).agentNodes.find((n) => n.id === 'agent-1');
+    expect(node?.toolCount).toBe(2);
+  });
+
+  // ── fixture-based ─────────────────────────────────────────────────────────
+
+  it('derives implementation phase from happy-path replay fixture', () => {
+    const raw = readFileSync(join(REPLAY_FIXTURES, 'happy-path.replay.jsonl'), 'utf8');
+    const events = parseReplay(raw);
+    const state = deriveState(events);
+    expect(state.activePhase).toBe('implementation');
+    expect(state.fileAttention.some((f) => f.filePath === 'src/logger.ts')).toBe(true);
+  });
+
+  it('derives risk signals from risk-escalation replay fixture', () => {
+    const raw = readFileSync(join(REPLAY_FIXTURES, 'risk-escalation.replay.jsonl'), 'utf8');
+    const events = parseReplay(raw);
+    const state = deriveState(events);
+    expect(state.riskSignals.some((r) => r.includes('failed tool call'))).toBe(true);
+    expect(state.riskSignals.some((r) => r.toLowerCase().includes('churn'))).toBe(true);
+  });
+
+  it('tracks parent/subagent nodes from subagent-flow replay fixture', () => {
+    const raw = readFileSync(join(REPLAY_FIXTURES, 'subagent-flow.replay.jsonl'), 'utf8');
+    const events = parseReplay(raw);
+    const state = deriveState(events);
+    expect(state.agentNodes.some((n) => n.id === 'orchestrator')).toBe(true);
+    expect(state.agentNodes.some((n) => n.id === 'playwright-setup')).toBe(true);
   });
 });

--- a/shadow-agent/tests/derive.test.ts
+++ b/shadow-agent/tests/derive.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { deriveState } from '../src/shared/derive';
 import { paymentRefactorSession } from '../src/shared/fixtures/payment-refactor-session';
 import { parseReplay } from '../src/shared/replay-store';
@@ -12,16 +12,21 @@ const REPLAY_FIXTURES = join(TEST_DIR, 'fixtures/replays');
 
 let eventCounter = 0;
 
+beforeEach(() => {
+  eventCounter = 0;
+});
+
 function makeEvent(
   kind: CanonicalEvent['kind'],
   overrides: Partial<CanonicalEvent> = {}
 ): CanonicalEvent {
+  const timestamp = new Date(Date.UTC(2026, 3, 18, 10, 0, eventCounter)).toISOString();
   eventCounter += 1;
   return {
     id: overrides.id ?? `evt-${eventCounter}`,
     sessionId: 'test-session',
     source: 'replay',
-    timestamp: overrides.timestamp ?? `2026-04-18T10:00:${String(eventCounter).padStart(2, '0')}.000Z`,
+    timestamp: overrides.timestamp ?? timestamp,
     actor: 'assistant',
     kind,
     payload: {},

--- a/shadow-agent/tests/derive.test.ts
+++ b/shadow-agent/tests/derive.test.ts
@@ -1,22 +1,27 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { deriveState } from '../src/shared/derive';
 import { paymentRefactorSession } from '../src/shared/fixtures/payment-refactor-session';
 import { parseReplay } from '../src/shared/replay-store';
 import type { CanonicalEvent } from '../src/shared/schema';
 
-const REPLAY_FIXTURES = join(import.meta.dirname, 'fixtures/replays');
+const TEST_DIR = fileURLToPath(new URL('.', import.meta.url));
+const REPLAY_FIXTURES = join(TEST_DIR, 'fixtures/replays');
+
+let eventCounter = 0;
 
 function makeEvent(
   kind: CanonicalEvent['kind'],
   overrides: Partial<CanonicalEvent> = {}
 ): CanonicalEvent {
+  eventCounter += 1;
   return {
-    id: Math.random().toString(36).slice(2),
+    id: overrides.id ?? `evt-${eventCounter}`,
     sessionId: 'test-session',
     source: 'replay',
-    timestamp: new Date().toISOString(),
+    timestamp: overrides.timestamp ?? `2026-04-18T10:00:${String(eventCounter).padStart(2, '0')}.000Z`,
     actor: 'assistant',
     kind,
     payload: {},
@@ -220,5 +225,27 @@ describe('deriveState', () => {
     const state = deriveState(events);
     expect(state.agentNodes.some((n) => n.id === 'orchestrator')).toBe(true);
     expect(state.agentNodes.some((n) => n.id === 'playwright-setup')).toBe(true);
+  });
+
+  it('handles out-of-order timestamps without crashing', () => {
+    const events = [
+      makeEvent('tool_started', { sessionId: 'oos-session', id: 'evt-late', timestamp: '2026-04-18T10:00:05.000Z', payload: { toolName: 'Write' } }),
+      makeEvent('tool_started', { sessionId: 'oos-session', id: 'evt-early', timestamp: '2026-04-18T10:00:01.000Z', payload: { toolName: 'Read' } }),
+    ];
+
+    const state = deriveState(events);
+    expect(state.sessionId).toBe('oos-session');
+    expect(state.activePhase).toBe('implementation');
+  });
+
+  it('handles duplicate IDs without crashing', () => {
+    const events = [
+      makeEvent('message', { sessionId: 'dup-session', id: 'dup-1', payload: { text: 'first' } }),
+      makeEvent('message', { sessionId: 'dup-session', id: 'dup-1', payload: { text: 'second' } }),
+    ];
+
+    const state = deriveState(events);
+    expect(state.sessionId).toBe('dup-session');
+    expect(state.transcript.length).toBe(2);
   });
 });

--- a/shadow-agent/tests/derive.test.ts
+++ b/shadow-agent/tests/derive.test.ts
@@ -20,13 +20,13 @@ function makeEvent(
   kind: CanonicalEvent['kind'],
   overrides: Partial<CanonicalEvent> = {}
 ): CanonicalEvent {
-  const timestamp = new Date(Date.UTC(2026, 3, 18, 10, 0, eventCounter)).toISOString();
-  eventCounter += 1;
+  const sequence = eventCounter + 1;
+  eventCounter = sequence;
   return {
-    id: overrides.id ?? `evt-${eventCounter}`,
+    id: overrides.id ?? `evt-${sequence}`,
     sessionId: 'test-session',
     source: 'replay',
-    timestamp: overrides.timestamp ?? timestamp,
+    timestamp: overrides.timestamp ?? new Date(Date.UTC(2026, 3, 18, 10, 0, sequence)).toISOString(),
     actor: 'assistant',
     kind,
     payload: {},

--- a/shadow-agent/tests/fixtures/README.md
+++ b/shadow-agent/tests/fixtures/README.md
@@ -36,7 +36,7 @@ These are already-normalized `CanonicalEvent` objects in JSONL format, usable di
 
 | File | Description |
 |------|-------------|
-| `happy-path.replay.jsonl` | ~12 clean canonical events; implementation phase |
+| `happy-path.replay.jsonl` | 9 clean canonical events; implementation phase |
 | `subagent-flow.replay.jsonl` | Parent + subagent nodes with tool events |
 | `risk-escalation.replay.jsonl` | Multiple tool failures + bash churn |
 | `corrupt-partial.replay.jsonl` | Valid events followed by a truncated/corrupt line |

--- a/shadow-agent/tests/fixtures/README.md
+++ b/shadow-agent/tests/fixtures/README.md
@@ -1,0 +1,42 @@
+# Test Fixture Corpus
+
+This directory holds representative session fixtures used across parsing, derive, renderer,
+and inference tests. All tests that need representative data should import from here rather
+than defining ad-hoc inline data.
+
+## Regenerating Fixtures
+
+Transcript JSONL files are hand-crafted to match Claude Code transcript format. Replay JSONL
+files are canonical `CanonicalEvent` objects serialized one-per-line. To update a fixture:
+1. Edit the JSONL file directly.
+2. Re-run `npm test` and confirm tests still pass.
+3. If the schema changes (`CanonicalEvent`, `DerivedState`), update the fixtures accordingly
+   and add a comment in this file noting the schema version the fixtures target.
+
+---
+
+## Transcript Fixtures (`transcripts/`)
+
+These use the raw Claude Code transcript format as produced by `~/.claude/projects/.../*.jsonl`.
+Each line is a JSON object with `sessionId`, optional `cwd`, and `message.{role, content}`.
+
+| File | Description | Key events |
+|------|-------------|------------|
+| `happy-path.jsonl` | Small clean session (~6 transcript lines) | Read + Write + success; phase = implementation |
+| `tool-heavy.jsonl` | Dense tool session | Many Bash + Read calls; triggers bash-churn risk |
+| `risk-escalation.jsonl` | Session with failures | Multiple `tool_result` errors; triggers failed-tool risk |
+| `subagent-flow.jsonl` | Sub-agent delegation pattern | user→assistant→tool delegation messages |
+
+---
+
+## Replay Fixtures (`replays/`)
+
+These are already-normalized `CanonicalEvent` objects in JSONL format, usable directly with
+`parseReplay()` and `deriveState()`.
+
+| File | Description |
+|------|-------------|
+| `happy-path.replay.jsonl` | ~12 clean canonical events; implementation phase |
+| `subagent-flow.replay.jsonl` | Parent + subagent nodes with tool events |
+| `risk-escalation.replay.jsonl` | Multiple tool failures + bash churn |
+| `corrupt-partial.replay.jsonl` | Valid events followed by a truncated/corrupt line |

--- a/shadow-agent/tests/fixtures/replays/corrupt-partial.replay.jsonl
+++ b/shadow-agent/tests/fixtures/replays/corrupt-partial.replay.jsonl
@@ -1,0 +1,3 @@
+{"id":"ok-1","sessionId":"corrupt-test","source":"replay","timestamp":"2026-04-01T09:00:00.000Z","actor":"system","kind":"session_started","payload":{}}
+{"id":"ok-2","sessionId":"corrupt-test","source":"replay","timestamp":"2026-04-01T09:00:05.000Z","actor":"user","kind":"message","payload":{"text":"Start"}}
+{ THIS LINE IS INTENTIONALLY CORRUPT — missing closing brace and quotes

--- a/shadow-agent/tests/fixtures/replays/happy-path.replay.jsonl
+++ b/shadow-agent/tests/fixtures/replays/happy-path.replay.jsonl
@@ -1,0 +1,9 @@
+{"id":"hp-1","sessionId":"happy-path","source":"replay","timestamp":"2026-04-01T10:00:00.000Z","actor":"system","kind":"session_started","payload":{"cwd":"/workspace/myapp"}}
+{"id":"hp-2","sessionId":"happy-path","source":"replay","timestamp":"2026-04-01T10:00:05.000Z","actor":"user","kind":"message","payload":{"text":"Please add a structured logger utility."}}
+{"id":"hp-3","sessionId":"happy-path","source":"replay","timestamp":"2026-04-01T10:00:10.000Z","actor":"assistant","kind":"message","payload":{"text":"I'll read the utilities first."}}
+{"id":"hp-4","sessionId":"happy-path","source":"replay","timestamp":"2026-04-01T10:00:15.000Z","actor":"assistant","kind":"tool_started","payload":{"toolName":"Read","file_path":"src/utils.ts"}}
+{"id":"hp-5","sessionId":"happy-path","source":"replay","timestamp":"2026-04-01T10:00:16.000Z","actor":"assistant","kind":"tool_completed","payload":{"toolName":"Read","file_path":"src/utils.ts"}}
+{"id":"hp-6","sessionId":"happy-path","source":"replay","timestamp":"2026-04-01T10:00:20.000Z","actor":"assistant","kind":"tool_started","payload":{"toolName":"Write","filePath":"src/logger.ts"}}
+{"id":"hp-7","sessionId":"happy-path","source":"replay","timestamp":"2026-04-01T10:00:21.000Z","actor":"assistant","kind":"tool_completed","payload":{"toolName":"Write","filePath":"src/logger.ts"}}
+{"id":"hp-8","sessionId":"happy-path","source":"replay","timestamp":"2026-04-01T10:00:25.000Z","actor":"assistant","kind":"message","payload":{"text":"Done! Logger created at src/logger.ts."}}
+{"id":"hp-9","sessionId":"happy-path","source":"replay","timestamp":"2026-04-01T10:00:30.000Z","actor":"system","kind":"session_ended","payload":{}}

--- a/shadow-agent/tests/fixtures/replays/happy-path.replay.jsonl
+++ b/shadow-agent/tests/fixtures/replays/happy-path.replay.jsonl
@@ -1,8 +1,8 @@
 {"id":"hp-1","sessionId":"happy-path","source":"replay","timestamp":"2026-04-01T10:00:00.000Z","actor":"system","kind":"session_started","payload":{"cwd":"/workspace/myapp"}}
 {"id":"hp-2","sessionId":"happy-path","source":"replay","timestamp":"2026-04-01T10:00:05.000Z","actor":"user","kind":"message","payload":{"text":"Please add a structured logger utility."}}
 {"id":"hp-3","sessionId":"happy-path","source":"replay","timestamp":"2026-04-01T10:00:10.000Z","actor":"assistant","kind":"message","payload":{"text":"I'll read the utilities first."}}
-{"id":"hp-4","sessionId":"happy-path","source":"replay","timestamp":"2026-04-01T10:00:15.000Z","actor":"assistant","kind":"tool_started","payload":{"toolName":"Read","file_path":"src/utils.ts"}}
-{"id":"hp-5","sessionId":"happy-path","source":"replay","timestamp":"2026-04-01T10:00:16.000Z","actor":"assistant","kind":"tool_completed","payload":{"toolName":"Read","file_path":"src/utils.ts"}}
+{"id":"hp-4","sessionId":"happy-path","source":"replay","timestamp":"2026-04-01T10:00:15.000Z","actor":"assistant","kind":"tool_started","payload":{"toolName":"Read","filePath":"src/utils.ts"}}
+{"id":"hp-5","sessionId":"happy-path","source":"replay","timestamp":"2026-04-01T10:00:16.000Z","actor":"assistant","kind":"tool_completed","payload":{"toolName":"Read","filePath":"src/utils.ts"}}
 {"id":"hp-6","sessionId":"happy-path","source":"replay","timestamp":"2026-04-01T10:00:20.000Z","actor":"assistant","kind":"tool_started","payload":{"toolName":"Write","filePath":"src/logger.ts"}}
 {"id":"hp-7","sessionId":"happy-path","source":"replay","timestamp":"2026-04-01T10:00:21.000Z","actor":"assistant","kind":"tool_completed","payload":{"toolName":"Write","filePath":"src/logger.ts"}}
 {"id":"hp-8","sessionId":"happy-path","source":"replay","timestamp":"2026-04-01T10:00:25.000Z","actor":"assistant","kind":"message","payload":{"text":"Done! Logger created at src/logger.ts."}}

--- a/shadow-agent/tests/fixtures/replays/risk-escalation.replay.jsonl
+++ b/shadow-agent/tests/fixtures/replays/risk-escalation.replay.jsonl
@@ -1,11 +1,11 @@
 {"id":"re-1","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:00.000Z","actor":"system","kind":"session_started","payload":{"cwd":"/workspace/api"}}
 {"id":"re-2","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:05.000Z","actor":"user","kind":"message","payload":{"text":"Fix the failing migration."}}
 {"id":"re-3","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:10.000Z","actor":"assistant","kind":"tool_started","payload":{"toolName":"Bash"}}
-{"id":"re-4","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:11.000Z","actor":"assistant","kind":"tool_failed","payload":{"toolName":"Bash","error":"column already exists"}}
+{"id":"re-4","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:11.000Z","actor":"assistant","kind":"tool_failed","payload":{"toolName":"Bash","error":"column already exists","is_error":true}}
 {"id":"re-5","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:15.000Z","actor":"assistant","kind":"tool_started","payload":{"toolName":"Bash"}}
-{"id":"re-6","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:16.000Z","actor":"assistant","kind":"tool_failed","payload":{"toolName":"Bash","error":"connection refused"}}
+{"id":"re-6","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:16.000Z","actor":"assistant","kind":"tool_failed","payload":{"toolName":"Bash","error":"connection refused","is_error":true}}
 {"id":"re-7","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:20.000Z","actor":"assistant","kind":"tool_started","payload":{"toolName":"Bash"}}
-{"id":"re-8","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:21.000Z","actor":"assistant","kind":"tool_failed","payload":{"toolName":"Bash","error":"no transaction in progress"}}
+{"id":"re-8","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:21.000Z","actor":"assistant","kind":"tool_failed","payload":{"toolName":"Bash","error":"no transaction in progress","is_error":true}}
 {"id":"re-9","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:25.000Z","actor":"assistant","kind":"tool_started","payload":{"toolName":"Bash"}}
 {"id":"re-10","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:26.000Z","actor":"assistant","kind":"tool_completed","payload":{"toolName":"Bash"}}
 {"id":"re-11","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:30.000Z","actor":"assistant","kind":"message","payload":{"text":"The database container crashed. Restarting."}}

--- a/shadow-agent/tests/fixtures/replays/risk-escalation.replay.jsonl
+++ b/shadow-agent/tests/fixtures/replays/risk-escalation.replay.jsonl
@@ -1,0 +1,12 @@
+{"id":"re-1","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:00.000Z","actor":"system","kind":"session_started","payload":{"cwd":"/workspace/api"}}
+{"id":"re-2","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:05.000Z","actor":"user","kind":"message","payload":{"text":"Fix the failing migration."}}
+{"id":"re-3","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:10.000Z","actor":"assistant","kind":"tool_started","payload":{"toolName":"Bash"}}
+{"id":"re-4","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:11.000Z","actor":"assistant","kind":"tool_failed","payload":{"toolName":"Bash","error":"column already exists"}}
+{"id":"re-5","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:15.000Z","actor":"assistant","kind":"tool_started","payload":{"toolName":"Bash"}}
+{"id":"re-6","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:16.000Z","actor":"assistant","kind":"tool_failed","payload":{"toolName":"Bash","error":"connection refused"}}
+{"id":"re-7","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:20.000Z","actor":"assistant","kind":"tool_started","payload":{"toolName":"Bash"}}
+{"id":"re-8","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:21.000Z","actor":"assistant","kind":"tool_failed","payload":{"toolName":"Bash","error":"no transaction in progress"}}
+{"id":"re-9","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:25.000Z","actor":"assistant","kind":"tool_started","payload":{"toolName":"Bash"}}
+{"id":"re-10","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:26.000Z","actor":"assistant","kind":"tool_completed","payload":{"toolName":"Bash"}}
+{"id":"re-11","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:30.000Z","actor":"assistant","kind":"message","payload":{"text":"The database container crashed. Restarting."}}
+{"id":"re-12","sessionId":"risk-escalation","source":"replay","timestamp":"2026-04-01T12:00:35.000Z","actor":"system","kind":"session_ended","payload":{}}

--- a/shadow-agent/tests/fixtures/replays/subagent-flow.replay.jsonl
+++ b/shadow-agent/tests/fixtures/replays/subagent-flow.replay.jsonl
@@ -1,0 +1,13 @@
+{"id":"sa-1","sessionId":"subagent-flow","source":"replay","timestamp":"2026-04-01T11:00:00.000Z","actor":"system","kind":"session_started","payload":{"cwd":"/workspace/monorepo"}}
+{"id":"sa-2","sessionId":"subagent-flow","source":"replay","timestamp":"2026-04-01T11:00:05.000Z","actor":"user","kind":"message","payload":{"text":"Add E2E tests for checkout."}}
+{"id":"sa-3","sessionId":"subagent-flow","source":"replay","timestamp":"2026-04-01T11:00:10.000Z","actor":"orchestrator","kind":"agent_spawned","payload":{"label":"orchestrator"}}
+{"id":"sa-4","sessionId":"subagent-flow","source":"replay","timestamp":"2026-04-01T11:00:15.000Z","actor":"orchestrator","kind":"subagent_dispatched","payload":{"label":"playwright-setup","parentId":"orchestrator"}}
+{"id":"sa-5","sessionId":"subagent-flow","source":"replay","timestamp":"2026-04-01T11:00:20.000Z","actor":"playwright-setup","kind":"agent_spawned","payload":{"label":"playwright-setup","parentId":"orchestrator"}}
+{"id":"sa-6","sessionId":"subagent-flow","source":"replay","timestamp":"2026-04-01T11:00:25.000Z","actor":"playwright-setup","kind":"tool_started","payload":{"toolName":"Bash","filePath":null}}
+{"id":"sa-7","sessionId":"subagent-flow","source":"replay","timestamp":"2026-04-01T11:00:30.000Z","actor":"playwright-setup","kind":"tool_completed","payload":{"toolName":"Bash"}}
+{"id":"sa-8","sessionId":"subagent-flow","source":"replay","timestamp":"2026-04-01T11:00:35.000Z","actor":"playwright-setup","kind":"agent_completed","payload":{"label":"playwright-setup"}}
+{"id":"sa-9","sessionId":"subagent-flow","source":"replay","timestamp":"2026-04-01T11:00:40.000Z","actor":"orchestrator","kind":"subagent_returned","payload":{"label":"playwright-setup"}}
+{"id":"sa-10","sessionId":"subagent-flow","source":"replay","timestamp":"2026-04-01T11:00:45.000Z","actor":"orchestrator","kind":"tool_started","payload":{"toolName":"Write","filePath":"tests/e2e/checkout.spec.ts"}}
+{"id":"sa-11","sessionId":"subagent-flow","source":"replay","timestamp":"2026-04-01T11:00:46.000Z","actor":"orchestrator","kind":"tool_completed","payload":{"toolName":"Write","filePath":"tests/e2e/checkout.spec.ts"}}
+{"id":"sa-12","sessionId":"subagent-flow","source":"replay","timestamp":"2026-04-01T11:00:50.000Z","actor":"orchestrator","kind":"agent_completed","payload":{"label":"orchestrator"}}
+{"id":"sa-13","sessionId":"subagent-flow","source":"replay","timestamp":"2026-04-01T11:00:55.000Z","actor":"system","kind":"session_ended","payload":{}}

--- a/shadow-agent/tests/fixtures/transcripts/happy-path.jsonl
+++ b/shadow-agent/tests/fixtures/transcripts/happy-path.jsonl
@@ -1,0 +1,6 @@
+{"sessionId":"happy-path","cwd":"/workspace/myapp","message":{"role":"user","content":"Please add a structured logger utility in src/logger.ts."}}
+{"sessionId":"happy-path","message":{"role":"assistant","content":[{"type":"text","text":"I'll read the existing utilities first, then create the logger."},{"type":"tool_use","id":"tu-1","name":"Read","input":{"file_path":"src/utils.ts"}}]}}
+{"sessionId":"happy-path","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu-1","content":"export function helper() { return 42; }","is_error":false}]}}
+{"sessionId":"happy-path","message":{"role":"assistant","content":[{"type":"tool_use","id":"tu-2","name":"Write","input":{"file_path":"src/logger.ts","content":"export function log(level: string, msg: string) { console.log(`[${level}] ${msg}`); }"}}]}}
+{"sessionId":"happy-path","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu-2","content":"File written successfully","is_error":false}]}}
+{"sessionId":"happy-path","message":{"role":"assistant","content":[{"type":"text","text":"Done! The logger utility has been created in src/logger.ts with level-based output."}]}}

--- a/shadow-agent/tests/fixtures/transcripts/risk-escalation.jsonl
+++ b/shadow-agent/tests/fixtures/transcripts/risk-escalation.jsonl
@@ -1,0 +1,12 @@
+{"sessionId":"risk-escalation","cwd":"/workspace/api","message":{"role":"user","content":"Fix the database migration that keeps failing in staging."}}
+{"sessionId":"risk-escalation","message":{"role":"assistant","content":[{"type":"text","text":"I'll investigate the migration failure."},{"type":"tool_use","id":"re-1","name":"Bash","input":{"command":"npm run migrate:latest 2>&1"}}]}}
+{"sessionId":"risk-escalation","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"re-1","content":"ERROR: column 'user_id' already exists","is_error":true}]}}
+{"sessionId":"risk-escalation","message":{"role":"assistant","content":[{"type":"tool_use","id":"re-2","name":"Bash","input":{"command":"psql -c \"\\d users\" 2>&1"}}]}}
+{"sessionId":"risk-escalation","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"re-2","content":"ERROR: connection refused","is_error":true}]}}
+{"sessionId":"risk-escalation","message":{"role":"assistant","content":[{"type":"tool_use","id":"re-3","name":"Read","input":{"file_path":"migrations/20260101_add_user_id.ts"}}]}}
+{"sessionId":"risk-escalation","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"re-3","content":"export async function up(db) { await db.schema.addColumn('users', 'user_id', ...); }","is_error":false}]}}
+{"sessionId":"risk-escalation","message":{"role":"assistant","content":[{"type":"tool_use","id":"re-4","name":"Bash","input":{"command":"npm run migrate:rollback 2>&1"}}]}}
+{"sessionId":"risk-escalation","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"re-4","content":"ERROR: no transaction in progress","is_error":true}]}}
+{"sessionId":"risk-escalation","message":{"role":"assistant","content":[{"type":"tool_use","id":"re-5","name":"Bash","input":{"command":"docker-compose ps 2>&1"}}]}}
+{"sessionId":"risk-escalation","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"re-5","content":"db container: Exit 1","is_error":false}]}}
+{"sessionId":"risk-escalation","message":{"role":"assistant","content":[{"type":"text","text":"The database container has crashed. I need to restart the environment before the migration can proceed."}]}}

--- a/shadow-agent/tests/fixtures/transcripts/risk-escalation.jsonl
+++ b/shadow-agent/tests/fixtures/transcripts/risk-escalation.jsonl
@@ -8,5 +8,5 @@
 {"sessionId":"risk-escalation","message":{"role":"assistant","content":[{"type":"tool_use","id":"re-4","name":"Bash","input":{"command":"npm run migrate:rollback 2>&1"}}]}}
 {"sessionId":"risk-escalation","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"re-4","content":"ERROR: no transaction in progress","is_error":true}]}}
 {"sessionId":"risk-escalation","message":{"role":"assistant","content":[{"type":"tool_use","id":"re-5","name":"Bash","input":{"command":"docker-compose ps 2>&1"}}]}}
-{"sessionId":"risk-escalation","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"re-5","content":"db container: Exit 1","is_error":false}]}}
+{"sessionId":"risk-escalation","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"re-5","content":"db container: Exit 1","is_error":true}]}}
 {"sessionId":"risk-escalation","message":{"role":"assistant","content":[{"type":"text","text":"The database container has crashed. I need to restart the environment before the migration can proceed."}]}}

--- a/shadow-agent/tests/fixtures/transcripts/subagent-flow.jsonl
+++ b/shadow-agent/tests/fixtures/transcripts/subagent-flow.jsonl
@@ -1,0 +1,8 @@
+{"sessionId":"subagent-flow","cwd":"/workspace/monorepo","message":{"role":"user","content":"Add end-to-end tests for the checkout flow using Playwright."}}
+{"sessionId":"subagent-flow","message":{"role":"assistant","content":[{"type":"text","text":"I'll delegate the Playwright setup to a subagent and handle the test writing myself."},{"type":"tool_use","id":"sf-1","name":"Task","input":{"description":"Install and configure Playwright in the project","subagent":"playwright-setup"}}]}}
+{"sessionId":"subagent-flow","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"sf-1","content":"Playwright installed, playwright.config.ts created","is_error":false}]}}
+{"sessionId":"subagent-flow","message":{"role":"assistant","content":[{"type":"text","text":"Great, Playwright is set up. Now I'll write the checkout tests."},{"type":"tool_use","id":"sf-2","name":"Read","input":{"file_path":"src/pages/Checkout.tsx"}}]}}
+{"sessionId":"subagent-flow","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"sf-2","content":"export default function Checkout() { ... }","is_error":false}]}}
+{"sessionId":"subagent-flow","message":{"role":"assistant","content":[{"type":"tool_use","id":"sf-3","name":"Write","input":{"file_path":"tests/e2e/checkout.spec.ts","content":"import { test, expect } from '@playwright/test'; test('checkout flow', async ({ page }) => { ... });"}}]}}
+{"sessionId":"subagent-flow","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"sf-3","content":"File written","is_error":false}]}}
+{"sessionId":"subagent-flow","message":{"role":"assistant","content":[{"type":"text","text":"The checkout E2E tests are ready. Run npx playwright test to execute them."}]}}

--- a/shadow-agent/tests/fixtures/transcripts/tool-heavy.jsonl
+++ b/shadow-agent/tests/fixtures/transcripts/tool-heavy.jsonl
@@ -1,0 +1,20 @@
+{"sessionId":"tool-heavy","cwd":"/workspace/app","message":{"role":"user","content":"Debug the failing CI pipeline and fix any issues."}}
+{"sessionId":"tool-heavy","message":{"role":"assistant","content":[{"type":"text","text":"Let me investigate the CI failure."},{"type":"tool_use","id":"th-1","name":"Bash","input":{"command":"npm test 2>&1 | tail -30"}}]}}
+{"sessionId":"tool-heavy","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"th-1","content":"FAIL src/auth.test.ts - 3 failed","is_error":false}]}}
+{"sessionId":"tool-heavy","message":{"role":"assistant","content":[{"type":"tool_use","id":"th-2","name":"Read","input":{"file_path":"src/auth.test.ts"}}]}}
+{"sessionId":"tool-heavy","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"th-2","content":"describe('auth', () => { ... });","is_error":false}]}}
+{"sessionId":"tool-heavy","message":{"role":"assistant","content":[{"type":"tool_use","id":"th-3","name":"Grep","input":{"pattern":"TokenExpired","path":"src"}}]}}
+{"sessionId":"tool-heavy","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"th-3","content":"src/auth.ts:42: throw new TokenExpiredError()","is_error":false}]}}
+{"sessionId":"tool-heavy","message":{"role":"assistant","content":[{"type":"tool_use","id":"th-4","name":"Read","input":{"file_path":"src/auth.ts"}}]}}
+{"sessionId":"tool-heavy","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"th-4","content":"export class TokenExpiredError extends Error {}","is_error":false}]}}
+{"sessionId":"tool-heavy","message":{"role":"assistant","content":[{"type":"tool_use","id":"th-5","name":"Bash","input":{"command":"grep -r 'TokenExpired' src/ --include='*.ts'"}}]}}
+{"sessionId":"tool-heavy","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"th-5","content":"3 matches found","is_error":false}]}}
+{"sessionId":"tool-heavy","message":{"role":"assistant","content":[{"type":"tool_use","id":"th-6","name":"Read","input":{"file_path":"src/middleware/auth.ts"}}]}}
+{"sessionId":"tool-heavy","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"th-6","content":"export function authMiddleware() { ... }","is_error":false}]}}
+{"sessionId":"tool-heavy","message":{"role":"assistant","content":[{"type":"tool_use","id":"th-7","name":"Bash","input":{"command":"npm run lint 2>&1"}}]}}
+{"sessionId":"tool-heavy","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"th-7","content":"0 errors, 2 warnings","is_error":false}]}}
+{"sessionId":"tool-heavy","message":{"role":"assistant","content":[{"type":"tool_use","id":"th-8","name":"Bash","input":{"command":"npm test -- --testPathPattern=auth 2>&1"}}]}}
+{"sessionId":"tool-heavy","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"th-8","content":"FAIL - TokenExpiredError not caught in handler","is_error":false}]}}
+{"sessionId":"tool-heavy","message":{"role":"assistant","content":[{"type":"tool_use","id":"th-9","name":"Glob","input":{"pattern":"src/**/*.test.ts"}}]}}
+{"sessionId":"tool-heavy","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"th-9","content":"12 files matched","is_error":false}]}}
+{"sessionId":"tool-heavy","message":{"role":"assistant","content":[{"type":"text","text":"I can see the issue. The error handler doesn't catch TokenExpiredError. Let me fix it."}]}}

--- a/shadow-agent/tests/fixtures/transcripts/tool-heavy.jsonl
+++ b/shadow-agent/tests/fixtures/transcripts/tool-heavy.jsonl
@@ -1,6 +1,6 @@
 {"sessionId":"tool-heavy","cwd":"/workspace/app","message":{"role":"user","content":"Debug the failing CI pipeline and fix any issues."}}
 {"sessionId":"tool-heavy","message":{"role":"assistant","content":[{"type":"text","text":"Let me investigate the CI failure."},{"type":"tool_use","id":"th-1","name":"Bash","input":{"command":"npm test 2>&1 | tail -30"}}]}}
-{"sessionId":"tool-heavy","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"th-1","content":"FAIL src/auth.test.ts - 3 failed","is_error":false}]}}
+{"sessionId":"tool-heavy","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"th-1","content":"FAIL src/auth.test.ts - 3 failed","is_error":true}]}}
 {"sessionId":"tool-heavy","message":{"role":"assistant","content":[{"type":"tool_use","id":"th-2","name":"Read","input":{"file_path":"src/auth.test.ts"}}]}}
 {"sessionId":"tool-heavy","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"th-2","content":"describe('auth', () => { ... });","is_error":false}]}}
 {"sessionId":"tool-heavy","message":{"role":"assistant","content":[{"type":"tool_use","id":"th-3","name":"Grep","input":{"pattern":"TokenExpired","path":"src"}}]}}
@@ -14,7 +14,7 @@
 {"sessionId":"tool-heavy","message":{"role":"assistant","content":[{"type":"tool_use","id":"th-7","name":"Bash","input":{"command":"npm run lint 2>&1"}}]}}
 {"sessionId":"tool-heavy","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"th-7","content":"0 errors, 2 warnings","is_error":false}]}}
 {"sessionId":"tool-heavy","message":{"role":"assistant","content":[{"type":"tool_use","id":"th-8","name":"Bash","input":{"command":"npm test -- --testPathPattern=auth 2>&1"}}]}}
-{"sessionId":"tool-heavy","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"th-8","content":"FAIL - TokenExpiredError not caught in handler","is_error":false}]}}
+{"sessionId":"tool-heavy","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"th-8","content":"FAIL - TokenExpiredError not caught in handler","is_error":true}]}}
 {"sessionId":"tool-heavy","message":{"role":"assistant","content":[{"type":"tool_use","id":"th-9","name":"Glob","input":{"pattern":"src/**/*.test.ts"}}]}}
 {"sessionId":"tool-heavy","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"th-9","content":"12 files matched","is_error":false}]}}
 {"sessionId":"tool-heavy","message":{"role":"assistant","content":[{"type":"text","text":"I can see the issue. The error handler doesn't catch TokenExpiredError. Let me fix it."}]}}

--- a/shadow-agent/tests/persistence.test.ts
+++ b/shadow-agent/tests/persistence.test.ts
@@ -99,4 +99,45 @@ describe('FileReplayStore', () => {
     expect(sessions[0].sessionId).toBe('session-b');
     expect(sessions[1].sessionId).toBe('session-a');
   });
+
+  // ── edge / failure cases ──────────────────────────────────────────────────
+
+  it('loadSession throws on a nonexistent session', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'shadow-agent-persistence-'));
+    const store = new FileReplayStore(rootDir);
+    await expect(store.loadSession('nonexistent-session')).rejects.toThrow();
+  });
+
+  it('listSessions returns empty array for a fresh store', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'shadow-agent-persistence-'));
+    const store = new FileReplayStore(rootDir);
+    const sessions = await store.listSessions();
+    expect(sessions).toEqual([]);
+  });
+
+  it('loadEvents returns empty array for a session with no events', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'shadow-agent-persistence-'));
+    const store = new FileReplayStore(rootDir);
+    // Save a session with an explicit empty event list
+    await store.saveSession('empty-session', [], 'Empty');
+    const events = await store.loadEvents('empty-session');
+    expect(events).toEqual([]);
+  });
+
+  it('session IDs with special characters are encoded/decoded correctly', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'shadow-agent-persistence-'));
+    const store = new FileReplayStore(rootDir);
+    const sessionId = 'session/with spaces & special=chars';
+    const evt = makeEvent({
+      id: 'x-1',
+      sessionId,
+      timestamp: '2026-01-01T00:00:00.000Z',
+      kind: 'session_started',
+      actor: 'system'
+    });
+    await store.saveSession(sessionId, [evt], 'Special');
+    const loaded = await store.loadSession(sessionId);
+    expect(loaded.record.sessionId).toBe(sessionId);
+    expect(loaded.events).toHaveLength(1);
+  });
 });

--- a/shadow-agent/tests/persistence.test.ts
+++ b/shadow-agent/tests/persistence.test.ts
@@ -1,8 +1,8 @@
 import { readFile } from 'node:fs/promises';
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { FileReplayStore } from '../src/persistence';
 import type { CanonicalEvent } from '../src/shared/schema';
 
@@ -17,9 +17,21 @@ function makeEvent(
   };
 }
 
+const tempRoots: string[] = [];
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    const rootDir = tempRoots.pop();
+    if (rootDir) {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  }
+});
+
 describe('FileReplayStore', () => {
   it('persists canonical events and reloads them from disk', async () => {
     const rootDir = mkdtempSync(join(tmpdir(), 'shadow-agent-persistence-'));
+    tempRoots.push(rootDir);
     const store = new FileReplayStore(rootDir);
     const sessionId = 'payment-refactor';
     const events = [
@@ -58,6 +70,7 @@ describe('FileReplayStore', () => {
 
   it('appends events and lists sessions in updated order', async () => {
     const rootDir = mkdtempSync(join(tmpdir(), 'shadow-agent-persistence-'));
+    tempRoots.push(rootDir);
     const store = new FileReplayStore(rootDir);
 
     await store.saveSession('session-a', [
@@ -104,12 +117,14 @@ describe('FileReplayStore', () => {
 
   it('loadSession throws on a nonexistent session', async () => {
     const rootDir = mkdtempSync(join(tmpdir(), 'shadow-agent-persistence-'));
+    tempRoots.push(rootDir);
     const store = new FileReplayStore(rootDir);
-    await expect(store.loadSession('nonexistent-session')).rejects.toThrow();
+    await expect(store.loadSession('nonexistent-session')).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
   it('listSessions returns empty array for a fresh store', async () => {
     const rootDir = mkdtempSync(join(tmpdir(), 'shadow-agent-persistence-'));
+    tempRoots.push(rootDir);
     const store = new FileReplayStore(rootDir);
     const sessions = await store.listSessions();
     expect(sessions).toEqual([]);
@@ -117,6 +132,7 @@ describe('FileReplayStore', () => {
 
   it('loadEvents returns empty array for a session with no events', async () => {
     const rootDir = mkdtempSync(join(tmpdir(), 'shadow-agent-persistence-'));
+    tempRoots.push(rootDir);
     const store = new FileReplayStore(rootDir);
     // Save a session with an explicit empty event list
     await store.saveSession('empty-session', [], 'Empty');
@@ -126,6 +142,7 @@ describe('FileReplayStore', () => {
 
   it('session IDs with special characters are encoded/decoded correctly', async () => {
     const rootDir = mkdtempSync(join(tmpdir(), 'shadow-agent-persistence-'));
+    tempRoots.push(rootDir);
     const store = new FileReplayStore(rootDir);
     const sessionId = 'session/with spaces & special=chars';
     const evt = makeEvent({
@@ -137,7 +154,11 @@ describe('FileReplayStore', () => {
     });
     await store.saveSession(sessionId, [evt], 'Special');
     const loaded = await store.loadSession(sessionId);
+    const sessions = await store.listSessions();
+    const listed = sessions.find((session) => session.sessionId === sessionId);
+
     expect(loaded.record.sessionId).toBe(sessionId);
-    expect(loaded.events).toHaveLength(1);
+    expect(loaded.events).toEqual([evt]);
+    expect(listed?.sessionId).toBe(sessionId);
   });
 });

--- a/shadow-agent/tests/phase1-integration.test.ts
+++ b/shadow-agent/tests/phase1-integration.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Phase 1 end-to-end integration tests.
+ *
+ * Each test takes a fixture from the corpus and drives the full pipeline:
+ *   transcript JSONL → CanonicalEvents → deriveState()
+ *
+ * This catches regressions across the entire Phase 1 stack in a single pass.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { parseClaudeTranscriptJsonl } from '../src/shared/transcript-adapter';
+import { deriveState } from '../src/shared/derive';
+import { parseReplay } from '../src/shared/replay-store';
+
+const TRANSCRIPT_FIXTURES = join(import.meta.dirname, 'fixtures/transcripts');
+const REPLAY_FIXTURES = join(import.meta.dirname, 'fixtures/replays');
+
+describe('Phase 1 integration: transcript → events → deriveState', () => {
+  it('happy-path: derives implementation phase + file attention', () => {
+    const raw = readFileSync(join(TRANSCRIPT_FIXTURES, 'happy-path.jsonl'), 'utf8');
+    const events = parseClaudeTranscriptJsonl(raw);
+    const state = deriveState(events);
+
+    expect(state.activePhase).toBe('implementation');
+    expect(state.fileAttention.some((f) => f.filePath.includes('logger.ts'))).toBe(true);
+    expect(state.riskSignals).toHaveLength(0);
+    expect(state.sessionId).not.toBe('unknown');
+    expect(state.transcript.length).toBeGreaterThan(0);
+  });
+
+  it('risk-escalation: derives validation phase + multiple risk signals', () => {
+    const raw = readFileSync(join(TRANSCRIPT_FIXTURES, 'risk-escalation.jsonl'), 'utf8');
+    const events = parseClaudeTranscriptJsonl(raw);
+    const state = deriveState(events);
+
+    expect(state.riskSignals.some((r) => r.includes('failed tool call'))).toBe(true);
+    // 4+ bash calls → bash churn risk
+    expect(state.riskSignals.some((r) => r.toLowerCase().includes('churn'))).toBe(true);
+    // risk signals drive next-move recommendations
+    expect(state.nextMoves.some((m) => m.toLowerCase().includes('risk'))).toBe(true);
+  });
+
+  it('tool-heavy: derives validation or exploration phase + bash-churn risk', () => {
+    const raw = readFileSync(join(TRANSCRIPT_FIXTURES, 'tool-heavy.jsonl'), 'utf8');
+    const events = parseClaudeTranscriptJsonl(raw);
+    const state = deriveState(events);
+
+    // Should flag bash churn (4+ Bash tool_started events in the fixture)
+    expect(state.riskSignals.some((r) => r.toLowerCase().includes('churn'))).toBe(true);
+    // Multiple read/grep/glob (5 in fixture — just under the 6-call exploration threshold)
+    // so exploration risk may or may not fire; we only assert bash churn is present
+  });
+
+  it('subagent-flow: captures objective from first user message', () => {
+    const raw = readFileSync(join(TRANSCRIPT_FIXTURES, 'subagent-flow.jsonl'), 'utf8');
+    const events = parseClaudeTranscriptJsonl(raw);
+    const state = deriveState(events);
+
+    expect(state.currentObjective).toContain('end-to-end tests');
+    expect(state.fileAttention.some((f) => f.filePath.includes('.spec.ts'))).toBe(true);
+  });
+});
+
+describe('Phase 1 integration: replay fixtures → deriveState', () => {
+  it('happy-path replay: implementation phase, logger.ts in file attention', () => {
+    const raw = readFileSync(join(REPLAY_FIXTURES, 'happy-path.replay.jsonl'), 'utf8');
+    const events = parseReplay(raw);
+    const state = deriveState(events, 'Happy Path Session');
+
+    expect(state.activePhase).toBe('implementation');
+    expect(state.fileAttention.some((f) => f.filePath.includes('logger.ts'))).toBe(true);
+    expect(state.shadowInsights.some((i) => i.kind === 'phase')).toBe(true);
+  });
+
+  it('risk-escalation replay: multiple failed tools → risk signals present', () => {
+    const raw = readFileSync(join(REPLAY_FIXTURES, 'risk-escalation.replay.jsonl'), 'utf8');
+    const events = parseReplay(raw);
+    const state = deriveState(events, 'Risk Session');
+
+    expect(state.riskSignals.length).toBeGreaterThanOrEqual(2);
+    expect(state.shadowInsights.some((i) => i.kind === 'risk')).toBe(true);
+  });
+
+  it('subagent-flow replay: parent + subagent nodes in agentNodes', () => {
+    const raw = readFileSync(join(REPLAY_FIXTURES, 'subagent-flow.replay.jsonl'), 'utf8');
+    const events = parseReplay(raw);
+    const state = deriveState(events, 'Subagent Session');
+
+    const orchestrator = state.agentNodes.find((n) => n.id === 'orchestrator');
+    const playwrightAgent = state.agentNodes.find((n) => n.id === 'playwright-setup');
+    expect(orchestrator).toBeDefined();
+    expect(playwrightAgent).toBeDefined();
+    expect(playwrightAgent?.state).toBe('completed');
+    expect(state.fileAttention.some((f) => f.filePath.includes('.spec.ts'))).toBe(true);
+  });
+
+  it('all fixture replays produce valid DerivedState without throwing', () => {
+    const fixtures = [
+      'happy-path.replay.jsonl',
+      'subagent-flow.replay.jsonl',
+      'risk-escalation.replay.jsonl',
+    ];
+    for (const fname of fixtures) {
+      const raw = readFileSync(join(REPLAY_FIXTURES, fname), 'utf8');
+      expect(() => {
+        const events = parseReplay(raw);
+        deriveState(events);
+      }).not.toThrow();
+    }
+  });
+});

--- a/shadow-agent/tests/phase1-integration.test.ts
+++ b/shadow-agent/tests/phase1-integration.test.ts
@@ -44,7 +44,7 @@ describe('Phase 1 integration: transcript → events → deriveState', () => {
     expect(state.nextMoves.some((m) => m.toLowerCase().includes('risk'))).toBe(true);
   });
 
-  it('tool-heavy: derives validation or exploration phase + bash-churn risk', () => {
+  it('tool-heavy: derives validation phase + bash-churn risk', () => {
     const raw = readFileSync(join(TRANSCRIPT_FIXTURES, 'tool-heavy.jsonl'), 'utf8');
     const events = parseClaudeTranscriptJsonl(raw);
     const state = deriveState(events);

--- a/shadow-agent/tests/phase1-integration.test.ts
+++ b/shadow-agent/tests/phase1-integration.test.ts
@@ -36,6 +36,7 @@ describe('Phase 1 integration: transcript → events → deriveState', () => {
     const events = parseClaudeTranscriptJsonl(raw);
     const state = deriveState(events);
 
+    expect(state.activePhase).toBe('validation');
     expect(state.riskSignals.some((r) => r.includes('failed tool call'))).toBe(true);
     // 4+ bash calls → bash churn risk
     expect(state.riskSignals.some((r) => r.toLowerCase().includes('churn'))).toBe(true);
@@ -48,6 +49,7 @@ describe('Phase 1 integration: transcript → events → deriveState', () => {
     const events = parseClaudeTranscriptJsonl(raw);
     const state = deriveState(events);
 
+    expect(state.activePhase).toBe('validation');
     // Should flag bash churn (4+ Bash tool_started events in the fixture)
     expect(state.riskSignals.some((r) => r.toLowerCase().includes('churn'))).toBe(true);
     // Multiple read/grep/glob (5 in fixture — just under the 6-call exploration threshold)
@@ -97,7 +99,7 @@ describe('Phase 1 integration: replay fixtures → deriveState', () => {
     expect(state.fileAttention.some((f) => f.filePath.includes('.spec.ts'))).toBe(true);
   });
 
-  it('all fixture replays produce valid DerivedState without throwing', () => {
+  it('all valid fixture replays produce valid DerivedState without throwing', () => {
     const fixtures = [
       'happy-path.replay.jsonl',
       'subagent-flow.replay.jsonl',

--- a/shadow-agent/tests/phase1-integration.test.ts
+++ b/shadow-agent/tests/phase1-integration.test.ts
@@ -18,9 +18,17 @@ const FIXTURE_DIR = fileURLToPath(new URL('.', import.meta.url));
 const TRANSCRIPT_FIXTURES = join(FIXTURE_DIR, 'fixtures/transcripts');
 const REPLAY_FIXTURES = join(FIXTURE_DIR, 'fixtures/replays');
 
+function readTranscriptFixture(name: string): string {
+  return readFileSync(join(TRANSCRIPT_FIXTURES, name), 'utf8');
+}
+
+function readReplayFixture(name: string): string {
+  return readFileSync(join(REPLAY_FIXTURES, name), 'utf8');
+}
+
 describe('Phase 1 integration: transcript → events → deriveState', () => {
   it('happy-path: derives implementation phase + file attention', () => {
-    const raw = readFileSync(join(TRANSCRIPT_FIXTURES, 'happy-path.jsonl'), 'utf8');
+    const raw = readTranscriptFixture('happy-path.jsonl');
     const events = parseClaudeTranscriptJsonl(raw);
     const state = deriveState(events);
 
@@ -32,7 +40,7 @@ describe('Phase 1 integration: transcript → events → deriveState', () => {
   });
 
   it('risk-escalation: derives validation phase + multiple risk signals', () => {
-    const raw = readFileSync(join(TRANSCRIPT_FIXTURES, 'risk-escalation.jsonl'), 'utf8');
+    const raw = readTranscriptFixture('risk-escalation.jsonl');
     const events = parseClaudeTranscriptJsonl(raw);
     const state = deriveState(events);
 
@@ -45,7 +53,7 @@ describe('Phase 1 integration: transcript → events → deriveState', () => {
   });
 
   it('tool-heavy: derives validation phase + bash-churn risk', () => {
-    const raw = readFileSync(join(TRANSCRIPT_FIXTURES, 'tool-heavy.jsonl'), 'utf8');
+    const raw = readTranscriptFixture('tool-heavy.jsonl');
     const events = parseClaudeTranscriptJsonl(raw);
     const state = deriveState(events);
 
@@ -57,7 +65,7 @@ describe('Phase 1 integration: transcript → events → deriveState', () => {
   });
 
   it('subagent-flow: captures objective from first user message', () => {
-    const raw = readFileSync(join(TRANSCRIPT_FIXTURES, 'subagent-flow.jsonl'), 'utf8');
+    const raw = readTranscriptFixture('subagent-flow.jsonl');
     const events = parseClaudeTranscriptJsonl(raw);
     const state = deriveState(events);
 
@@ -68,7 +76,7 @@ describe('Phase 1 integration: transcript → events → deriveState', () => {
 
 describe('Phase 1 integration: replay fixtures → deriveState', () => {
   it('happy-path replay: implementation phase, logger.ts in file attention', () => {
-    const raw = readFileSync(join(REPLAY_FIXTURES, 'happy-path.replay.jsonl'), 'utf8');
+    const raw = readReplayFixture('happy-path.replay.jsonl');
     const events = parseReplay(raw);
     const state = deriveState(events, 'Happy Path Session');
 
@@ -78,7 +86,7 @@ describe('Phase 1 integration: replay fixtures → deriveState', () => {
   });
 
   it('risk-escalation replay: multiple failed tools → risk signals present', () => {
-    const raw = readFileSync(join(REPLAY_FIXTURES, 'risk-escalation.replay.jsonl'), 'utf8');
+    const raw = readReplayFixture('risk-escalation.replay.jsonl');
     const events = parseReplay(raw);
     const state = deriveState(events, 'Risk Session');
 
@@ -87,7 +95,7 @@ describe('Phase 1 integration: replay fixtures → deriveState', () => {
   });
 
   it('subagent-flow replay: parent + subagent nodes in agentNodes', () => {
-    const raw = readFileSync(join(REPLAY_FIXTURES, 'subagent-flow.replay.jsonl'), 'utf8');
+    const raw = readReplayFixture('subagent-flow.replay.jsonl');
     const events = parseReplay(raw);
     const state = deriveState(events, 'Subagent Session');
 
@@ -106,7 +114,7 @@ describe('Phase 1 integration: replay fixtures → deriveState', () => {
       'risk-escalation.replay.jsonl',
     ];
     for (const fname of fixtures) {
-      const raw = readFileSync(join(REPLAY_FIXTURES, fname), 'utf8');
+      const raw = readReplayFixture(fname);
       expect(() => {
         const events = parseReplay(raw);
         deriveState(events);

--- a/shadow-agent/tests/phase1-integration.test.ts
+++ b/shadow-agent/tests/phase1-integration.test.ts
@@ -8,13 +8,15 @@
  */
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { parseClaudeTranscriptJsonl } from '../src/shared/transcript-adapter';
 import { deriveState } from '../src/shared/derive';
 import { parseReplay } from '../src/shared/replay-store';
 
-const TRANSCRIPT_FIXTURES = join(import.meta.dirname, 'fixtures/transcripts');
-const REPLAY_FIXTURES = join(import.meta.dirname, 'fixtures/replays');
+const FIXTURE_DIR = fileURLToPath(new URL('.', import.meta.url));
+const TRANSCRIPT_FIXTURES = join(FIXTURE_DIR, 'fixtures/transcripts');
+const REPLAY_FIXTURES = join(FIXTURE_DIR, 'fixtures/replays');
 
 describe('Phase 1 integration: transcript → events → deriveState', () => {
   it('happy-path: derives implementation phase + file attention', () => {

--- a/shadow-agent/tests/replay-store.test.ts
+++ b/shadow-agent/tests/replay-store.test.ts
@@ -1,6 +1,10 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { buildSessionRecord, parseReplay, serializeEvents } from '../src/shared/replay-store';
 import type { CanonicalEvent } from '../src/shared/schema';
+
+const REPLAY_FIXTURES = join(import.meta.dirname, 'fixtures/replays');
 
 const events: CanonicalEvent[] = [
   {
@@ -46,5 +50,52 @@ describe('replay-store', () => {
       source: 'replay',
       eventCount: 2
     });
+  });
+
+  // ── edge cases ─────────────────────────────────────────────────────────────
+
+  it('buildSessionRecord with empty array uses epoch defaults', () => {
+    const record = buildSessionRecord([], 'Empty');
+    expect(record.sessionId).toBe('unknown');
+    expect(record.eventCount).toBe(0);
+    // timestamps should be the epoch default
+    expect(record.startedAt).toBe(new Date(0).toISOString());
+    expect(record.updatedAt).toBe(new Date(0).toISOString());
+  });
+
+  it('buildSessionRecord skips events with invalid timestamps', () => {
+    const badEvents: CanonicalEvent[] = [
+      { id: 'e1', sessionId: 's', source: 'replay', timestamp: 'not-a-date', actor: 'system', kind: 'session_started', payload: {} },
+      { id: 'e2', sessionId: 's', source: 'replay', timestamp: '2026-01-01T00:00:00.000Z', actor: 'user', kind: 'message', payload: {} },
+    ];
+    const record = buildSessionRecord(badEvents);
+    expect(record.startedAt).toBe('2026-01-01T00:00:00.000Z');
+    expect(record.updatedAt).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('serializeEvents produces one JSON line per event', () => {
+    const lines = serializeEvents(events).split('\n');
+    expect(lines).toHaveLength(2);
+    for (const line of lines) {
+      expect(() => JSON.parse(line)).not.toThrow();
+    }
+  });
+
+  it('parseReplay on a single corrupt line throws with line number', () => {
+    expect(() => parseReplay('not-json-at-all')).toThrow(/line 1/i);
+  });
+
+  it('round-trips the happy-path replay fixture', () => {
+    const raw = readFileSync(join(REPLAY_FIXTURES, 'happy-path.replay.jsonl'), 'utf8');
+    const parsed = parseReplay(raw);
+    expect(parsed.length).toBeGreaterThan(0);
+    expect(parsed[0]?.sessionId).toBe('happy-path');
+    const roundTripped = parseReplay(serializeEvents(parsed));
+    expect(roundTripped).toEqual(parsed);
+  });
+
+  it('parseReplay throws on corrupt-partial fixture (corrupt line)', () => {
+    const raw = readFileSync(join(REPLAY_FIXTURES, 'corrupt-partial.replay.jsonl'), 'utf8');
+    expect(() => parseReplay(raw)).toThrow(/line/i);
   });
 });

--- a/shadow-agent/tests/replay-store.test.ts
+++ b/shadow-agent/tests/replay-store.test.ts
@@ -1,10 +1,12 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { buildSessionRecord, parseReplay, serializeEvents } from '../src/shared/replay-store';
 import type { CanonicalEvent } from '../src/shared/schema';
 
-const REPLAY_FIXTURES = join(import.meta.dirname, 'fixtures/replays');
+const FIXTURE_DIR = fileURLToPath(new URL('.', import.meta.url));
+const REPLAY_FIXTURES = join(FIXTURE_DIR, 'fixtures/replays');
 
 const events: CanonicalEvent[] = [
   {

--- a/shadow-agent/tests/replay-store.test.ts
+++ b/shadow-agent/tests/replay-store.test.ts
@@ -65,12 +65,13 @@ describe('replay-store', () => {
     expect(record.updatedAt).toBe(new Date(0).toISOString());
   });
 
-  it('buildSessionRecord skips events with invalid timestamps', () => {
+  it('buildSessionRecord ignores invalid timestamps when computing bounds', () => {
     const badEvents: CanonicalEvent[] = [
       { id: 'e1', sessionId: 's', source: 'replay', timestamp: 'not-a-date', actor: 'system', kind: 'session_started', payload: {} },
       { id: 'e2', sessionId: 's', source: 'replay', timestamp: '2026-01-01T00:00:00.000Z', actor: 'user', kind: 'message', payload: {} },
     ];
     const record = buildSessionRecord(badEvents);
+    expect(record.eventCount).toBe(2);
     expect(record.startedAt).toBe('2026-01-01T00:00:00.000Z');
     expect(record.updatedAt).toBe('2026-01-01T00:00:00.000Z');
   });
@@ -98,6 +99,6 @@ describe('replay-store', () => {
 
   it('parseReplay throws on corrupt-partial fixture (corrupt line)', () => {
     const raw = readFileSync(join(REPLAY_FIXTURES, 'corrupt-partial.replay.jsonl'), 'utf8');
-    expect(() => parseReplay(raw)).toThrow(/line/i);
+    expect(() => parseReplay(raw)).toThrow(/line\s*3/i);
   });
 });

--- a/shadow-agent/tests/transcript-adapter.test.ts
+++ b/shadow-agent/tests/transcript-adapter.test.ts
@@ -1,9 +1,11 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { parseClaudeTranscriptJsonl } from '../src/shared/transcript-adapter';
 
-const FIXTURES = join(import.meta.dirname, 'fixtures/transcripts');
+const FIXTURE_DIR = fileURLToPath(new URL('.', import.meta.url));
+const FIXTURES = join(FIXTURE_DIR, 'fixtures/transcripts');
 
 describe('parseClaudeTranscriptJsonl', () => {
   it('converts text, tool_use, and tool_result blocks into canonical events deterministically', () => {

--- a/shadow-agent/tests/transcript-adapter.test.ts
+++ b/shadow-agent/tests/transcript-adapter.test.ts
@@ -45,9 +45,8 @@ describe('parseClaudeTranscriptJsonl', () => {
     ].join('\n');
 
     const events = parseClaudeTranscriptJsonl(raw);
-    expect(events.some((e) => e.kind === 'message')).toBe(true);
-    // Should still produce events from valid lines
-    expect(events.length).toBeGreaterThan(0);
+    const messageEvents = events.filter((e) => e.kind === 'message');
+    expect(messageEvents).toHaveLength(2);
   });
 
   it('returns no events for completely empty input', () => {
@@ -138,8 +137,11 @@ describe('parseClaudeTranscriptJsonl', () => {
     ].join('\n');
     const events = parseClaudeTranscriptJsonl(raw);
     const sessionIds = [...new Set(events.map((e) => e.sessionId))];
-    // Last sessionId wins for new events after the change
+    const sessionEnded = [...events].reverse().find((event) => event.kind === 'session_ended');
+
+    expect(sessionIds).toContain('first-session');
     expect(sessionIds).toContain('second-session');
+    expect(sessionEnded?.sessionId).toBe('second-session');
   });
 
   it('parses the happy-path fixture without errors', () => {

--- a/shadow-agent/tests/transcript-adapter.test.ts
+++ b/shadow-agent/tests/transcript-adapter.test.ts
@@ -1,5 +1,9 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { parseClaudeTranscriptJsonl } from '../src/shared/transcript-adapter';
+
+const FIXTURES = join(import.meta.dirname, 'fixtures/transcripts');
 
 describe('parseClaudeTranscriptJsonl', () => {
   it('converts text, tool_use, and tool_result blocks into canonical events deterministically', () => {
@@ -27,5 +31,135 @@ describe('parseClaudeTranscriptJsonl', () => {
     expect(events.some((event) => event.kind === 'tool_failed')).toBe(true);
     expect(events.at(-1)?.kind).toBe('session_ended');
     expect(secondRunEvents).toEqual(events);
+  });
+
+  // ── edge cases ────────────────────────────────────────────────────────────
+
+  it('skips malformed JSON lines without aborting the parse', () => {
+    const raw = [
+      JSON.stringify({ sessionId: 's1', message: { role: 'user', content: 'hello' } }),
+      'THIS IS NOT JSON',
+      JSON.stringify({ sessionId: 's1', message: { role: 'assistant', content: 'hi' } }),
+    ].join('\n');
+
+    const events = parseClaudeTranscriptJsonl(raw);
+    expect(events.some((e) => e.kind === 'message')).toBe(true);
+    // Should still produce events from valid lines
+    expect(events.length).toBeGreaterThan(0);
+  });
+
+  it('returns no events for completely empty input', () => {
+    expect(parseClaudeTranscriptJsonl('')).toHaveLength(0);
+    expect(parseClaudeTranscriptJsonl('   \n\n  ')).toHaveLength(0);
+  });
+
+  it('handles content as a plain string (not array)', () => {
+    const raw = JSON.stringify({
+      sessionId: 's1',
+      message: { role: 'user', content: 'Just a plain string message.' }
+    });
+    const events = parseClaudeTranscriptJsonl(raw);
+    const msgEvent = events.find((e) => e.kind === 'message');
+    expect(msgEvent).toBeDefined();
+    expect(msgEvent?.payload.text).toBe('Just a plain string message.');
+    expect(msgEvent?.actor).toBe('user');
+  });
+
+  it('maps tool_result with is_error=false to tool_completed', () => {
+    const raw = JSON.stringify({
+      sessionId: 's1',
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'tu-1', content: 'ok', is_error: false }]
+      }
+    });
+    const events = parseClaudeTranscriptJsonl(raw);
+    expect(events.some((e) => e.kind === 'tool_completed')).toBe(true);
+    expect(events.some((e) => e.kind === 'tool_failed')).toBe(false);
+  });
+
+  it('maps tool_result with is_error=true to tool_failed', () => {
+    const raw = JSON.stringify({
+      sessionId: 's1',
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'tu-1', content: 'err', is_error: true }]
+      }
+    });
+    const events = parseClaudeTranscriptJsonl(raw);
+    expect(events.some((e) => e.kind === 'tool_failed')).toBe(true);
+  });
+
+  it('silently skips unknown block types', () => {
+    const raw = JSON.stringify({
+      sessionId: 's1',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Real message.' },
+          { type: 'unknown_future_block_type', data: {} },
+        ]
+      }
+    });
+    // Should not throw; unknown block just produces no event
+    const events = parseClaudeTranscriptJsonl(raw);
+    expect(events.some((e) => e.kind === 'message')).toBe(true);
+  });
+
+  it('includes thinking blocks as message events', () => {
+    const raw = JSON.stringify({
+      sessionId: 's1',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'This is my reasoning...' },
+          { type: 'text', text: 'My response.' },
+        ]
+      }
+    });
+    const events = parseClaudeTranscriptJsonl(raw);
+    const messages = events.filter((e) => e.kind === 'message');
+    expect(messages.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('always appends session_ended as the last event', () => {
+    const raw = JSON.stringify({ sessionId: 's1', message: { role: 'user', content: 'hi' } });
+    const events = parseClaudeTranscriptJsonl(raw);
+    expect(events.at(-1)?.kind).toBe('session_ended');
+    expect(events.at(-1)?.actor).toBe('system');
+  });
+
+  it('captures sessionId changes across lines', () => {
+    const raw = [
+      JSON.stringify({ sessionId: 'first-session', message: { role: 'user', content: 'hello' } }),
+      JSON.stringify({ sessionId: 'second-session', message: { role: 'user', content: 'world' } }),
+    ].join('\n');
+    const events = parseClaudeTranscriptJsonl(raw);
+    const sessionIds = [...new Set(events.map((e) => e.sessionId))];
+    // Last sessionId wins for new events after the change
+    expect(sessionIds).toContain('second-session');
+  });
+
+  it('parses the happy-path fixture without errors', () => {
+    const raw = readFileSync(join(FIXTURES, 'happy-path.jsonl'), 'utf8');
+    const events = parseClaudeTranscriptJsonl(raw);
+    expect(events.some((e) => e.kind === 'session_started')).toBe(true);
+    expect(events.some((e) => e.kind === 'tool_started')).toBe(true);
+    expect(events.some((e) => e.kind === 'tool_completed')).toBe(true);
+    expect(events.at(-1)?.kind).toBe('session_ended');
+  });
+
+  it('parses the risk-escalation fixture and produces tool_failed events', () => {
+    const raw = readFileSync(join(FIXTURES, 'risk-escalation.jsonl'), 'utf8');
+    const events = parseClaudeTranscriptJsonl(raw);
+    const failures = events.filter((e) => e.kind === 'tool_failed');
+    expect(failures.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('parses the tool-heavy fixture and produces multiple tool events', () => {
+    const raw = readFileSync(join(FIXTURES, 'tool-heavy.jsonl'), 'utf8');
+    const events = parseClaudeTranscriptJsonl(raw);
+    const toolEvents = events.filter((e) => e.kind === 'tool_started' || e.kind === 'tool_completed');
+    expect(toolEvents.length).toBeGreaterThanOrEqual(8);
   });
 });


### PR DESCRIPTION
## Summary

Implements two testing issues against main.

### Issue #25 — Shared replay fixture corpus
- \	ests/fixtures/README.md\: describes each fixture + regeneration process
- **Transcript fixtures** (Claude JSONL format): happy-path, tool-heavy, risk-escalation, subagent-flow
- **Replay fixtures** (canonical JSONL format): happy-path, subagent-flow, risk-escalation, corrupt-partial

### Issue #20 — Phase 1 edge coverage
**transcript-adapter.test.ts** (12 new tests):
- Malformed JSON lines skipped without aborting
- Empty input, plain-string content, unknown block types, thinking blocks
- \is_error=false\ → \	ool_completed\; \is_error=true\ → \	ool_failed\
- session_ended always last; sessionId changes across lines
- Fixture-based: happy-path, risk-escalation, tool-heavy

**derive.test.ts** (20 new tests):
- Empty state, phase precedence (write>plan>bash>read), bash-churn risk, exploration-volume risk
- All 3 file-path payload keys (\ilePath\, \ile_path\, \path\)
- Agent node state transitions + toolCount tracking
- Fixture-based: happy-path, risk-escalation, subagent-flow replays

**replay-store.test.ts** (6 new tests):
- Empty array, invalid timestamps, one-JSON-line-per-event
- Single corrupt line throws with line number; fixture round-trip; corrupt-partial throws

**persistence.test.ts** (4 new tests):
- loadSession on nonexistent → throws; listSessions on fresh store → []; empty event list; special characters in session ID

**tests/phase1-integration.test.ts** (new, 8 tests):
- Full pipeline: transcript JSONL → parseClaudeTranscriptJsonl → deriveState()
- Full pipeline: replay JSONL → parseReplay → deriveState()
- All 4 fixtures exercised; asserts phase, risk signals, file attention, agent nodes

All 74 tests pass.

Closes #20, #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR adds a shared test fixture corpus and comprehensive Phase 1 edge-coverage tests to improve robustness across the shadow-agent pipeline. It establishes deterministic test fixtures and 74 passing tests covering malformed input handling, state transitions, risk signal detection, and end-to-end integration scenarios.

## Fixture Corpus

Added `tests/fixtures/` directory with documentation and normalized test data:

### Documentation
| File | Purpose |
|------|---------|
| `fixtures/README.md` | Fixture management guide explaining regeneration procedures and schema versioning |

### Transcript Fixtures (Claude Code JSONL format)
| Fixture | Events | Scenario |
|---------|--------|----------|
| `transcripts/happy-path.jsonl` | 5 | User requests logger utility; assistant reads helper, writes logger.ts |
| `transcripts/tool-heavy.jsonl` | 20+ | CI debugging with multiple tool calls (read, grep, test, lint) |
| `transcripts/risk-escalation.jsonl` | 12 | Database migration failure with sequential bash errors |
| `transcripts/subagent-flow.jsonl` | 8 | E2E test delegation with subagent orchestration |

### Replay Fixtures (Canonical JSONL format)
| Fixture | Events | Scenario |
|---------|--------|----------|
| `replays/happy-path.replay.jsonl` | 9 | Session lifecycle: read util → write logger → complete |
| `replays/risk-escalation.replay.jsonl` | 12 | Bash tool failures with escalating risk signals |
| `replays/subagent-flow.replay.jsonl` | 13 | Parent-child agent execution and tool orchestration |
| `replays/corrupt-partial.replay.jsonl` | 3 | Data corruption edge case (2 valid + 1 malformed line) |

## Test Coverage

### New Test Files & Coverage

| Module | File | Tests | Key Coverage Areas |
|--------|------|-------|-------------------|
| **Parsing** | `transcript-adapter.test.ts` | 12 | Malformed JSON resilience; unknown block types; thinking blocks; session finalization; error→tool_failed mapping |
| **State Derivation** | `derive.test.ts` | 20 | Empty state; phase precedence (Write > Plan > Bash > Read); bash churn (≥4) and exploration-volume (≥6) risk thresholds; file-path payload key variants (filePath, file_path, path); agent lifecycle and tool counting; fixture round-trips |
| **Replay Parsing** | `replay-store.test.ts` | 6 | Empty array handling; invalid timestamps; JSON-line-per-event format; corrupt-line error reporting with line numbers; fixture round-trip verification |
| **Persistence** | `persistence.test.ts` | 4 | Nonexistent session handling (ENOENT); empty store listing; empty event lists; special-character session ID encoding |
| **Integration** | `phase1-integration.test.ts` | 8 | End-to-end transcript JSONL → derived state assertions; end-to-end replay JSONL → derived state assertions; phase/risk/file-attention validation across all fixtures |

### Test Utilities

- **`makeEvent()`** helper in `derive.test.ts`: Generates deterministic `CanonicalEvent` instances with auto-incrementing timestamps for reproducible scenario testing

### Metrics

| Metric | Count |
|--------|-------|
| **Total tests added** | 74 (all passing) |
| **Fixture files** | 8 (4 transcripts, 4 replays) |
| **Lines added** | ~650 |
| **Coverage objectives addressed** | 5/5 (parsing, derive, replay-store, persistence, integration) |

## Key Behaviors Validated

### Risk Signal Detection
- **Bash churn**: Triggered at ≥4 bash tool invocations
- **Exploration volume**: Triggered at ≥6 read/grep/glob operations
- **Failed tools**: Detected via `is_error=true` → `tool_failed` mapping

### Phase Precedence
Write/Edit → Plan/TodoRead → Bash → Read/Grep/Glob (explicitly tested for conflicts)

### File Attention Aggregation
Descending sort by touch count across multiple payload keys (`filePath`, `file_path`, `path`)

### Agent Orchestration
Parent-child agent lifecycle with spawned→idle→completed state transitions and per-agent tool counting

## Linked Issues Resolved
- **#20**: Edge coverage across Phase 1 pipeline ✓
- **#25**: Deterministic fixture corpus ✓

<!-- end of auto-generated comment: release notes by coderabbit.ai -->