### PR TITLE
feat: pluggable capture transport system for shadow-agent

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,8 +35,9 @@ Shadow-agent runs its own AI model alongside the observed agent. We use **OpenCo
 (`third_party/sidecar/`) already solved this exact problem — its `opencode-client.js` is
 the complete pattern. OpenCode gives us provider abstraction for free: the user can use
 Claude, GPT-4, Gemini, or any OpenRouter model without shadow-agent caring. If the user
-already has OpenCode configured, shadow-agent inherits credentials automatically with zero
-additional auth setup.
+already has OpenCode configured, shadow-agent can reuse those provider keys through the
+legacy auth files, but only after the user explicitly opts into that file-based fallback
+path for migration.
 
 When OpenCode isn't available, we fall back to the Anthropic SDK directly. The auth chain
 loads credentials in priority order: `process.env` →
@@ -44,7 +45,8 @@ loads credentials in priority order: `process.env` →
 legacy file-based fallbacks when `SHADOW_ALLOW_FILE_CREDENTIAL_FALLBACK=1` is explicitly set.
 Those legacy fallbacks are `~/.shadow-agent/.env` and `~/.local/share/opencode/auth.json`.
 When consented legacy credentials are loaded, shadow-agent migrates supported provider keys
-into the encrypted store for future runs.
+into the encrypted store for future runs, so continued plaintext reads are not the steady
+state.
 
 On POSIX systems, `~/.shadow-agent/` should be owner-only (`0700`) and
 `credentials.enc.json` should be read/write for the owner only (`0600`). On Windows,
@@ -65,17 +67,18 @@ budget.
 
 ## Event Capture
 
-We watch Claude Code's JSONL transcript files via a filesystem watcher. This is the
-simplest reliable approach — Claude Code writes JSONL, we tail it. No need to configure
-hooks on the observed agent's side. Events are parsed incrementally, normalized into
-`CanonicalEvent` objects, and streamed to the renderer via IPC through a bounded event
-queue with a hot in-memory window, spill-to-disk persistence, and per-consumer checkpoints.
+Event capture is now transport-pluggable. The default path still watches Claude Code JSONL
+files via a filesystem tailer, but the runtime can also ingest streaming HTTP, WebSocket,
+and raw socket feeds through the same parser → normalizer → queue → IPC pipeline.
 
-An HTTP hook server may come later (Phase 3+) for lower latency, but the architecture
-is transport-agnostic — the buffer and IPC bridge don't care where events come from.
+The file-tail path remains the simplest zero-config option for Claude transcripts, and it
+now adds checksum-based rotation detection so replaced transcript files replay cleanly even
+when the filename stays the same. Network transports trade that convenience for lower-latency
+or externally pushed event delivery without changing the downstream consumers.
 
-We rejected HTTP hook server for Phase 2 (more complex, requires observed agent
-configuration) and direct process attachment (fragile, platform-specific).
+We rejected direct process attachment (fragile, platform-specific). All supported transports
+feed the same bounded event queue with a hot in-memory window, spill-to-disk persistence,
+and per-consumer checkpoints.
 
 → See [`docs/domain-events.md`](domain-events.md) for the event domain: transcript
 watcher, canonical schema, normalizer, session discovery, IPC bridge.
@@ -135,7 +138,8 @@ remaining optional harness work is either implemented or explicitly deferred.
   `ShadowContextPacket` type and `buildUserMessage`), response parser, trigger logic,
   shadow inference engine orchestrator, direct Anthropic API fallback, and MCP server.
   Landed on main via PR #28, #32, and follow-up hardening work on 2026-04-20. OpenCode
-  client remains the main deferred item.
+  client and provider selection ship via `opencode-client.ts` and
+  `inference-client-factory.ts` (OpenCode first, Anthropic fallback).
 - **Live Event Capture**: `fs.watch` transcript tailing, bounded event queue, IPC bridge,
   and session manager landed on main via PR #27.
 - **Advanced Rendering**: Canvas2D + D3-Force renderer, overlay panels, and host abstraction

--- a/docs/domain-events.md
+++ b/docs/domain-events.md
@@ -82,17 +82,22 @@ snapshot via `ipcMain.handle('shadow:snapshot')` or incremental catch-up via
 
 Canvas redraws are governed by requestAnimationFrame (max 60fps, natural throttle).
 
-## Adapters (Future)
+## Capture Transports
 
 The architecture is transport-agnostic. The buffer and IPC bridge don't care where events
-come from. Planned adapters beyond the JSONL watcher:
+come from, and the live runtime now supports multiple capture transports:
 
-- **HTTP hook server** (Phase 3): Express/Hono on localhost:4098, accepts Claude Code
-  hook POSTs, normalizes through the same pipeline. Lower latency than file watching.
-- **Codex adapter**: Parse Codex CLI transcripts into CanonicalEvent.
-- **OpenCode adapter**: Parse OpenCode session files.
+- **File-tail**: Watches Claude Code JSONL files, tracks byte offsets, fingerprints the
+  head of the file, and resets cleanly on truncation or rotation.
+- **Streaming HTTP**: Connects to a long-lived HTTP response body and reads incremental
+  NDJSON chunks with reconnect handling.
+- **WebSocket**: Consumes framed messages, normalizes them into parser-friendly chunks,
+  and reconnects after disconnects.
+- **Socket**: Reads raw TCP streams, applies light backpressure-aware pausing, and
+  reconnects after disconnects.
 
-Each adapter implements the same normalizer interface and pushes into the shared buffer.
+Each transport feeds the same incremental parser and normalizer pipeline so the downstream
+event buffer, IPC bridge, renderer, and inference consumers stay unchanged.
 
 ## File Map
 

--- a/docs/domain-inference.md
+++ b/docs/domain-inference.md
@@ -1,11 +1,10 @@
 # Domain: Inference Engine
 
-> **Status: Core runtime landed on main** — Auth loader (`auth.ts`), context packager
-> (`context-packager.ts` with `packContext`), prompt builder (`prompt-builder.ts`
-> exporting `ShadowContextPacket` and `buildUserMessage`), response parser, inference
-> trigger, shadow inference engine orchestrator, direct Anthropic API fallback, and
-> MCP server are implemented and covered by tests. The OpenCode client
-> (`opencode-client.ts`) remains planned work; direct Anthropic API is the current runtime path.
+> **Status: Landed on main** — Auth loader, context packager, prompt builder, response
+> parser, inference trigger, orchestrator, OpenCode client (`opencode-client.ts`),
+> provider selection (`inference-client-factory.ts`), direct Anthropic fallback, and
+> MCP server are on main. Runtime order: OpenCode when the SDK starts, otherwise
+> direct Anthropic (`SHADOW_INFERENCE_PROVIDER` can force either path).
 
 The inference engine is shadow-agent's brain — it consumes the observed agent's event
 stream and produces structured interpretations (phase, risk, predictions, confidence).
@@ -17,19 +16,20 @@ Prompt source: `prompts/shadow-system-prompt.json`
 
 ## OpenCode Harness
 
-The intended primary harness is `@opencode-ai/sdk`, copied almost verbatim from sidecar's
-`opencode-client.js`. That path is still planned work. Once implemented, it gives us
-provider abstraction for free — the user authenticates once and can use Claude, GPT-4,
-Gemini, or any OpenRouter model as the interpretation engine. The current shipped runtime
-path is the direct Anthropic client plus the provider-agnostic interfaces that keep the
-OpenCode slot ready.
+The primary harness is `@opencode-ai/sdk` via `src/inference/opencode-client.ts`, which
+starts a local OpenCode server on port 4097, creates a session, sends structured prompts,
+and polls for completion. `createInferenceClient()` in `inference-client-factory.ts` tries
+OpenCode first unless `SHADOW_INFERENCE_PROVIDER=anthropic` or `direct` is set.
 
-When OpenCode isn't installed, we fall back to `@anthropic-ai/sdk` directly. Simpler
-(no session management, no polling) but locks to Anthropic only.
+When the SDK is unavailable or the server fails to start, we fall back to
+`@anthropic-ai/sdk` through `src/inference/direct-api.ts` (Anthropic-only, no session
+management).
 
 Inference delivery is local-only by default. Before any prompt is sent off-host, the user
 must explicitly opt in. Sanitized transcript content is the default payload, and raw
-transcript delivery requires a separate explicit opt-in.
+transcript delivery requires a separate explicit opt-in. The Electron shell persists those
+privacy toggles in `~/.shadow-agent/privacy.json`; environment variables still override the
+saved file when present.
 
 ## Auth Chain
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -64,6 +64,17 @@ Permission guidance:
 - Windows: leave the store inside your user profile so standard per-user ACLs protect it
 - Do not place credential files in shared folders, synced team drives, or repo working trees
 
+## Privacy Controls
+
+Shadow-agent starts in local-only mode. The Electron app's Privacy panel lets you explicitly opt in to:
+
+- off-host shadow inference
+- raw transcript storage/export
+
+Those toggles persist to `~/.shadow-agent/privacy.json`. If you set
+`SHADOW_ALLOW_OFF_HOST_INFERENCE` or `SHADOW_ALLOW_RAW_TRANSCRIPT_STORAGE`, the environment
+variables override the saved file for that run.
+
 ## Project Structure
 
 - `shadow-agent/src/electron/`: Main process code, including IPC handling, session management, and file loading.

--- a/docs/plans/plan-master-a-must-do.md
+++ b/docs/plans/plan-master-a-must-do.md
@@ -169,6 +169,6 @@ After merge sequence completes:
 - [x] `docs/todo.md` reconciled, `docs/history/log.md` current (drift-remediation pass)
 - [x] Remaining open PRs (#26 canvas renderer, #27 live capture, #30 observability, #33 docs finish-line) were addressed and merged on 2026-04-20
 - [x] #26 and #27 merged to main — the core product feature lines are shipped
-- [ ] Issues #21 and #24 implemented via new PRs and merged (blocked on #26/#27)
-- [ ] All 18 original issues (#8-#25) closed
+- [x] Issues #21 and #24 implemented and merged (2026-04-20, via PRs #26/#27 follow-up work)
+- [x] All 18 original issues (#8-#25) closed (2026-04-20)
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -5,9 +5,6 @@
 
 ## Implementation
 
-- 2026-04-13: **Wire Three.js dot-grid background** — Optional Citadel-style canvas dot-grid OR @react-three/fiber ParticleField as Layer 0 behind the Canvas2D visualization. Subtle parallax, very low opacity. LOW PRIORITY — canvas looks fine without it.
-
-- 2026-04-01: **Implement OpenCode inference client** — Create `src/inference/opencode-client.ts`. Copy sidecar's `opencode-client.js`. Start server, create session, send prompt, poll completion. Not yet implemented — direct Anthropic API fallback exists as an interim path.
 
 ## Testing
 

--- a/shadow-agent/README.md
+++ b/shadow-agent/README.md
@@ -28,7 +28,8 @@ Shadow-agent runs in local-only mode by default.
 - Off-host inference stays disabled until the user explicitly opts in.
 - Raw transcript storage/export requires its own explicit opt-in.
 
-Opt in through process environment variables or `~/.shadow-agent/.env`:
+The Electron app exposes these consent gates in its Privacy panel and persists them locally in
+`~/.shadow-agent/privacy.json`. Environment variables still work and override the saved file:
 
 ```bash
 SHADOW_ALLOW_OFF_HOST_INFERENCE=true

--- a/shadow-agent/package-lock.json
+++ b/shadow-agent/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.91.1",
+        "@opencode-ai/sdk": "^1.15.5",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@react-spring/web": "^9.7.5",
@@ -944,6 +945,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.15.5.tgz",
+      "integrity": "sha512-ozJuEmXzrOvia5n0L1KAuvpyf9ESGmTk1FiPhn0RK5X1whbzjlTXL0NAxqNCEkqETxL35jS1KHArEiTpvtJ6FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2520,7 +2530,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3219,7 +3228,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -3577,7 +3585,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3933,7 +3940,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -3946,7 +3952,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5015,7 +5020,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/shadow-agent/package.json
+++ b/shadow-agent/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.91.1",
+    "@opencode-ai/sdk": "^1.15.5",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@react-spring/web": "^9.7.5",

--- a/shadow-agent/src/capture/capture-transport.ts
+++ b/shadow-agent/src/capture/capture-transport.ts
@@ -1,0 +1,75 @@
+import type { EventQueueBackpressureState, EventSource } from '../shared/schema';
+
+export type CaptureTransportKind = 'file-tail' | 'http-stream' | 'websocket' | 'socket';
+export type CaptureTransportResetReason = 'rotation' | 'truncation' | 'reconnect';
+
+export interface CaptureSession {
+  sessionId: string;
+  label: string;
+  source: EventSource;
+  path?: string;
+  transportId: string;
+}
+
+export interface CaptureChunk {
+  session: CaptureSession;
+  chunk: string;
+}
+
+export interface CaptureTransportContext {
+  getBackpressure(): EventQueueBackpressureState;
+  onSessionStarted(session: CaptureSession): Promise<void> | void;
+  onSessionReset(session: CaptureSession, reason: CaptureTransportResetReason): Promise<void> | void;
+  onChunk(chunk: CaptureChunk): Promise<void> | void;
+}
+
+export interface CaptureTransportSubscription {
+  stop(): void | Promise<void>;
+}
+
+export interface CaptureTransport {
+  readonly id: string;
+  readonly kind: CaptureTransportKind;
+  start(context: CaptureTransportContext): Promise<CaptureTransportSubscription>;
+}
+
+export interface FileTailCaptureTransportOptions {
+  kind: 'file-tail';
+  overridePath?: string;
+  discoveryIntervalMs?: number;
+  fingerprintBytes?: number;
+}
+
+export interface HttpStreamCaptureTransportOptions {
+  kind: 'http-stream';
+  url: string;
+  headers?: Record<string, string>;
+  reconnectDelayMs?: number;
+  sessionId?: string;
+  sessionLabel?: string;
+}
+
+export interface WebSocketCaptureTransportOptions {
+  kind: 'websocket';
+  url: string;
+  protocols?: string | string[];
+  reconnectDelayMs?: number;
+  sessionId?: string;
+  sessionLabel?: string;
+}
+
+export interface SocketCaptureTransportOptions {
+  kind: 'socket';
+  host: string;
+  port: number;
+  reconnectDelayMs?: number;
+  sessionId?: string;
+  sessionLabel?: string;
+}
+
+export type CaptureTransportOptions =
+  | FileTailCaptureTransportOptions
+  | HttpStreamCaptureTransportOptions
+  | WebSocketCaptureTransportOptions
+  | SocketCaptureTransportOptions;
+

--- a/shadow-agent/src/capture/capture-transports.ts
+++ b/shadow-agent/src/capture/capture-transports.ts
@@ -1,0 +1,95 @@
+import type { CaptureTransport, CaptureTransportOptions, HttpStreamCaptureTransportOptions, SocketCaptureTransportOptions, WebSocketCaptureTransportOptions } from './capture-transport';
+import { createHttpStreamCaptureTransport } from './http-stream-transport';
+import { createSocketCaptureTransport } from './socket-transport';
+import { createFileTailCaptureTransport } from './transcript-watcher';
+import { createWebSocketCaptureTransport } from './websocket-transport';
+
+const DEFAULT_CAPTURE_TRANSPORT = 'file-tail';
+
+function parseReconnectDelayMs(raw: string | undefined): number | undefined {
+  if (!raw?.trim()) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return undefined;
+  }
+  return parsed;
+}
+
+function requiredEnv(value: string | undefined, variableName: string): string {
+  if (value && value.trim()) {
+    return value.trim();
+  }
+  throw new Error(`Missing required capture environment variable: ${variableName}`);
+}
+
+function parsePort(raw: string | undefined): number {
+  const port = Number.parseInt(requiredEnv(raw, 'SHADOW_CAPTURE_SOCKET_PORT'), 10);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(`Invalid SHADOW_CAPTURE_SOCKET_PORT: ${raw ?? '<unset>'}`);
+  }
+  return port;
+}
+
+export function resolveCaptureTransportOptionsFromEnv(
+  env: NodeJS.ProcessEnv = process.env
+): CaptureTransportOptions {
+  const kind = (env.SHADOW_CAPTURE_TRANSPORT ?? DEFAULT_CAPTURE_TRANSPORT).trim().toLowerCase();
+
+  switch (kind) {
+    case 'file-tail':
+      return {
+        kind: 'file-tail',
+        overridePath: env.SHADOW_CAPTURE_FILE?.trim() || undefined
+      };
+    case 'http':
+    case 'http-stream':
+      return {
+        kind: 'http-stream',
+        url: requiredEnv(
+          env.SHADOW_CAPTURE_HTTP_URL ?? env.SHADOW_CAPTURE_TARGET,
+          'SHADOW_CAPTURE_HTTP_URL or SHADOW_CAPTURE_TARGET'
+        ),
+        reconnectDelayMs: parseReconnectDelayMs(env.SHADOW_CAPTURE_RECONNECT_MS),
+        sessionId: env.SHADOW_CAPTURE_SESSION_ID?.trim() || undefined,
+        sessionLabel: env.SHADOW_CAPTURE_SESSION_LABEL?.trim() || undefined
+      } satisfies HttpStreamCaptureTransportOptions;
+    case 'ws':
+    case 'websocket':
+      return {
+        kind: 'websocket',
+        url: requiredEnv(
+          env.SHADOW_CAPTURE_WS_URL ?? env.SHADOW_CAPTURE_TARGET,
+          'SHADOW_CAPTURE_WS_URL or SHADOW_CAPTURE_TARGET'
+        ),
+        reconnectDelayMs: parseReconnectDelayMs(env.SHADOW_CAPTURE_RECONNECT_MS),
+        sessionId: env.SHADOW_CAPTURE_SESSION_ID?.trim() || undefined,
+        sessionLabel: env.SHADOW_CAPTURE_SESSION_LABEL?.trim() || undefined
+      } satisfies WebSocketCaptureTransportOptions;
+    case 'socket':
+      return {
+        kind: 'socket',
+        host: requiredEnv(env.SHADOW_CAPTURE_SOCKET_HOST, 'SHADOW_CAPTURE_SOCKET_HOST'),
+        port: parsePort(env.SHADOW_CAPTURE_SOCKET_PORT),
+        reconnectDelayMs: parseReconnectDelayMs(env.SHADOW_CAPTURE_RECONNECT_MS),
+        sessionId: env.SHADOW_CAPTURE_SESSION_ID?.trim() || undefined,
+        sessionLabel: env.SHADOW_CAPTURE_SESSION_LABEL?.trim() || undefined
+      } satisfies SocketCaptureTransportOptions;
+    default:
+      throw new Error(`Unsupported SHADOW_CAPTURE_TRANSPORT: ${kind}`);
+  }
+}
+
+export function createCaptureTransport(options: CaptureTransportOptions): CaptureTransport {
+  switch (options.kind) {
+    case 'file-tail':
+      return createFileTailCaptureTransport(options);
+    case 'http-stream':
+      return createHttpStreamCaptureTransport(options);
+    case 'websocket':
+      return createWebSocketCaptureTransport(options);
+    case 'socket':
+      return createSocketCaptureTransport(options);
+  }
+}

--- a/shadow-agent/src/capture/event-buffer.ts
+++ b/shadow-agent/src/capture/event-buffer.ts
@@ -17,6 +17,11 @@ import type {
   EventQueueMetrics
 } from '../shared/schema';
 import { createLogger } from '../shared/logger';
+import {
+  DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS,
+  prepareEventsForStorage,
+  type TranscriptPrivacySettings
+} from '../shared/privacy';
 
 const logger = createLogger({ minLevel: 'info' });
 
@@ -45,6 +50,7 @@ export interface EventBufferOptions {
   highWatermark?: number;
   criticalWatermark?: number;
   sessionId?: string;
+  getPrivacy?: () => TranscriptPrivacySettings;
 }
 
 export type EventSubscriber = (events: CanonicalEvent[], metrics: EventQueueMetrics) => void;
@@ -126,14 +132,30 @@ async function readSpillFile(filePath: string): Promise<EventEnvelope[]> {
   }
 }
 
-async function writeSpillFile(filePath: string, envelopes: EventEnvelope[]): Promise<void> {
+async function writeSpillFile(
+  filePath: string,
+  envelopes: EventEnvelope[],
+  privacy: TranscriptPrivacySettings
+): Promise<void> {
   if (envelopes.length === 0) {
     await rm(filePath, { force: true });
     return;
   }
 
   await mkdir(path.dirname(filePath), { recursive: true });
-  const payload = `${envelopes.map((envelope) => JSON.stringify(envelope)).join('\n')}\n`;
+  const sanitizedEvents = prepareEventsForStorage(
+    envelopes.map((envelope) => envelope.event),
+    privacy,
+    { storeRawTranscript: privacy.allowRawTranscriptStorage }
+  );
+  const payload = `${envelopes
+    .map((envelope, index) =>
+      JSON.stringify({
+        ...envelope,
+        event: sanitizedEvents[index] ?? envelope.event
+      })
+    )
+    .join('\n')}\n`;
   await writeFile(filePath, payload, 'utf8');
 }
 
@@ -170,6 +192,7 @@ export function createEventBuffer(capacityOrOptions: number | EventBufferOptions
   const persistenceRoot = options.persistenceRoot ?? DEFAULT_PERSISTENCE_ROOT;
   const highWatermark = clampRatio(options.highWatermark ?? DEFAULT_HIGH_WATERMARK);
   const criticalWatermark = Math.max(highWatermark, clampRatio(options.criticalWatermark ?? DEFAULT_CRITICAL_WATERMARK));
+  const getPrivacy = options.getPrivacy ?? (() => DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS);
   const subscribers = new Set<EventSubscriber>();
   const consumerDefaults = new Map<string, { startAt: 'latest' | 'earliest' }>();
   const checkpoints = new Map<string, EventQueueCheckpoint>();
@@ -404,7 +427,7 @@ export function createEventBuffer(capacityOrOptions: number | EventBufferOptions
         }
 
         if (spilledCount > 0 || droppedCount > 0 || spilledDepth > 0) {
-          await writeSpillFile(spillPath(), spilled);
+          await writeSpillFile(spillPath(), spilled, getPrivacy());
         }
 
         updateOffsets(spilled);

--- a/shadow-agent/src/capture/event-buffer.ts
+++ b/shadow-agent/src/capture/event-buffer.ts
@@ -17,11 +17,8 @@ import type {
   EventQueueMetrics
 } from '../shared/schema';
 import { createLogger } from '../shared/logger';
-import {
-  DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS,
-  prepareEventsForStorage,
-  type TranscriptPrivacySettings
-} from '../shared/privacy';
+import { DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS, prepareEventsForStorage } from '../shared/privacy';
+import type { TranscriptPrivacySettings } from '../shared/schema';
 
 const logger = createLogger({ minLevel: 'info' });
 

--- a/shadow-agent/src/capture/http-stream-transport.ts
+++ b/shadow-agent/src/capture/http-stream-transport.ts
@@ -1,0 +1,131 @@
+import { createLogger } from '../shared/logger';
+import type {
+  CaptureSession,
+  CaptureTransport,
+  CaptureTransportContext,
+  CaptureTransportSubscription,
+  HttpStreamCaptureTransportOptions
+} from './capture-transport';
+
+const logger = createLogger({ minLevel: 'info' });
+const DEFAULT_RECONNECT_DELAY_MS = 1_000;
+
+function buildSession(options: HttpStreamCaptureTransportOptions): CaptureSession {
+  const url = new URL(options.url);
+  return {
+    sessionId: options.sessionId ?? `http-stream-${url.host}`,
+    label: options.sessionLabel ?? `Live HTTP: ${url.host}`,
+    source: 'claude-hook',
+    path: options.url,
+    transportId: 'http-stream'
+  };
+}
+
+export function createHttpStreamCaptureTransport(
+  options: HttpStreamCaptureTransportOptions
+): CaptureTransport {
+  return {
+    id: 'http-stream',
+    kind: 'http-stream',
+    async start(context: CaptureTransportContext): Promise<CaptureTransportSubscription> {
+      const session = buildSession(options);
+      const reconnectDelayMs = Math.max(50, options.reconnectDelayMs ?? DEFAULT_RECONNECT_DELAY_MS);
+
+      let abortController: AbortController | null = null;
+      let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+      let stopped = false;
+      let hasConnected = false;
+
+      const clearReconnectTimer = () => {
+        if (reconnectTimer) {
+          clearTimeout(reconnectTimer);
+          reconnectTimer = null;
+        }
+      };
+
+      const scheduleReconnect = () => {
+        if (stopped || reconnectTimer) {
+          return;
+        }
+        reconnectTimer = setTimeout(() => {
+          reconnectTimer = null;
+          void connect();
+        }, reconnectDelayMs);
+      };
+
+      const connect = async (): Promise<void> => {
+        if (stopped) {
+          return;
+        }
+
+        const decoder = new TextDecoder();
+        abortController = new AbortController();
+        try {
+          logger.info('capture', 'transport.http_stream.connecting', { url: options.url });
+          const response = await fetch(options.url, {
+            headers: options.headers,
+            signal: abortController.signal
+          });
+
+          if (!response.ok) {
+            throw new Error(`HTTP stream responded with ${response.status} ${response.statusText}`);
+          }
+          if (!response.body) {
+            throw new Error('HTTP stream response did not provide a body.');
+          }
+
+          if (!hasConnected) {
+            await context.onSessionStarted(session);
+            hasConnected = true;
+          } else {
+            await context.onSessionReset(session, 'reconnect');
+          }
+
+          const reader = response.body.getReader();
+          try {
+            while (!stopped) {
+              const { value, done } = await reader.read();
+              if (done) {
+                const trailing = decoder.decode();
+                if (trailing) {
+                  await context.onChunk({ session, chunk: trailing });
+                }
+                break;
+              }
+              if (value && value.byteLength > 0) {
+                await context.onChunk({
+                  session,
+                  chunk: decoder.decode(value, { stream: true })
+                });
+              }
+            }
+          } finally {
+            reader.releaseLock();
+          }
+        } catch (error) {
+          if (!stopped) {
+            logger.warn('capture', 'transport.http_stream.error', { url: options.url, error });
+          }
+        } finally {
+          abortController = null;
+          if (!stopped) {
+            scheduleReconnect();
+          }
+        }
+      };
+
+      void connect();
+
+      return {
+        stop() {
+          stopped = true;
+          clearReconnectTimer();
+          abortController?.abort();
+          abortController = null;
+          logger.info('capture', 'transport.http_stream.stopped', { url: options.url });
+        }
+      };
+    }
+  };
+}
+

--- a/shadow-agent/src/capture/ipc-bridge.ts
+++ b/shadow-agent/src/capture/ipc-bridge.ts
@@ -21,6 +21,7 @@ export interface IpcBridgeOptions {
   getWebContents: () => WebContents | null;
   buildSnapshot: () => Promise<SnapshotPayload | null>;
   privacy?: TranscriptPrivacySettings;
+  getPrivacy?: () => TranscriptPrivacySettings;
 }
 
 export interface IpcBridge {
@@ -29,7 +30,7 @@ export interface IpcBridge {
 
 export function createIpcBridge(opts: IpcBridgeOptions): IpcBridge {
   const { buffer, getWebContents, buildSnapshot } = opts;
-  const privacy = opts.privacy ?? DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS;
+  const getPrivacy = opts.getPrivacy ?? (() => opts.privacy ?? DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS);
 
   return {
     start() {
@@ -58,7 +59,7 @@ export function createIpcBridge(opts: IpcBridgeOptions): IpcBridge {
             return;
           }
 
-          const rendererBatch = prepareEventsForStorage(pending.events, privacy);
+          const rendererBatch = prepareEventsForStorage(pending.events, getPrivacy());
           logger.debug('ipc', 'snapshot.sent', {
             eventCount: rendererBatch.length,
             truncated: pending.truncated

--- a/shadow-agent/src/capture/session-manager.ts
+++ b/shadow-agent/src/capture/session-manager.ts
@@ -1,26 +1,28 @@
 /**
  * Session manager orchestrates the full capture pipeline:
- * session discovery → watcher → incremental parser → normalizer → buffer → IPC bridge
+ * transport → incremental parser → normalizer → buffer → IPC bridge
  *
- * Scans every 30 seconds for new sessions. Tears down the old pipeline when a
- * new session is detected.
+ * The transport decides where bytes come from (file tail, HTTP stream,
+ * WebSocket, socket) and when sessions rotate or reconnect.
  */
 import type { WebContents } from 'electron';
 import { DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS } from '../shared/privacy';
 import type { SnapshotPayload, LoadedSource, TranscriptPrivacySettings } from '../shared/schema';
 import { buildRendererInput } from '../shared/renderer-input-adapter';
-import { discoverActiveSession, type DiscoveredSession } from './session-discovery';
-import { watchTranscript, type TranscriptWatcher } from './transcript-watcher';
 import { createIncrementalParser } from './incremental-parser';
 import { normalizeEntry } from './normalizer';
 import { createEventBuffer, type EventBuffer } from './event-buffer';
 import { createIpcBridge } from './ipc-bridge';
 import { createLogger } from '../shared/logger';
-import { readFile } from 'node:fs/promises';
+import type {
+  CaptureSession,
+  CaptureTransport,
+  CaptureTransportOptions,
+  CaptureTransportSubscription
+} from './capture-transport';
+import { createCaptureTransport } from './capture-transports';
 
 const logger = createLogger({ minLevel: 'info' });
-
-const REDISCOVERY_INTERVAL_MS = 30_000;
 
 export interface SessionManager {
   start(overridePath?: string): Promise<void>;
@@ -33,118 +35,76 @@ export function createSessionManager(
   getWebContents: () => WebContents | null,
   options: {
     privacy?: TranscriptPrivacySettings;
+    getPrivacy?: () => TranscriptPrivacySettings;
     queuePersistenceRoot?: string;
     queueMemoryCapacity?: number;
     queueTotalCapacity?: number;
+    transport?: CaptureTransport | CaptureTransportOptions;
   } = {}
 ): SessionManager {
-  const privacy = options.privacy ?? DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS;
+  const getPrivacy = options.getPrivacy ?? (() => options.privacy ?? DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS);
   const buffer = createEventBuffer({
     persistenceRoot: options.queuePersistenceRoot,
     memoryCapacity: options.queueMemoryCapacity,
-    totalCapacity: options.queueTotalCapacity
+    totalCapacity: options.queueTotalCapacity,
+    getPrivacy
   });
-  let activeSession: DiscoveredSession | null = null;
-  let activeWatcher: TranscriptWatcher | null = null;
-  let rediscoveryTimer: ReturnType<typeof setInterval> | null = null;
+  let activeSession: CaptureSession | null = null;
+  let activeParser = createIncrementalParser(() => undefined);
+  let transportSubscription: CaptureTransportSubscription | null = null;
   let bridgeCleanup: (() => void) | null = null;
   let sessionTitle = 'Live session';
+  const transport =
+    options.transport && 'start' in options.transport
+      ? options.transport
+      : createCaptureTransport(options.transport ?? { kind: 'file-tail' });
 
   const buildSnapshot = async (): Promise<SnapshotPayload | null> => {
     const events = await buffer.getAll();
     const source: LoadedSource = {
       kind: 'transcript',
       label: sessionTitle,
-      path: activeSession?.filePath
+      path: activeSession?.path
     };
 
     return {
       ...buildRendererInput(events, {
         source,
         fallbackTitle: sessionTitle,
-        privacySettings: privacy
+        privacySettings: getPrivacy()
       }),
       captureQueue: buffer.getMetrics()
     };
   };
 
   const teardown = () => {
-    if (activeWatcher) {
-      activeWatcher.stop();
-      activeWatcher = null;
-    }
+    void transportSubscription?.stop();
+    transportSubscription = null;
     activeSession = null;
   };
 
-  const startSession = async (session: DiscoveredSession) => {
-    teardown();
-    activeSession = session;
-    sessionTitle = `Live: ${session.sessionId.slice(0, 12)}`;
+  const startSession = async (session: CaptureSession) => {
+    sessionTitle = session.label;
     await buffer.setSession(session.sessionId);
+    activeSession = session;
+    activeParser = createIncrementalParser((entry) => {
+      const events = normalizeEntry(entry, session.sessionId);
+      if (events.length === 0) {
+        return;
+      }
+      void buffer.push(events).catch((error) => {
+        logger.error('capture', 'session_manager.push_failed', {
+          sessionId: session.sessionId,
+          error
+        });
+      });
+    });
 
     logger.info('capture', 'session_manager.start_session', {
-      filePath: session.filePath,
+      filePath: session.path,
       sessionId: session.sessionId,
+      transportId: session.transportId
     });
-
-    // Catch-up: read the entire existing file first
-    try {
-      const raw = await readFile(session.filePath, 'utf8');
-      const lines = raw.split(/\r?\n/).filter((l) => l.trim());
-      const catchupEvents = lines.flatMap((line) => {
-        try {
-          const entry = JSON.parse(line) as Record<string, unknown>;
-          return normalizeEntry(entry, session.sessionId);
-        } catch {
-          return [];
-        }
-      });
-      if (catchupEvents.length > 0) {
-        const result = await buffer.push(catchupEvents);
-        logger.info('capture', 'session_manager.catchup', {
-          count: catchupEvents.length,
-          backpressureLevel: result.backpressure.level
-        });
-      }
-    } catch (err) {
-      logger.warn('capture', 'session_manager.catchup_failed', { error: err });
-    }
-
-    // Then watch for incremental updates
-    const parser = createIncrementalParser((entry) => {
-      const events = normalizeEntry(entry, session.sessionId);
-      if (events.length > 0) {
-        void buffer.push(events).catch((error) => {
-          logger.error('capture', 'session_manager.push_failed', {
-            sessionId: session.sessionId,
-            error
-          });
-        });
-      }
-    });
-
-    activeWatcher = watchTranscript(
-      session.filePath,
-      (chunk) => {
-        parser.push(chunk);
-      },
-      {
-        getBackpressure: () => buffer.getBackpressure()
-      }
-    );
-  };
-
-  const runRediscovery = async (overridePath?: string) => {
-    const found = await discoverActiveSession(overridePath);
-    if (!found) return;
-
-    const isNewSession = !activeSession || found.filePath !== activeSession.filePath;
-    if (isNewSession) {
-      logger.info('capture', 'session_manager.new_session_detected', {
-        filePath: found.filePath,
-      });
-      await startSession(found);
-    }
   };
 
   return {
@@ -154,24 +114,53 @@ export function createSessionManager(
         buffer,
         getWebContents,
         buildSnapshot,
-        privacy,
+        getPrivacy,
       });
       bridgeCleanup = bridge.start();
 
-      // Initial discovery
-      await runRediscovery(overridePath);
+      const effectiveTransport =
+        overridePath && transport.kind === 'file-tail'
+          ? createCaptureTransport({ kind: 'file-tail', overridePath })
+          : transport;
 
-      // Periodic re-discovery
-      rediscoveryTimer = setInterval(() => {
-        void runRediscovery(overridePath);
-      }, REDISCOVERY_INTERVAL_MS);
+      transportSubscription = await effectiveTransport.start({
+        getBackpressure: () => buffer.getBackpressure(),
+        onSessionStarted: async (session) => {
+          const isNewSession =
+            !activeSession ||
+            session.sessionId !== activeSession.sessionId ||
+            session.path !== activeSession.path;
+          if (!isNewSession) {
+            return;
+          }
+          logger.info('capture', 'session_manager.new_session_detected', {
+            sessionId: session.sessionId,
+            filePath: session.path,
+            transportId: session.transportId
+          });
+          await startSession(session);
+        },
+        onSessionReset: async (session, reason) => {
+          if (!activeSession || activeSession.sessionId !== session.sessionId) {
+            return;
+          }
+          activeParser.reset();
+          logger.info('capture', 'session_manager.session_reset', {
+            sessionId: session.sessionId,
+            reason,
+            filePath: session.path
+          });
+        },
+        onChunk: async ({ session, chunk }) => {
+          if (!activeSession || activeSession.sessionId !== session.sessionId) {
+            await startSession(session);
+          }
+          activeParser.push(chunk);
+        }
+      });
     },
 
     stop() {
-      if (rediscoveryTimer) {
-        clearInterval(rediscoveryTimer);
-        rediscoveryTimer = null;
-      }
       teardown();
       if (bridgeCleanup) {
         bridgeCleanup();

--- a/shadow-agent/src/capture/socket-transport.ts
+++ b/shadow-agent/src/capture/socket-transport.ts
@@ -1,0 +1,133 @@
+import net from 'node:net';
+import { createLogger } from '../shared/logger';
+import type {
+  CaptureSession,
+  CaptureTransport,
+  CaptureTransportContext,
+  CaptureTransportSubscription,
+  SocketCaptureTransportOptions
+} from './capture-transport';
+import { computeWatchDelay } from './transcript-watcher';
+
+const logger = createLogger({ minLevel: 'info' });
+const DEFAULT_RECONNECT_DELAY_MS = 1_000;
+
+function buildSession(options: SocketCaptureTransportOptions): CaptureSession {
+  return {
+    sessionId: options.sessionId ?? `socket-${options.host}:${options.port}`,
+    label: options.sessionLabel ?? `Live Socket: ${options.host}:${options.port}`,
+    source: 'claude-hook',
+    path: `tcp://${options.host}:${options.port}`,
+    transportId: 'socket'
+  };
+}
+
+export function createSocketCaptureTransport(
+  options: SocketCaptureTransportOptions
+): CaptureTransport {
+  return {
+    id: 'socket',
+    kind: 'socket',
+    async start(context: CaptureTransportContext): Promise<CaptureTransportSubscription> {
+      const session = buildSession(options);
+      const reconnectDelayMs = Math.max(50, options.reconnectDelayMs ?? DEFAULT_RECONNECT_DELAY_MS);
+
+      let socket: net.Socket | null = null;
+      let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+      let stopped = false;
+      let hasConnected = false;
+
+      const clearReconnectTimer = () => {
+        if (reconnectTimer) {
+          clearTimeout(reconnectTimer);
+          reconnectTimer = null;
+        }
+      };
+
+      const scheduleReconnect = () => {
+        if (stopped || reconnectTimer) {
+          return;
+        }
+        reconnectTimer = setTimeout(() => {
+          reconnectTimer = null;
+          connect();
+        }, reconnectDelayMs);
+      };
+
+      const connect = () => {
+        if (stopped) {
+          return;
+        }
+
+        logger.info('capture', 'transport.socket.connecting', {
+          host: options.host,
+          port: options.port
+        });
+
+        const nextSocket = net.createConnection({
+          host: options.host,
+          port: options.port
+        });
+        socket = nextSocket;
+        nextSocket.setEncoding('utf8');
+
+        nextSocket.on('connect', () => {
+          void (async () => {
+            if (!hasConnected) {
+              await context.onSessionStarted(session);
+              hasConnected = true;
+            } else {
+              await context.onSessionReset(session, 'reconnect');
+            }
+          })();
+        });
+
+        nextSocket.on('data', (chunk: string) => {
+          void (async () => {
+            const backpressure = context.getBackpressure();
+            if (backpressure.shouldThrottle) {
+              nextSocket.pause();
+              setTimeout(() => {
+                if (!stopped) {
+                  nextSocket.resume();
+                }
+              }, computeWatchDelay(50, backpressure));
+            }
+            await context.onChunk({ session, chunk });
+          })();
+        });
+
+        nextSocket.on('error', (error) => {
+          if (!stopped) {
+            logger.warn('capture', 'transport.socket.error', {
+              host: options.host,
+              port: options.port,
+              error
+            });
+          }
+        });
+
+        nextSocket.on('close', () => {
+          if (!stopped) {
+            scheduleReconnect();
+          }
+        });
+      };
+
+      connect();
+
+      return {
+        stop() {
+          stopped = true;
+          clearReconnectTimer();
+          socket?.destroy();
+          socket = null;
+          logger.info('capture', 'transport.socket.stopped', {
+            host: options.host,
+            port: options.port
+          });
+        }
+      };
+    }
+  };
+}

--- a/shadow-agent/src/capture/transcript-watcher.ts
+++ b/shadow-agent/src/capture/transcript-watcher.ts
@@ -1,12 +1,25 @@
 /**
- * Watches a single JSONL transcript file for new lines, handles truncation and rotation.
- * Emits raw string chunks to registered callbacks.
+ * Robust file-tail capture transport for Claude transcript JSONL files.
+ *
+ * Tracks byte offsets, detects truncation, and fingerprints the head of the file
+ * so rotated/replaced transcripts are replayed from the beginning even when the
+ * replacement file is the same size or larger than the previous one.
  */
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
 import { open, stat } from 'node:fs/promises';
 import type { FileHandle } from 'node:fs/promises';
-import fs from 'node:fs';
+import path from 'node:path';
 import type { EventQueueBackpressureState } from '../shared/schema';
 import { createLogger } from '../shared/logger';
+import { discoverActiveSession, type DiscoveredSession } from './session-discovery';
+import type {
+  CaptureSession,
+  CaptureTransport,
+  CaptureTransportContext,
+  CaptureTransportSubscription,
+  FileTailCaptureTransportOptions
+} from './capture-transport';
 
 const logger = createLogger({ minLevel: 'info' });
 
@@ -20,8 +33,17 @@ export interface TranscriptWatcherOptions {
   getBackpressure?: () => EventQueueBackpressureState;
 }
 
+interface FileFingerprint {
+  size: number;
+  mtimeMs: number;
+  ino?: number;
+  checksum: string;
+}
+
+const DEFAULT_DISCOVERY_INTERVAL_MS = 30_000;
+const DEFAULT_FINGERPRINT_BYTES = 4_096;
 const DEBOUNCE_MS = 100;
-const READ_CHUNK = 65_536; // 64 KB
+const READ_CHUNK = 65_536;
 
 export function computeWatchDelay(
   baseDelayMs: number,
@@ -39,86 +61,309 @@ export function computeWatchDelay(
   return baseDelayMs;
 }
 
+function buildSession(discovered: DiscoveredSession): CaptureSession {
+  return {
+    sessionId: discovered.sessionId,
+    label: `Live: ${discovered.sessionId.slice(0, 12)}`,
+    source: 'claude-transcript',
+    path: discovered.filePath,
+    transportId: 'file-tail'
+  };
+}
+
+async function computeFileFingerprint(
+  filePath: string,
+  fingerprintBytes: number
+): Promise<FileFingerprint | null> {
+  try {
+    const info = await stat(filePath);
+    const byteCount = Math.max(0, Math.min(info.size, fingerprintBytes));
+    const hash = createHash('sha1');
+
+    if (byteCount > 0) {
+      const handle = await open(filePath, 'r');
+      try {
+        const buffer = Buffer.allocUnsafe(byteCount);
+        const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+        hash.update(buffer.subarray(0, bytesRead));
+      } finally {
+        await handle.close().catch(() => undefined);
+      }
+    }
+
+    return {
+      size: info.size,
+      mtimeMs: info.mtimeMs,
+      ino: typeof info.ino === 'number' ? info.ino : undefined,
+      checksum: hash.digest('hex')
+    };
+  } catch {
+    return null;
+  }
+}
+
+function hasFingerprintChanged(previous: FileFingerprint | null, next: FileFingerprint | null): boolean {
+  if (!previous || !next) {
+    return false;
+  }
+
+  if (previous.ino !== undefined && next.ino !== undefined && previous.ino !== next.ino) {
+    return true;
+  }
+
+  return previous.checksum !== next.checksum;
+}
+
+function attachWatcher(
+  watchPath: string,
+  onSignal: () => void
+): fs.FSWatcher | null {
+  try {
+    return fs.watch(watchPath, { persistent: false }, () => {
+      onSignal();
+    });
+  } catch (error) {
+    logger.warn('capture', 'watcher.attach_failed', { watchPath, error });
+    return null;
+  }
+}
+
+export function createFileTailCaptureTransport(
+  options: FileTailCaptureTransportOptions = { kind: 'file-tail' }
+): CaptureTransport {
+  return {
+    id: 'file-tail',
+    kind: 'file-tail',
+    async start(context: CaptureTransportContext): Promise<CaptureTransportSubscription> {
+      const discoveryIntervalMs = Math.max(1_000, options.discoveryIntervalMs ?? DEFAULT_DISCOVERY_INTERVAL_MS);
+      const fingerprintBytes = Math.max(128, options.fingerprintBytes ?? DEFAULT_FINGERPRINT_BYTES);
+
+      let activeSession: CaptureSession | null = null;
+      let activeHandle: FileHandle | null = null;
+      let activeFingerprint: FileFingerprint | null = null;
+      let activeFileWatcher: fs.FSWatcher | null = null;
+      let activeDirWatcher: fs.FSWatcher | null = null;
+      let rediscoveryTimer: ReturnType<typeof setInterval> | null = null;
+      let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+      let stopped = false;
+      let readInFlight = false;
+      let pendingRead = false;
+      let offset = 0;
+
+      const closeHandle = async () => {
+        if (!activeHandle) {
+          return;
+        }
+        await activeHandle.close().catch(() => undefined);
+        activeHandle = null;
+      };
+
+      const clearWatchers = () => {
+        activeFileWatcher?.close();
+        activeDirWatcher?.close();
+        activeFileWatcher = null;
+        activeDirWatcher = null;
+      };
+
+      const scheduleRead = (delay = DEBOUNCE_MS) => {
+        if (stopped) {
+          return;
+        }
+        if (debounceTimer) {
+          clearTimeout(debounceTimer);
+        }
+        debounceTimer = setTimeout(() => {
+          debounceTimer = null;
+          void readNew();
+        }, computeWatchDelay(delay, context.getBackpressure()));
+      };
+
+      const resetCursor = async (reason: 'rotation' | 'truncation') => {
+        if (!activeSession) {
+          return;
+        }
+        await closeHandle();
+        offset = 0;
+        activeFingerprint = null;
+        await context.onSessionReset(activeSession, reason);
+      };
+
+      const ensureWatchers = (filePath: string) => {
+        clearWatchers();
+        activeFileWatcher = attachWatcher(filePath, () => {
+          scheduleRead();
+        });
+        activeDirWatcher = attachWatcher(path.dirname(filePath), () => {
+          scheduleRead();
+        });
+      };
+
+      const readNew = async () => {
+        if (stopped || !activeSession) {
+          return;
+        }
+        if (readInFlight) {
+          pendingRead = true;
+          return;
+        }
+
+        readInFlight = true;
+        try {
+          const filePath = activeSession.path;
+          if (!filePath) {
+            return;
+          }
+
+          const info = await stat(filePath).catch(() => null);
+          if (!info) {
+            return;
+          }
+
+          const fingerprint = await computeFileFingerprint(filePath, fingerprintBytes);
+
+          if (info.size < offset) {
+            logger.info('capture', 'watcher.truncated', { filePath, oldOffset: offset });
+            await resetCursor('truncation');
+          } else if (offset > 0 && hasFingerprintChanged(activeFingerprint, fingerprint)) {
+            logger.info('capture', 'watcher.rotated', { filePath });
+            await resetCursor('rotation');
+          }
+
+          if (info.size <= offset) {
+            activeFingerprint = fingerprint;
+            return;
+          }
+
+          if (!activeHandle) {
+            activeHandle = await open(filePath, 'r');
+          }
+
+          const readSession = activeSession;
+          while (!stopped && activeSession === readSession) {
+            const remaining = info.size - offset;
+            if (remaining <= 0) {
+              break;
+            }
+
+            const buffer = Buffer.allocUnsafe(Math.min(remaining, READ_CHUNK));
+            const { bytesRead } = await activeHandle.read(buffer, 0, buffer.length, offset);
+            if (bytesRead <= 0) {
+              break;
+            }
+
+            offset += bytesRead;
+            await context.onChunk({
+              session: readSession,
+              chunk: buffer.subarray(0, bytesRead).toString('utf8')
+            });
+          }
+
+          activeFingerprint = fingerprint;
+        } catch (error) {
+          logger.error('capture', 'watcher.read_error', {
+            filePath: activeSession.path,
+            error
+          });
+          await closeHandle();
+        } finally {
+          readInFlight = false;
+          if (pendingRead) {
+            pendingRead = false;
+            scheduleRead(0);
+          }
+        }
+      };
+
+      const activateSession = async (discovered: DiscoveredSession) => {
+        const nextSession = buildSession(discovered);
+        const isSameFile = activeSession?.path === nextSession.path;
+        if (isSameFile) {
+          return;
+        }
+
+        await closeHandle();
+        clearWatchers();
+
+        activeSession = nextSession;
+        offset = 0;
+        activeFingerprint = null;
+        ensureWatchers(discovered.filePath);
+        await context.onSessionStarted(nextSession);
+        scheduleRead(0);
+      };
+
+      const runDiscovery = async () => {
+        const discovered = await discoverActiveSession(options.overridePath);
+        if (!discovered) {
+          return;
+        }
+        await activateSession(discovered);
+      };
+
+      await runDiscovery();
+
+      rediscoveryTimer = setInterval(() => {
+        void runDiscovery();
+      }, discoveryIntervalMs);
+
+      return {
+        async stop() {
+          stopped = true;
+          if (debounceTimer) {
+            clearTimeout(debounceTimer);
+            debounceTimer = null;
+          }
+          if (rediscoveryTimer) {
+            clearInterval(rediscoveryTimer);
+            rediscoveryTimer = null;
+          }
+          clearWatchers();
+          await closeHandle();
+          logger.info('capture', 'watcher.stopped', { filePath: activeSession?.path });
+        }
+      };
+    }
+  };
+}
+
 export function watchTranscript(
   filePath: string,
   onChunk: ChunkCallback,
   options: TranscriptWatcherOptions = {}
 ): TranscriptWatcher {
-  let offset = 0;
-  let handle: FileHandle | null = null;
-  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   let stopped = false;
+  let subscriptionPromise: Promise<CaptureTransportSubscription> | null = null;
 
-  const readNew = async () => {
-    try {
-      const info = await stat(filePath);
-
-      // File was truncated or rotated → reset
-      if (info.size < offset) {
-        logger.info('capture', 'watcher.truncated', { filePath, oldOffset: offset });
-        if (handle) {
-          await handle.close().catch(() => undefined);
-          handle = null;
-        }
-        offset = 0;
+  subscriptionPromise = createFileTailCaptureTransport({
+    kind: 'file-tail',
+    overridePath: filePath
+  })
+    .start({
+      getBackpressure: () =>
+        options.getBackpressure?.() ?? {
+          level: 'normal',
+          shouldThrottle: false,
+          totalRatio: 0,
+          pendingWrites: 0
+        },
+      onSessionStarted: () => undefined,
+      onSessionReset: () => undefined,
+      onChunk: ({ chunk }) => {
+        onChunk(chunk);
       }
-
-      if (info.size <= offset) return;
-
-      if (!handle) {
-        handle = await open(filePath, 'r');
-      }
-
-      const toRead = info.size - offset;
-      const buf = Buffer.allocUnsafe(Math.min(toRead, READ_CHUNK));
-      const { bytesRead } = await handle.read(buf, 0, buf.length, offset);
-      if (bytesRead > 0) {
-        offset += bytesRead;
-        onChunk(buf.subarray(0, bytesRead).toString('utf8'));
-        // If there's more data, schedule another read immediately
-        if (bytesRead === READ_CHUNK) {
-          scheduleRead(0);
-        }
-      }
-    } catch (err) {
-      logger.error('capture', 'watcher.read_error', { filePath, error: err });
-      if (handle) {
-        await handle.close().catch(() => undefined);
-        handle = null;
-      }
-    }
-  };
-
-  const scheduleRead = (delay = DEBOUNCE_MS) => {
-    if (stopped) return;
-    if (debounceTimer) clearTimeout(debounceTimer);
-    const nextDelay = computeWatchDelay(delay, options.getBackpressure?.());
-    debounceTimer = setTimeout(() => {
-      void readNew();
-    }, nextDelay);
-  };
-
-  const watcher = fs.watch(filePath, { persistent: false }, () => {
-    scheduleRead();
-  });
-
-  watcher.on('error', (err) => {
-    logger.error('capture', 'watcher.fs_error', { filePath, error: err });
-  });
-
-  // Initial read — catch up on existing content
-  void readNew();
+    })
+    .catch((error) => {
+      logger.error('capture', 'watcher.legacy_start_failed', { filePath, error });
+    });
 
   return {
     stop() {
-      stopped = true;
-      if (debounceTimer) clearTimeout(debounceTimer);
-      watcher.close();
-      if (handle) {
-        void handle.close().catch(() => undefined);
-        handle = null;
+      if (stopped) {
+        return;
       }
-      logger.info('capture', 'watcher.stopped', { filePath });
-    },
+      stopped = true;
+      void subscriptionPromise?.then((subscription) => subscription.stop());
+      subscriptionPromise = null;
+    }
   };
 }

--- a/shadow-agent/src/capture/transcript-watcher.ts
+++ b/shadow-agent/src/capture/transcript-watcher.ts
@@ -337,24 +337,23 @@ export function watchTranscript(
   subscriptionPromise = createFileTailCaptureTransport({
     kind: 'file-tail',
     overridePath: filePath
-  })
-    .start({
-      getBackpressure: () =>
-        options.getBackpressure?.() ?? {
-          level: 'normal',
-          shouldThrottle: false,
-          totalRatio: 0,
-          pendingWrites: 0
-        },
-      onSessionStarted: () => undefined,
-      onSessionReset: () => undefined,
-      onChunk: ({ chunk }) => {
-        onChunk(chunk);
-      }
-    })
-    .catch((error) => {
-      logger.error('capture', 'watcher.legacy_start_failed', { filePath, error });
-    });
+  }).start({
+    getBackpressure: () =>
+      options.getBackpressure?.() ?? {
+        level: 'normal',
+        shouldThrottle: false,
+        totalRatio: 0,
+        pendingWrites: 0
+      },
+    onSessionStarted: () => undefined,
+    onSessionReset: () => undefined,
+    onChunk: ({ chunk }) => {
+      onChunk(chunk);
+    }
+  });
+  void subscriptionPromise.catch((error) => {
+    logger.error('capture', 'watcher.legacy_start_failed', { filePath, error });
+  });
 
   return {
     stop() {

--- a/shadow-agent/src/capture/websocket-transport.ts
+++ b/shadow-agent/src/capture/websocket-transport.ts
@@ -1,0 +1,144 @@
+import { createLogger } from '../shared/logger';
+import type {
+  CaptureSession,
+  CaptureTransport,
+  CaptureTransportContext,
+  CaptureTransportSubscription,
+  WebSocketCaptureTransportOptions
+} from './capture-transport';
+
+const logger = createLogger({ minLevel: 'info' });
+const DEFAULT_RECONNECT_DELAY_MS = 1_000;
+
+function buildSession(options: WebSocketCaptureTransportOptions): CaptureSession {
+  const url = new URL(options.url);
+  return {
+    sessionId: options.sessionId ?? `websocket-${url.host}`,
+    label: options.sessionLabel ?? `Live WebSocket: ${url.host}`,
+    source: 'claude-hook',
+    path: options.url,
+    transportId: 'websocket'
+  };
+}
+
+function ensureMessageDelimiter(chunk: string): string {
+  return chunk.endsWith('\n') ? chunk : `${chunk}\n`;
+}
+
+async function readMessageData(data: unknown): Promise<string | null> {
+  if (typeof data === 'string') {
+    return ensureMessageDelimiter(data);
+  }
+  if (data instanceof ArrayBuffer) {
+    return ensureMessageDelimiter(Buffer.from(data).toString('utf8'));
+  }
+  if (ArrayBuffer.isView(data)) {
+    return ensureMessageDelimiter(Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString('utf8'));
+  }
+  if (typeof Blob !== 'undefined' && data instanceof Blob) {
+    return ensureMessageDelimiter(await data.text());
+  }
+  return null;
+}
+
+export function createWebSocketCaptureTransport(
+  options: WebSocketCaptureTransportOptions
+): CaptureTransport {
+  return {
+    id: 'websocket',
+    kind: 'websocket',
+    async start(context: CaptureTransportContext): Promise<CaptureTransportSubscription> {
+      const session = buildSession(options);
+      const reconnectDelayMs = Math.max(50, options.reconnectDelayMs ?? DEFAULT_RECONNECT_DELAY_MS);
+
+      let socket: WebSocket | null = null;
+      let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+      let stopped = false;
+      let hasOpened = false;
+
+      const clearReconnectTimer = () => {
+        if (reconnectTimer) {
+          clearTimeout(reconnectTimer);
+          reconnectTimer = null;
+        }
+      };
+
+      const scheduleReconnect = () => {
+        if (stopped || reconnectTimer) {
+          return;
+        }
+        reconnectTimer = setTimeout(() => {
+          reconnectTimer = null;
+          void connect();
+        }, reconnectDelayMs);
+      };
+
+      const connect = async (): Promise<void> => {
+        if (stopped) {
+          return;
+        }
+
+        logger.info('capture', 'transport.websocket.connecting', { url: options.url });
+        let nextSocket: WebSocket;
+        try {
+          nextSocket = new WebSocket(options.url, options.protocols);
+        } catch (error) {
+          logger.warn('capture', 'transport.websocket.create_failed', { url: options.url, error });
+          scheduleReconnect();
+          return;
+        }
+        socket = nextSocket;
+
+        nextSocket.onopen = () => {
+          void (async () => {
+            if (!hasOpened) {
+              await context.onSessionStarted(session);
+              hasOpened = true;
+            } else {
+              await context.onSessionReset(session, 'reconnect');
+            }
+          })();
+        };
+
+        nextSocket.onmessage = (event) => {
+          void (async () => {
+            const chunk = await readMessageData(event.data);
+            if (chunk) {
+              await context.onChunk({ session, chunk });
+            }
+          })();
+        };
+
+        nextSocket.onerror = (event) => {
+          if (!stopped) {
+            logger.warn('capture', 'transport.websocket.error', { url: options.url, error: event });
+          }
+        };
+
+        nextSocket.onclose = () => {
+          if (!stopped) {
+            scheduleReconnect();
+          }
+        };
+      };
+
+      void connect();
+
+      return {
+        stop() {
+          stopped = true;
+          clearReconnectTimer();
+          const openState = typeof WebSocket !== 'undefined' ? WebSocket.OPEN : 1;
+          if (socket && socket.readyState === openState) {
+            socket.close();
+          } else {
+            socket?.close();
+          }
+          socket = null;
+          logger.info('capture', 'transport.websocket.stopped', { url: options.url });
+        }
+      };
+    }
+  };
+}
+

--- a/shadow-agent/src/electron/preload.ts
+++ b/shadow-agent/src/electron/preload.ts
@@ -10,6 +10,8 @@ const bridge: ShadowAgentBridge = {
   },
   getLiveSnapshot: () => ipcRenderer.invoke('shadow:snapshot') as Promise<SnapshotPayload | null>,
   openReplayFile: () => ipcRenderer.invoke('shadow-agent:open-replay-file') as Promise<SnapshotPayload | null>,
+  getPrivacyPolicy: () => ipcRenderer.invoke('shadow-agent:get-privacy-policy'),
+  updatePrivacySettings: (updates) => ipcRenderer.invoke('shadow-agent:update-privacy-settings', updates),
   exportReplayJsonl: (events: CanonicalEvent[], suggestedFileName?: string, options?: { storeRawTranscript?: boolean }) =>
     ipcRenderer.invoke('shadow-agent:export-replay-jsonl', events, suggestedFileName, options) as Promise<ExportResult>
 };

--- a/shadow-agent/src/electron/start-main-process.ts
+++ b/shadow-agent/src/electron/start-main-process.ts
@@ -1,10 +1,16 @@
 import { app, BrowserWindow, ipcMain } from 'electron';
 import path from 'node:path';
-import { DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS, loadTranscriptPrivacySettings } from '../shared/privacy';
+import {
+  DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS,
+  loadTranscriptPrivacySettings,
+  resolvePrivacyPolicy,
+  saveTranscriptPrivacySettings
+} from '../shared/privacy';
 import type { CanonicalEvent, TranscriptPrivacySettings } from '../shared/schema';
 import { createLogger } from '../shared/logger';
 import { buildFixtureSnapshot, loadSnapshotFromFile, pickOpenFile, saveReplayFile } from './session-io';
 import { createSessionManager } from '../capture/session-manager';
+import { resolveCaptureTransportOptionsFromEnv } from '../capture/capture-transports';
 import { createInferenceEngine, type InferenceEngine } from '../inference/shadow-inference-engine';
 import { deriveState } from '../shared/derive';
 
@@ -52,12 +58,19 @@ function createWindow(): BrowserWindow {
 
 export function registerIpcHandlers(
   getMainWindow: () => BrowserWindow | null,
-  privacySettings: TranscriptPrivacySettings = DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS
+  privacyAccess: {
+    getSettings: () => TranscriptPrivacySettings;
+    updateSettings?: (updates: Partial<TranscriptPrivacySettings>) => Promise<TranscriptPrivacySettings>;
+  } = {
+    getSettings: () => DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS
+  }
 ): void {
+  const getPrivacySettings = privacyAccess.getSettings;
+
   ipcMain.removeHandler('shadow-agent:bootstrap');
   ipcMain.handle('shadow-agent:bootstrap', () => {
     logger.info('ipc', 'bootstrap_requested');
-    return buildFixtureSnapshot(privacySettings);
+    return buildFixtureSnapshot(getPrivacySettings());
   });
 
   ipcMain.removeHandler('shadow-agent:open-replay-file');
@@ -71,7 +84,7 @@ export function registerIpcHandlers(
       }
 
       logger.info('ipc', 'open_replay_selected', { fileName: path.basename(filePath) });
-      return await loadSnapshotFromFile(filePath, privacySettings);
+      return await loadSnapshotFromFile(filePath, getPrivacySettings());
     } catch (error) {
       logger.error('ipc', 'open_replay_failed', {
         fileName: filePath ? path.basename(filePath) : undefined,
@@ -91,7 +104,7 @@ export function registerIpcHandlers(
       options?: { storeRawTranscript?: boolean }
     ) => {
     try {
-      return await saveReplayFile(getMainWindow(), events, suggestedFileName, options, privacySettings);
+      return await saveReplayFile(getMainWindow(), events, suggestedFileName, options, getPrivacySettings());
     } catch (error) {
       logger.error('ipc', 'export_replay_failed', {
         suggestedFileName: suggestedFileName ? path.basename(suggestedFileName) : undefined,
@@ -105,6 +118,19 @@ export function registerIpcHandlers(
     }
     }
   );
+
+  ipcMain.removeHandler('shadow-agent:get-privacy-policy');
+  ipcMain.handle('shadow-agent:get-privacy-policy', () => resolvePrivacyPolicy(getPrivacySettings()));
+
+  ipcMain.removeHandler('shadow-agent:update-privacy-settings');
+  ipcMain.handle('shadow-agent:update-privacy-settings', async (_event, updates: Partial<TranscriptPrivacySettings> = {}) => {
+    if (!privacyAccess.updateSettings) {
+      return resolvePrivacyPolicy(getPrivacySettings());
+    }
+
+    const nextSettings = await privacyAccess.updateSettings(updates);
+    return resolvePrivacyPolicy(nextSettings);
+  });
 }
 
 export function startMainProcess(): void {
@@ -115,13 +141,48 @@ export function startMainProcess(): void {
   app
     .whenReady()
     .then(async () => {
-      const privacySettings = await loadTranscriptPrivacySettings();
+      let privacySettings = await loadTranscriptPrivacySettings();
+      const getPrivacySettings = () => privacySettings;
       const currentSessionManager = createSessionManager(() => mainWindow?.webContents ?? null, {
-        privacy: privacySettings,
-        queuePersistenceRoot: path.join(app.getPath('userData'), 'capture-queue')
+        getPrivacy: getPrivacySettings,
+        queuePersistenceRoot: path.join(app.getPath('userData'), 'capture-queue'),
+        transport: resolveCaptureTransportOptionsFromEnv()
       });
       sessionManager = currentSessionManager;
-      registerIpcHandlers(() => mainWindow, privacySettings);
+      const createRuntimeInferenceEngine = () =>
+        createInferenceEngine({
+          buffer: currentSessionManager.getBuffer(),
+          getState: async () => {
+            const events = await currentSessionManager.getBuffer().getAll();
+            return deriveState(events);
+          },
+          privacy: getPrivacySettings(),
+          onInsights: (insights) => {
+            logger.info('inference', 'insights_received', { count: insights.length });
+          }
+        });
+      const refreshInferenceEngine = async () => {
+        inferenceEngine?.stop();
+        inferenceEngine = createRuntimeInferenceEngine();
+        await inferenceEngine.start();
+      };
+      const updatePrivacySettings = async (updates: Partial<TranscriptPrivacySettings>) => {
+        const definedUpdates = Object.fromEntries(
+          Object.entries(updates).filter((entry): entry is [keyof TranscriptPrivacySettings, boolean] => {
+            return entry[1] !== undefined;
+          })
+        ) as Partial<TranscriptPrivacySettings>;
+        privacySettings = await saveTranscriptPrivacySettings({
+          ...privacySettings,
+          ...definedUpdates
+        });
+        await refreshInferenceEngine();
+        return privacySettings;
+      };
+      registerIpcHandlers(() => mainWindow, {
+        getSettings: getPrivacySettings,
+        updateSettings: updatePrivacySettings
+      });
       try {
         mainWindow = createWindow();
         mainWindow.on('closed', () => {
@@ -129,17 +190,7 @@ export function startMainProcess(): void {
         });
         // Start live transcript capture (non-blocking; falls back gracefully if no session found)
         void currentSessionManager.start();
-        inferenceEngine = createInferenceEngine({
-          buffer: currentSessionManager.getBuffer(),
-          getState: () => {
-            const events = currentSessionManager.getBuffer().getAll();
-            return events.then((evts: CanonicalEvent[]) => deriveState(evts));
-          },
-          onInsights: (insights) => {
-            logger.info('inference', 'insights_received', { count: insights.length });
-          }
-        });
-        void inferenceEngine.start();
+        await refreshInferenceEngine();
         logger.info('app', 'ready');
       } catch (error) {
         logger.error('app', 'window_create_failed_on_ready', { error });

--- a/shadow-agent/src/inference/direct-api.ts
+++ b/shadow-agent/src/inference/direct-api.ts
@@ -42,7 +42,6 @@ export interface DirectApiClientDependencies {
 }
 
 async function loadAnthropicSdk(): Promise<{ default: AnthropicSdkConstructor }> {
-  // @ts-ignore
   return import('@anthropic-ai/sdk') as Promise<{ default: AnthropicSdkConstructor }>;
 }
 

--- a/shadow-agent/src/inference/inference-client-factory.ts
+++ b/shadow-agent/src/inference/inference-client-factory.ts
@@ -1,0 +1,29 @@
+/**
+ * Selects the best available inference adapter for the current environment.
+ *
+ * Order: explicit SHADOW_INFERENCE_PROVIDER preference → OpenCode (if SDK starts) →
+ * direct Anthropic fallback.
+ */
+import type { InferenceClient } from './inference-client';
+import { createDirectApiClient } from './direct-api';
+import { createOpencodeClient } from './opencode-client';
+
+export async function createInferenceClient(): Promise<InferenceClient | null> {
+  const preference = process.env.SHADOW_INFERENCE_PROVIDER?.trim().toLowerCase();
+
+  if (preference === 'anthropic' || preference === 'direct') {
+    return createDirectApiClient();
+  }
+
+  if (preference === 'opencode') {
+    const opencode = await createOpencodeClient();
+    return opencode ?? createDirectApiClient();
+  }
+
+  const opencode = await createOpencodeClient();
+  if (opencode) {
+    return opencode;
+  }
+
+  return createDirectApiClient();
+}

--- a/shadow-agent/src/inference/opencode-client.ts
+++ b/shadow-agent/src/inference/opencode-client.ts
@@ -26,7 +26,7 @@ export interface OpencodeClientDependencies {
 interface OpencodeSdkModule {
   createOpencodeServer(options: { port: number; cwd: string }): Promise<{
     url: string;
-    close?: () => Promise<void>;
+    close?: () => void | Promise<void>;
   }>;
   createOpencodeClient(options: { baseUrl: string }): OpencodeSdkClient;
 }
@@ -55,7 +55,7 @@ interface OpencodeMessagesResponse {
 }
 
 async function defaultLoadSdk(): Promise<OpencodeSdkModule> {
-  return import('@opencode-ai/sdk') as Promise<OpencodeSdkModule>;
+  return import('@opencode-ai/sdk') as unknown as Promise<OpencodeSdkModule>;
 }
 
 function extractAssistantText(response: OpencodeMessagesResponse): string {
@@ -118,7 +118,7 @@ export async function createOpencodeClient(
     return null;
   }
 
-  let server: { url: string; close?: () => Promise<void> } | null = null;
+  let server: { url: string; close?: () => void | Promise<void> } | null = null;
   let sdkClient: OpencodeSdkClient | null = null;
   let sessionId: string | null = null;
 
@@ -132,7 +132,7 @@ export async function createOpencodeClient(
     sessionId = session.id;
   } catch (error) {
     logger.warn('inference', 'opencode.start_failed', { error });
-    await server?.close?.();
+    await Promise.resolve(server?.close?.());
     return null;
   }
 

--- a/shadow-agent/src/inference/opencode-client.ts
+++ b/shadow-agent/src/inference/opencode-client.ts
@@ -1,0 +1,181 @@
+/**
+ * OpenCode inference harness — primary provider path when the SDK is available.
+ *
+ * Lazy-loads `@opencode-ai/sdk`, starts a local server on port 4097 (avoiding
+ * sidecar's 4096), creates a session, sends prompts, and polls for completion.
+ */
+import type { InferenceClient, InferenceRequest, InferenceResult } from './inference-client';
+import { createLogger } from '../shared/logger';
+
+const logger = createLogger({ minLevel: 'info' });
+
+const DEFAULT_PORT = 4097;
+const POLL_INTERVAL_MS = 1_000;
+const POLL_TIMEOUT_MS = 120_000;
+const MODEL = { provider: 'anthropic', model: 'claude-sonnet-4-5' };
+
+export interface OpencodeClientDependencies {
+  port?: number;
+  cwd?: string;
+  loadSdk?: () => Promise<OpencodeSdkModule>;
+  now?: () => number;
+  pollIntervalMs?: number;
+  pollTimeoutMs?: number;
+}
+
+interface OpencodeSdkModule {
+  createOpencodeServer(options: { port: number; cwd: string }): Promise<{
+    url: string;
+    close?: () => Promise<void>;
+  }>;
+  createOpencodeClient(options: { baseUrl: string }): OpencodeSdkClient;
+}
+
+interface OpencodeSdkClient {
+  session: {
+    create(): Promise<{ id: string }>;
+    promptAsync(input: {
+      path: { id: string };
+      body: {
+        model: { provider: string; model: string };
+        parts: Array<{ type: string; text: string }>;
+        system: string;
+        tools?: string[];
+      };
+    }): Promise<void>;
+    messages(input: { path: { id: string } }): Promise<OpencodeMessagesResponse>;
+  };
+}
+
+interface OpencodeMessagesResponse {
+  messages?: Array<{
+    role?: string;
+    parts?: Array<{ type?: string; text?: string }>;
+  }>;
+}
+
+async function defaultLoadSdk(): Promise<OpencodeSdkModule> {
+  return import('@opencode-ai/sdk') as Promise<OpencodeSdkModule>;
+}
+
+function extractAssistantText(response: OpencodeMessagesResponse): string {
+  const messages = response.messages ?? [];
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message.role !== 'assistant') {
+      continue;
+    }
+    const text = (message.parts ?? [])
+      .filter((part) => part.type === 'text' && part.text)
+      .map((part) => part.text!)
+      .join('');
+    if (text.trim()) {
+      return text;
+    }
+  }
+  return '';
+}
+
+async function pollForAssistantText(
+  client: OpencodeSdkClient,
+  sessionId: string,
+  intervalMs: number,
+  timeoutMs: number,
+  now: () => number
+): Promise<string> {
+  const deadline = now() + timeoutMs;
+  let stableText = '';
+
+  while (now() < deadline) {
+    const response = await client.session.messages({ path: { id: sessionId } });
+    const text = extractAssistantText(response);
+    if (text && text === stableText) {
+      return text;
+    }
+    stableText = text;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  if (stableText.trim()) {
+    return stableText;
+  }
+
+  throw new Error('OpenCode inference timed out before a response arrived.');
+}
+
+export async function createOpencodeClient(
+  deps: OpencodeClientDependencies = {}
+): Promise<InferenceClient | null> {
+  const now = deps.now ?? Date.now;
+  const pollIntervalMs = deps.pollIntervalMs ?? POLL_INTERVAL_MS;
+  const pollTimeoutMs = deps.pollTimeoutMs ?? POLL_TIMEOUT_MS;
+
+  let sdk: OpencodeSdkModule;
+  try {
+    sdk = await (deps.loadSdk ?? defaultLoadSdk)();
+  } catch (error) {
+    logger.warn('inference', 'opencode.sdk_not_available', { error });
+    return null;
+  }
+
+  let server: { url: string; close?: () => Promise<void> } | null = null;
+  let sdkClient: OpencodeSdkClient | null = null;
+  let sessionId: string | null = null;
+
+  try {
+    server = await sdk.createOpencodeServer({
+      port: deps.port ?? DEFAULT_PORT,
+      cwd: deps.cwd ?? process.cwd()
+    });
+    sdkClient = sdk.createOpencodeClient({ baseUrl: server.url });
+    const session = await sdkClient.session.create();
+    sessionId = session.id;
+  } catch (error) {
+    logger.warn('inference', 'opencode.start_failed', { error });
+    await server?.close?.();
+    return null;
+  }
+
+  if (!sdkClient || !sessionId) {
+    return null;
+  }
+
+  const activeSessionId = sessionId;
+
+  return {
+    id: 'opencode-harness',
+    provider: 'opencode' as const,
+
+    async infer(request: InferenceRequest): Promise<InferenceResult> {
+      const start = now();
+      logger.info('inference', 'opencode.request_start');
+
+      await sdkClient.session.promptAsync({
+        path: { id: activeSessionId },
+        body: {
+          model: MODEL,
+          parts: [{ type: 'text', text: request.userMessage }],
+          system: request.systemPrompt,
+          tools: []
+        }
+      });
+
+      const text = await pollForAssistantText(
+        sdkClient,
+        activeSessionId,
+        pollIntervalMs,
+        pollTimeoutMs,
+        now
+      );
+      const latencyMs = now() - start;
+
+      logger.info('inference', 'opencode.request_done', { latencyMs });
+
+      return {
+        text,
+        model: `${MODEL.provider}/${MODEL.model}`,
+        latencyMs
+      };
+    }
+  };
+}

--- a/shadow-agent/src/inference/shadow-inference-engine.ts
+++ b/shadow-agent/src/inference/shadow-inference-engine.ts
@@ -17,7 +17,7 @@ import { buildContextPacket } from './context-packager';
 import { buildInferenceRequest } from './prompt-builder';
 import { parseModelResponse } from './response-parser';
 import { createInferenceTrigger, type TriggerConfig } from './trigger';
-import { createDirectApiClient } from './direct-api';
+import { createInferenceClient } from './inference-client-factory';
 import { loadCredentials } from './auth';
 import type { InferenceClient } from './inference-client';
 import type { EventBufferLike } from './inference-client';
@@ -40,6 +40,18 @@ export interface InferenceEngine {
   stop(): void;
 }
 
+type CheckpointedEventBuffer = EventBufferLike & Required<
+  Pick<EventBufferLike, 'registerConsumer' | 'readPending' | 'commitCheckpoint'>
+>;
+
+function isCheckpointedEventBuffer(buffer: EventBufferLike): buffer is CheckpointedEventBuffer {
+  return (
+    typeof buffer.registerConsumer === 'function' &&
+    typeof buffer.readPending === 'function' &&
+    typeof buffer.commitCheckpoint === 'function'
+  );
+}
+
 export function createInferenceEngine(opts: InferenceEngineOptions): InferenceEngine {
   const { buffer, getState, onInsights } = opts;
   const privacy = opts.privacy ?? DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS;
@@ -49,10 +61,7 @@ export function createInferenceEngine(opts: InferenceEngineOptions): InferenceEn
   let unsubscribeBuffer: (() => void) | null = null;
   let drainingPending = false;
   let pendingDrain = false;
-  const supportsBufferedDrain =
-    typeof buffer.registerConsumer === 'function' &&
-    typeof buffer.readPending === 'function' &&
-    typeof buffer.commitCheckpoint === 'function';
+  const checkpointBuffer = isCheckpointedEventBuffer(buffer) ? buffer : null;
 
   const runInference = async () => {
     if (!client) return;
@@ -97,7 +106,7 @@ export function createInferenceEngine(opts: InferenceEngineOptions): InferenceEn
   const trigger = createInferenceTrigger(() => void runInference(), opts.triggerConfig);
 
   const drainPendingEvents = async () => {
-    if (!supportsBufferedDrain) {
+    if (!checkpointBuffer) {
       return;
     }
     if (drainingPending) {
@@ -109,17 +118,28 @@ export function createInferenceEngine(opts: InferenceEngineOptions): InferenceEn
     try {
       do {
         pendingDrain = false;
-        const pending = await buffer.readPending!(INFERENCE_CONSUMER_ID);
+        const pending = await checkpointBuffer.readPending(INFERENCE_CONSUMER_ID);
         if (pending.events.length === 0) {
           continue;
         }
 
         trigger.onEvents(pending.events);
-        await buffer.commitCheckpoint!(INFERENCE_CONSUMER_ID, pending.events.at(-1)!.id);
+        await checkpointBuffer.commitCheckpoint(
+          INFERENCE_CONSUMER_ID,
+          pending.events.at(-1)!.id
+        );
       } while (pendingDrain);
+    } catch (err) {
+      logger.error('inference', 'engine.drain_pending_error', { error: err });
     } finally {
       drainingPending = false;
     }
+  };
+
+  const scheduleDrain = () => {
+    void drainPendingEvents().catch((err) => {
+      logger.error('inference', 'engine.drain_pending_unhandled', { error: err });
+    });
   };
 
   return {
@@ -133,7 +153,7 @@ export function createInferenceEngine(opts: InferenceEngineOptions): InferenceEn
         return;
       }
 
-      client = await createDirectApiClient();
+      client = await createInferenceClient();
 
       if (!client) {
         logger.warn('inference', 'engine.no_client', {
@@ -144,13 +164,14 @@ export function createInferenceEngine(opts: InferenceEngineOptions): InferenceEn
 
       logger.info('inference', 'engine.started', { provider: client.provider });
 
-      if (supportsBufferedDrain) {
-        await buffer.registerConsumer!(INFERENCE_CONSUMER_ID, { startAt: 'latest' });
+      if (checkpointBuffer) {
+        await checkpointBuffer.registerConsumer(INFERENCE_CONSUMER_ID, { startAt: 'latest' });
+        scheduleDrain();
       }
 
       unsubscribeBuffer = buffer.subscribe((events) => {
-        if (supportsBufferedDrain) {
-          void drainPendingEvents();
+        if (checkpointBuffer) {
+          scheduleDrain();
           return;
         }
         trigger.onEvents(events);

--- a/shadow-agent/src/renderer/App.tsx
+++ b/shadow-agent/src/renderer/App.tsx
@@ -1,10 +1,16 @@
 import { startTransition, useEffect, useMemo, useReducer, useRef } from 'react';
-import type { CanonicalEvent, DerivedState, ShadowAgentBridge, SnapshotPayload, TimelineItem } from '../shared/schema';
+import type {
+  CanonicalEvent,
+  DerivedState,
+  PrivacyPolicy,
+  ShadowAgentBridge,
+  SnapshotPayload,
+  TimelineItem,
+  TranscriptPrivacySettings
+} from '../shared/schema';
 import { appReducer, initialAppState } from './app-state';
-import CanvasRenderer from './canvas/CanvasRenderer';
-import TimelineScrubber from './components/TimelineScrubber';
-import ShadowPanel from './components/ShadowPanel';
 import { getHostCapabilities, type ShadowAgentHost } from './host';
+import { getRendererSurfaceAdapter } from './renderer-surface-adapter';
 import { formatClock, safeFileName, toLabel } from './view-model';
 
 const LIVE_REFRESH_DEBOUNCE_MS = 300;
@@ -124,9 +130,72 @@ function FileAttentionView({ files }: { files: DerivedState['fileAttention'] }) 
   );
 }
 
+function PrivacyPanel({
+  privacy,
+  interactive,
+  busy,
+  onToggle
+}: {
+  privacy: PrivacyPolicy;
+  interactive: boolean;
+  busy: boolean;
+  onToggle: (updates: Partial<TranscriptPrivacySettings>) => void;
+}) {
+  return (
+    <div className="privacy-panel">
+      <div className="timeline-item">
+        <div className="timeline-item__topline">
+          <span className="timeline-item__label">Processing mode</span>
+          <Badge tone={privacy.processingMode === 'local-only' ? 'accent' : 'danger'}>
+            {privacy.processingMode === 'local-only' ? 'Local only' : 'Off-host opted in'}
+          </Badge>
+        </div>
+        <p className="privacy-note">
+          Transcript content is sanitized before render, export, persistence, and prompt delivery unless you explicitly
+          allow a narrower exception below.
+        </p>
+      </div>
+
+      <label className="toggle">
+        <input
+          type="checkbox"
+          checked={privacy.allowOffHostInference}
+          disabled={!interactive || busy}
+          onChange={(event) => onToggle({ allowOffHostInference: event.currentTarget.checked })}
+        />
+        <div>
+          <strong>Allow off-host shadow inference</strong>
+          <p className="privacy-note">
+            Disabled by default. Turning this on allows sanitized inference payloads to leave the machine.
+          </p>
+        </div>
+      </label>
+
+      <label className="toggle">
+        <input
+          type="checkbox"
+          checked={privacy.allowRawTranscriptStorage}
+          disabled={!interactive || busy}
+          onChange={(event) => onToggle({ allowRawTranscriptStorage: event.currentTarget.checked })}
+        />
+        <div>
+          <strong>Allow raw transcript storage/export</strong>
+          <p className="privacy-note">
+            Disabled by default. This enables explicit raw replay export and similar raw storage paths.
+          </p>
+        </div>
+      </label>
+
+      {!interactive ? <p className="privacy-note">This host can report privacy policy but cannot change it.</p> : null}
+    </div>
+  );
+}
+
 export interface ShadowAgentAppProps {
   host: ShadowAgentHost;
 }
+
+const rendererSurfaceAdapter = getRendererSurfaceAdapter();
 
 export default function App({ host }: ShadowAgentAppProps) {
   const [state, dispatch] = useReducer(appReducer, undefined, initialAppState);
@@ -238,6 +307,12 @@ export default function App({ host }: ShadowAgentAppProps) {
     }
     return `${safeFileName(snapshot.record.title)}.jsonl`;
   }, [snapshot]);
+  const privacyPolicy: PrivacyPolicy = snapshot?.privacy ?? {
+    allowRawTranscriptStorage: false,
+    allowOffHostInference: false,
+    processingMode: 'local-only',
+    transcriptHandling: 'sanitized-by-default'
+  };
 
   const loadReplay = async () => {
     if (!host.openReplayFile) {
@@ -273,14 +348,14 @@ export default function App({ host }: ShadowAgentAppProps) {
     }
   };
 
-  const exportReplay = async () => {
+  const exportReplay = async (options?: { storeRawTranscript?: boolean }) => {
     if (!snapshot || !host.exportReplayJsonl) {
       return;
     }
 
     dispatch({ type: 'EXPORT_START' });
     try {
-      const result = await host.exportReplayJsonl(snapshot.events, exportName);
+      const result = await host.exportReplayJsonl(snapshot.events, exportName, options);
       if (result.error) {
         dispatch({ type: 'EXPORT_ERROR', message: result.error });
       } else {
@@ -288,6 +363,23 @@ export default function App({ host }: ShadowAgentAppProps) {
       }
     } catch (err) {
       dispatch({ type: 'EXPORT_ERROR', message: err instanceof Error ? err.message : 'Unable to export replay JSONL.' });
+    }
+  };
+
+  const updatePrivacySettings = async (updates: Partial<TranscriptPrivacySettings>) => {
+    if (!host.updatePrivacySettings) {
+      return;
+    }
+
+    dispatch({ type: 'PRIVACY_UPDATE_START' });
+    try {
+      const nextPolicy = await host.updatePrivacySettings(updates);
+      dispatch({ type: 'PRIVACY_UPDATE_SUCCESS', privacy: nextPolicy });
+    } catch (err) {
+      dispatch({
+        type: 'PRIVACY_UPDATE_ERROR',
+        message: err instanceof Error ? err.message : 'Unable to update privacy settings.'
+      });
     }
   };
 
@@ -301,6 +393,9 @@ export default function App({ host }: ShadowAgentAppProps) {
         ? { label: 'FIXTURE', tone: 'neutral' as const }
         : { label: toLabel(snapshot.source.kind), tone: 'neutral' as const }
     : null;
+  const GraphCanvas = rendererSurfaceAdapter.GraphCanvas;
+  const TimelineSurface = rendererSurfaceAdapter.Timeline;
+  const ShadowPanelSurface = rendererSurfaceAdapter.ShadowPanel;
 
   return (
     <div className="app-shell">
@@ -329,10 +424,20 @@ export default function App({ host }: ShadowAgentAppProps) {
             <button
               type="button"
               className="button button--primary"
-              onClick={exportReplay}
+              onClick={() => void exportReplay()}
               disabled={!snapshot || busy !== null}
             >
-              Export replay JSONL
+              Export sanitized replay
+            </button>
+          ) : null}
+          {capabilities.canExportReplayJsonl ? (
+            <button
+              type="button"
+              className="button button--ghost"
+              onClick={() => void exportReplay({ storeRawTranscript: true })}
+              disabled={!snapshot || busy !== null || !privacyPolicy.allowRawTranscriptStorage}
+            >
+              Export raw replay
             </button>
           ) : null}
         </div>
@@ -371,12 +476,20 @@ export default function App({ host }: ShadowAgentAppProps) {
         <div className="panels panels--3col">
           <Panel title="Graph" eyebrow="Agent topology" className="panel--wide panel--graph">
             <div className="graph-shell">
-              <CanvasRenderer agentNodes={snapshot?.state.agentNodes ?? []} />
+              <GraphCanvas agentNodes={snapshot?.state.agentNodes ?? []} />
             </div>
           </Panel>
 
           <div className="panels__left-bottom">
-            <TimelineScrubber timeline={snapshot?.state.timeline ?? []} />
+            <TimelineSurface timeline={snapshot?.state.timeline ?? []} />
+            <Panel title="Privacy" eyebrow="Consent gates">
+              <PrivacyPanel
+                privacy={privacyPolicy}
+                interactive={capabilities.canManagePrivacy}
+                busy={busy === 'privacy'}
+                onToggle={(updates) => void updatePrivacySettings(updates)}
+              />
+            </Panel>
             <Panel title="Timeline" eyebrow="Activity stream">
               <TimelineView timeline={snapshot?.state.timeline ?? []} />
             </Panel>
@@ -385,7 +498,7 @@ export default function App({ host }: ShadowAgentAppProps) {
             </Panel>
           </div>
 
-          <ShadowPanel
+          <ShadowPanelSurface
             phase={snapshot ? toLabel(snapshot.state.activePhase) : 'Unknown'}
             objective={snapshot?.state.currentObjective ?? 'Waiting for data'}
             riskSignals={snapshot?.state.riskSignals ?? []}

--- a/shadow-agent/src/renderer/app-state.ts
+++ b/shadow-agent/src/renderer/app-state.ts
@@ -5,13 +5,13 @@
  * without React Testing Library or jsdom.  App.tsx should use
  * `useReducer(appReducer, initialAppState())` to consume this.
  */
-import type { SnapshotPayload } from '../shared/schema';
+import type { PrivacyPolicy, SnapshotPayload } from '../shared/schema';
 
 // ---------------------------------------------------------------------------
 // State
 // ---------------------------------------------------------------------------
 
-export type BusyKind = 'booting' | 'loading' | 'exporting';
+export type BusyKind = 'booting' | 'loading' | 'exporting' | 'privacy';
 
 export interface AppState {
   /** Non-null while an async operation is in flight. */
@@ -37,7 +37,10 @@ export type AppAction =
   | { type: 'LOAD_ERROR'; message: string }
   | { type: 'EXPORT_START' }
   | { type: 'EXPORT_SUCCESS' }
-  | { type: 'EXPORT_ERROR'; message: string };
+  | { type: 'EXPORT_ERROR'; message: string }
+  | { type: 'PRIVACY_UPDATE_START' }
+  | { type: 'PRIVACY_UPDATE_SUCCESS'; privacy: PrivacyPolicy }
+  | { type: 'PRIVACY_UPDATE_ERROR'; message: string };
 
 // ---------------------------------------------------------------------------
 // Reducer
@@ -80,6 +83,24 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       return { ...state, busy: null, error: null };
 
     case 'EXPORT_ERROR':
+      return { ...state, busy: null, error: action.message };
+
+    case 'PRIVACY_UPDATE_START':
+      return { ...state, busy: 'privacy', error: null };
+
+    case 'PRIVACY_UPDATE_SUCCESS':
+      return {
+        busy: null,
+        error: null,
+        snapshot: state.snapshot
+          ? {
+              ...state.snapshot,
+              privacy: action.privacy
+            }
+          : state.snapshot
+      };
+
+    case 'PRIVACY_UPDATE_ERROR':
       return { ...state, busy: null, error: action.message };
 
     default: {

--- a/shadow-agent/src/renderer/canvas/CanvasRenderer.tsx
+++ b/shadow-agent/src/renderer/canvas/CanvasRenderer.tsx
@@ -116,9 +116,16 @@ function getQuadraticPoint(sx: number, sy: number, cx: number, cy: number, tx: n
   };
 }
 
-function drawGrid(ctx: CanvasRenderingContext2D, width: number, height: number, gridStep: number) {
+function drawGrid(
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  gridStep: number,
+  time = 0
+) {
   ctx.save();
-  ctx.strokeStyle = 'rgba(13, 13, 31, 0.72)';
+  const pulse = 0.06 + 0.03 * Math.sin(time * 0.0012);
+  ctx.strokeStyle = `rgba(102, 204, 255, ${pulse})`;
   ctx.lineWidth = 0.5;
   for (let x = 0; x < width + gridStep; x += gridStep) {
     for (let y = 0; y < height + gridStep; y += gridStep * 0.866) {
@@ -348,7 +355,7 @@ function syncCanvasToDisplaySize(canvas: HTMLCanvasElement, profile: QualityCont
   };
 }
 
-interface CanvasRendererProps {
+export interface CanvasRendererProps {
   agentNodes: AgentNode[];
   riskLevel?: RiskLevel;
   latestInsight?: ShadowInsight;
@@ -460,7 +467,7 @@ export default function CanvasRenderer({ agentNodes, riskLevel, latestInsight }:
     ctx.fillRect(0, 0, viewport.width, viewport.height);
 
     if (profile.showGrid) {
-      drawGrid(ctx, viewport.width, viewport.height, profile.gridStep);
+      drawGrid(ctx, viewport.width, viewport.height, profile.gridStep, time);
     }
 
     const nodesById = new Map(nodesRef.current.map((node) => [node.id, node]));

--- a/shadow-agent/src/renderer/components/ShadowPanel.tsx
+++ b/shadow-agent/src/renderer/components/ShadowPanel.tsx
@@ -1,7 +1,7 @@
 import { animated, useSpring } from '@react-spring/web';
 import type { ShadowInsight } from '../../shared/schema';
 
-interface ShadowPanelProps {
+export interface ShadowPanelProps {
   phase: string;
   objective: string;
   riskSignals: string[];

--- a/shadow-agent/src/renderer/components/TimelineScrubber.tsx
+++ b/shadow-agent/src/renderer/components/TimelineScrubber.tsx
@@ -4,7 +4,7 @@ import { animated, useSpring } from '@react-spring/web';
 
 const AnimatedDiv = animated.div as React.ElementType;
 
-interface TimelineScrubberProps {
+export interface TimelineScrubberProps {
   timeline: TimelineItem[];
 }
 

--- a/shadow-agent/src/renderer/host.ts
+++ b/shadow-agent/src/renderer/host.ts
@@ -1,8 +1,17 @@
-import type { CanonicalEvent, ExportResult, ShadowAgentBridge, SnapshotPayload } from '../shared/schema';
+import type {
+  CanonicalEvent,
+  ExportResult,
+  PrivacyPolicy,
+  ShadowAgentBridge,
+  SnapshotPayload,
+  TranscriptPrivacySettings
+} from '../shared/schema';
 
 export interface ShadowAgentHost {
   loadInitialSnapshot(): Promise<SnapshotPayload>;
   openReplayFile?: () => Promise<SnapshotPayload | null>;
+  getPrivacyPolicy?: () => Promise<PrivacyPolicy>;
+  updatePrivacySettings?: (updates: Partial<TranscriptPrivacySettings>) => Promise<PrivacyPolicy>;
   exportReplayJsonl?: (
     events: CanonicalEvent[],
     suggestedFileName?: string,
@@ -12,12 +21,16 @@ export interface ShadowAgentHost {
 
 export interface ShadowAgentHostCapabilities {
   canOpenReplayFile: boolean;
+  canManagePrivacy: boolean;
   canExportReplayJsonl: boolean;
 }
 
 export function getHostCapabilities(host: ShadowAgentHost): ShadowAgentHostCapabilities {
   return {
     canOpenReplayFile: typeof host.openReplayFile === 'function',
+    canManagePrivacy:
+      typeof host.getPrivacyPolicy === 'function' &&
+      typeof host.updatePrivacySettings === 'function',
     canExportReplayJsonl: typeof host.exportReplayJsonl === 'function'
   };
 }
@@ -32,6 +45,8 @@ export function createBridgeHost(bridge: ShadowAgentBridge): ShadowAgentHost {
   return {
     loadInitialSnapshot: () => bridge.bootstrap(),
     openReplayFile: bridge.openReplayFile,
+    getPrivacyPolicy: bridge.getPrivacyPolicy,
+    updatePrivacySettings: bridge.updatePrivacySettings,
     exportReplayJsonl: bridge.exportReplayJsonl
   };
 }

--- a/shadow-agent/src/renderer/renderer-surface-adapter.tsx
+++ b/shadow-agent/src/renderer/renderer-surface-adapter.tsx
@@ -1,0 +1,22 @@
+import type { ComponentType } from 'react';
+import CanvasRenderer, { type CanvasRendererProps } from './canvas/CanvasRenderer';
+import ShadowPanel, { type ShadowPanelProps } from './components/ShadowPanel';
+import TimelineScrubber, { type TimelineScrubberProps } from './components/TimelineScrubber';
+
+export interface RendererSurfaceAdapter {
+  readonly id: string;
+  readonly GraphCanvas: ComponentType<CanvasRendererProps>;
+  readonly Timeline: ComponentType<TimelineScrubberProps>;
+  readonly ShadowPanel: ComponentType<ShadowPanelProps>;
+}
+
+const currentRendererSurfaceAdapter: RendererSurfaceAdapter = {
+  id: 'default-renderer-surfaces',
+  GraphCanvas: CanvasRenderer,
+  Timeline: TimelineScrubber,
+  ShadowPanel
+};
+
+export function getRendererSurfaceAdapter(): RendererSurfaceAdapter {
+  return currentRendererSurfaceAdapter;
+}

--- a/shadow-agent/src/shared/privacy.ts
+++ b/shadow-agent/src/shared/privacy.ts
@@ -1,6 +1,6 @@
-import { readFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { parseDotenv } from './dotenv';
 import type { CanonicalEvent, PrivacyPolicy, TranscriptPrivacySettings } from './schema';
 
@@ -17,6 +17,7 @@ export const TRANSCRIPT_PRIVACY_ENV_KEYS = {
   allowRawTranscriptStorage: 'SHADOW_ALLOW_RAW_TRANSCRIPT_STORAGE',
   allowOffHostInference: 'SHADOW_ALLOW_OFF_HOST_INFERENCE'
 } as const;
+export const TRANSCRIPT_PRIVACY_SETTINGS_FILE = 'privacy.json';
 
 const EMAIL_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
 const BEARER_PATTERN = /\bBearer\s+[A-Z0-9._-]{12,}\b/gi;
@@ -44,6 +45,27 @@ function parseBooleanSetting(value: string | undefined): boolean | undefined {
   return undefined;
 }
 
+export function getTranscriptPrivacySettingsPath(
+  homeDirPath = homedir()
+): string {
+  return join(homeDirPath, '.shadow-agent', TRANSCRIPT_PRIVACY_SETTINGS_FILE);
+}
+
+async function readStoredPrivacySettings(settingsPath: string): Promise<Partial<TranscriptPrivacySettings>> {
+  try {
+    const raw = await readFile(settingsPath, 'utf8');
+    const parsed = JSON.parse(raw) as Partial<TranscriptPrivacySettings>;
+    return {
+      allowRawTranscriptStorage:
+        typeof parsed.allowRawTranscriptStorage === 'boolean' ? parsed.allowRawTranscriptStorage : undefined,
+      allowOffHostInference:
+        typeof parsed.allowOffHostInference === 'boolean' ? parsed.allowOffHostInference : undefined
+    };
+  } catch {
+    return {};
+  }
+}
+
 export function resolveTranscriptPrivacySettings(
   overrides: Partial<TranscriptPrivacySettings> = {},
   env: NodeJS.ProcessEnv = process.env
@@ -67,18 +89,37 @@ export function resolveTranscriptPrivacySettings(
 export async function loadTranscriptPrivacySettings(
   overrides: Partial<TranscriptPrivacySettings> = {},
   envPath = join(homedir(), '.shadow-agent', '.env'),
-  env: NodeJS.ProcessEnv = process.env
+  env: NodeJS.ProcessEnv = process.env,
+  settingsPath = getTranscriptPrivacySettingsPath()
 ): Promise<TranscriptPrivacySettings> {
+  const storedSettings = await readStoredPrivacySettings(settingsPath);
+  let fileEnv: NodeJS.ProcessEnv = {};
+
   try {
     const contents = await readFile(envPath, 'utf8');
-    const fileEnv = parseDotenv(contents);
-    return resolveTranscriptPrivacySettings(overrides, {
-      ...fileEnv,
-      ...env
-    });
+    fileEnv = parseDotenv(contents);
   } catch {
-    return resolveTranscriptPrivacySettings(overrides, env);
+    // Fall through to stored settings + process env defaults.
   }
+
+  return resolveTranscriptPrivacySettings(
+    { ...storedSettings, ...overrides },
+    { ...fileEnv, ...env }
+  );
+}
+
+export async function saveTranscriptPrivacySettings(
+  settings: TranscriptPrivacySettings,
+  settingsPath = getTranscriptPrivacySettingsPath()
+): Promise<TranscriptPrivacySettings> {
+  const normalized: TranscriptPrivacySettings = {
+    allowRawTranscriptStorage: settings.allowRawTranscriptStorage === true,
+    allowOffHostInference: settings.allowOffHostInference === true
+  };
+
+  await mkdir(dirname(settingsPath), { recursive: true });
+  await writeFile(settingsPath, `${JSON.stringify(normalized, null, 2)}\n`, 'utf8');
+  return normalized;
 }
 
 export function resolvePrivacyPolicy(

--- a/shadow-agent/src/shared/schema.ts
+++ b/shadow-agent/src/shared/schema.ts
@@ -125,6 +125,8 @@ export interface ShadowAgentBridge {
   onLiveEvents: (callback: (events: CanonicalEvent[]) => void) => () => void;
   getLiveSnapshot: () => Promise<SnapshotPayload | null>;
   openReplayFile: () => Promise<SnapshotPayload | null>;
+  getPrivacyPolicy: () => Promise<PrivacyPolicy>;
+  updatePrivacySettings: (updates: Partial<TranscriptPrivacySettings>) => Promise<PrivacyPolicy>;
   exportReplayJsonl: (
     events: CanonicalEvent[],
     suggestedFileName?: string,

--- a/shadow-agent/tests/capture.test.ts
+++ b/shadow-agent/tests/capture.test.ts
@@ -10,6 +10,7 @@ import type { CanonicalEvent } from '../src/shared/schema';
 import { normalizeEntry } from '../src/capture/normalizer';
 import { discoverActiveSession } from '../src/capture/session-discovery';
 import { mkdtempSync, rmSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -164,6 +165,29 @@ describe('createEventBuffer', () => {
     expect(all.map((event) => event.id)).toEqual(['x', 'y', 'z']);
     expect(buf.getMetrics().memoryDepth).toBe(2);
     expect(buf.getMetrics().spilledDepth).toBe(1);
+  });
+
+  it('sanitizes transcript content before spilling events to disk', async () => {
+    const root = makeTempRoot();
+    const buf = createEventBuffer({
+      memoryCapacity: 1,
+      totalCapacity: 4,
+      persistenceRoot: root
+    });
+
+    await buf.push([
+      {
+        ...makeEvent('secret'),
+        payload: { text: 'Email dev@example.com from D:\\_projects\\AgentVisualCrazy\\secret.txt' }
+      },
+      makeEvent('next')
+    ]);
+
+    const spill = await readFile(join(root, 'default', 'spill.jsonl'), 'utf8');
+    expect(spill).toContain('[redacted-email]');
+    expect(spill).toContain('[redacted-path]');
+    expect(spill).not.toContain('dev@example.com');
+    expect(spill).not.toContain('D:\\_projects\\AgentVisualCrazy\\secret.txt');
   });
 
   it('drops the oldest spilled events once the total queue capacity is exceeded', async () => {

--- a/shadow-agent/tests/capture/capture-transports.test.ts
+++ b/shadow-agent/tests/capture/capture-transports.test.ts
@@ -1,0 +1,280 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import http from 'node:http';
+import net from 'node:net';
+import { appendFile, mkdtemp, rename, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import type {
+  CaptureSession,
+  CaptureTransportContext,
+  CaptureTransportResetReason,
+  CaptureTransportSubscription
+} from '../../src/capture/capture-transport';
+import { createHttpStreamCaptureTransport } from '../../src/capture/http-stream-transport';
+import { createSocketCaptureTransport } from '../../src/capture/socket-transport';
+import { createFileTailCaptureTransport } from '../../src/capture/transcript-watcher';
+import { createWebSocketCaptureTransport } from '../../src/capture/websocket-transport';
+
+const tempDirs: string[] = [];
+const subscriptions: CaptureTransportSubscription[] = [];
+const servers: Array<{ close: () => Promise<void> }> = [];
+
+async function waitFor(assertion: () => boolean | Promise<boolean>, timeoutMs = 4_000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await assertion()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms`);
+}
+
+function createContext() {
+  const sessions: CaptureSession[] = [];
+  const resets: CaptureTransportResetReason[] = [];
+  const chunks: string[] = [];
+
+  const context: CaptureTransportContext = {
+    getBackpressure: () => ({
+      level: 'normal',
+      shouldThrottle: false,
+      totalRatio: 0,
+      pendingWrites: 0
+    }),
+    onSessionStarted: (session) => {
+      sessions.push(session);
+    },
+    onSessionReset: (_session, reason) => {
+      resets.push(reason);
+    },
+    onChunk: ({ chunk }) => {
+      chunks.push(chunk);
+    }
+  };
+
+  return { context, sessions, resets, chunks };
+}
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function listenHttp(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Expected TCP server address');
+  }
+  servers.push({
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      })
+  });
+  return address.port;
+}
+
+async function listenSocket(server: net.Server): Promise<number> {
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Expected TCP server address');
+  }
+  servers.push({
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      })
+  });
+  return address.port;
+}
+
+afterEach(async () => {
+  while (subscriptions.length > 0) {
+    await subscriptions.pop()?.stop();
+  }
+
+  while (servers.length > 0) {
+    await servers.pop()?.close();
+  }
+
+  while (tempDirs.length > 0) {
+    await rm(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe('capture transports', () => {
+  let originalWebSocket: typeof globalThis.WebSocket | undefined;
+
+  beforeEach(() => {
+    originalWebSocket = globalThis.WebSocket;
+  });
+
+  afterEach(() => {
+    if (originalWebSocket) {
+      globalThis.WebSocket = originalWebSocket;
+      return;
+    }
+    Reflect.deleteProperty(globalThis, 'WebSocket');
+  });
+
+  it('file-tail transport replays replacement files when the head checksum changes', async () => {
+    const dir = await makeTempDir('shadow-file-tail-');
+    const filePath = path.join(dir, 'session-a.jsonl');
+    const initialLine = '{"sessionId":"session-a","message":{"role":"assistant","content":"hello"}}\n';
+    const appendedLine = '{"sessionId":"session-a","message":{"role":"assistant","content":"again"}}\n';
+    const rotatedLine = '{"sessionId":"session-a","message":{"role":"assistant","content":"hullo"}}\n';
+    await writeFile(filePath, initialLine, 'utf8');
+
+    const { context, sessions, resets, chunks } = createContext();
+    const subscription = await createFileTailCaptureTransport({
+      kind: 'file-tail',
+      overridePath: filePath,
+      discoveryIntervalMs: 5_000,
+      fingerprintBytes: 256
+    }).start(context);
+    subscriptions.push(subscription);
+
+    await waitFor(() => sessions.length === 1 && chunks.join('').includes(initialLine));
+
+    await appendFile(filePath, appendedLine, 'utf8');
+    await waitFor(() => chunks.join('').includes(appendedLine));
+
+    await rename(filePath, path.join(dir, 'session-a.rotated.jsonl'));
+    await writeFile(filePath, rotatedLine, 'utf8');
+
+    await waitFor(() => resets.includes('rotation') && chunks.join('').includes(rotatedLine));
+  });
+
+  it('http-stream transport reconnects and emits streamed chunks', async () => {
+    let requestCount = 0;
+    const server = http.createServer((_, response) => {
+      requestCount += 1;
+      response.writeHead(200, { 'Content-Type': 'application/x-ndjson' });
+      if (requestCount === 1) {
+        response.write('{"step":1}');
+        setTimeout(() => response.end('\n'), 10);
+        return;
+      }
+      response.end('{"step":2}\n');
+    });
+    const port = await listenHttp(server);
+
+    const { context, sessions, resets, chunks } = createContext();
+    const subscription = await createHttpStreamCaptureTransport({
+      kind: 'http-stream',
+      url: `http://127.0.0.1:${port}/stream`,
+      reconnectDelayMs: 25,
+      sessionId: 'http-stream-test'
+    }).start(context);
+    subscriptions.push(subscription);
+
+    await waitFor(() => sessions.length === 1 && chunks.join('').includes('{"step":1}\n'));
+    await waitFor(() => resets.includes('reconnect') && chunks.join('').includes('{"step":2}\n'));
+  });
+
+  it('websocket transport normalizes framed messages and reconnects after close', async () => {
+    class MockWebSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSED = 3;
+      static instances: MockWebSocket[] = [];
+
+      readyState = MockWebSocket.CONNECTING;
+      onopen: ((event: Event) => void) | null = null;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onclose: ((event: CloseEvent) => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+
+      constructor(
+        public readonly url: string,
+        public readonly protocols?: string | string[]
+      ) {
+        MockWebSocket.instances.push(this);
+      }
+
+      emitOpen() {
+        this.readyState = MockWebSocket.OPEN;
+        this.onopen?.({} as Event);
+      }
+
+      emitMessage(data: unknown) {
+        this.onmessage?.({ data } as MessageEvent);
+      }
+
+      emitClose() {
+        this.readyState = MockWebSocket.CLOSED;
+        this.onclose?.({} as CloseEvent);
+      }
+
+      close() {
+        this.emitClose();
+      }
+    }
+
+    globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+
+    const { context, sessions, resets, chunks } = createContext();
+    const subscription = await createWebSocketCaptureTransport({
+      kind: 'websocket',
+      url: 'ws://localhost:4098/shadow',
+      reconnectDelayMs: 25,
+      sessionId: 'ws-test'
+    }).start(context);
+    subscriptions.push(subscription);
+
+    const firstSocket = MockWebSocket.instances[0];
+    firstSocket?.emitOpen();
+    firstSocket?.emitMessage('{"frame":1}');
+
+    await waitFor(() => sessions.length === 1 && chunks.includes('{"frame":1}\n'));
+
+    firstSocket?.emitClose();
+    await waitFor(() => MockWebSocket.instances.length === 2);
+    MockWebSocket.instances[1]?.emitOpen();
+
+    await waitFor(() => resets.includes('reconnect'));
+  });
+
+  it('socket transport reconnects after disconnects and keeps streaming chunks', async () => {
+    let connectionCount = 0;
+    const server = net.createServer((socket) => {
+      connectionCount += 1;
+      socket.write(`{"connection":${connectionCount}}\n`);
+      socket.end();
+    });
+    const port = await listenSocket(server);
+
+    const { context, sessions, resets, chunks } = createContext();
+    const subscription = await createSocketCaptureTransport({
+      kind: 'socket',
+      host: '127.0.0.1',
+      port,
+      reconnectDelayMs: 25,
+      sessionId: 'tcp-test'
+    }).start(context);
+    subscriptions.push(subscription);
+
+    await waitFor(() => sessions.length === 1 && chunks.join('').includes('{"connection":1}\n'));
+    await waitFor(() => resets.includes('reconnect') && chunks.join('').includes('{"connection":2}\n'));
+  });
+});

--- a/shadow-agent/tests/capture/session-manager.test.ts
+++ b/shadow-agent/tests/capture/session-manager.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import type {
+  CaptureSession,
+  CaptureTransport,
+  CaptureTransportContext,
+  CaptureTransportSubscription
+} from '../../src/capture/capture-transport';
+
+const { handleMock, removeHandlerMock } = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  removeHandlerMock: vi.fn()
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: handleMock,
+    removeHandler: removeHandlerMock
+  }
+}));
+
+import { createSessionManager } from '../../src/capture/session-manager';
+
+const tempDirs: string[] = [];
+
+async function waitFor(assertion: () => boolean | Promise<boolean>, timeoutMs = 4_000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await assertion()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms`);
+}
+
+afterEach(async () => {
+  handleMock.mockReset();
+  removeHandlerMock.mockReset();
+
+  while (tempDirs.length > 0) {
+    await rm(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe('createSessionManager', () => {
+  it('routes pluggable transport chunks through parser resets and into the live snapshot', async () => {
+    const tempRoot = await mkdtemp(path.join(tmpdir(), 'shadow-session-manager-'));
+    tempDirs.push(tempRoot);
+
+    const session: CaptureSession = {
+      sessionId: 'transport-session',
+      label: 'Live Socket: test',
+      source: 'claude-hook',
+      path: 'tcp://127.0.0.1:5000',
+      transportId: 'socket'
+    };
+
+    let subscriptionStopped = false;
+
+    const transport: CaptureTransport = {
+      id: 'test-transport',
+      kind: 'socket',
+      async start(context: CaptureTransportContext): Promise<CaptureTransportSubscription> {
+        await context.onSessionStarted(session);
+        await context.onChunk({
+          session,
+          chunk: '{"message":{"role":"assistant","content":"par'
+        });
+        await context.onSessionReset(session, 'reconnect');
+        await context.onChunk({
+          session,
+          chunk: '{"message":{"role":"assistant","content":"parsed after reset"}}\n'
+        });
+
+        return {
+          stop() {
+            subscriptionStopped = true;
+          }
+        };
+      }
+    };
+
+    const manager = createSessionManager(() => null, {
+      queuePersistenceRoot: tempRoot,
+      transport
+    });
+
+    await manager.start();
+    await waitFor(async () => {
+      const snapshot = await manager.getCurrentSnapshot();
+      return snapshot?.state.transcript.some((entry) => entry.text === 'parsed after reset') ?? false;
+    });
+
+    const snapshot = await manager.getCurrentSnapshot();
+    expect(snapshot?.source.path).toBe('tcp://127.0.0.1:5000');
+    expect(snapshot?.state.transcript).toHaveLength(1);
+    expect(snapshot?.state.transcript[0]?.text).toBe('parsed after reset');
+
+    manager.stop();
+    expect(subscriptionStopped).toBe(true);
+  });
+});

--- a/shadow-agent/tests/electron/renderer-host.test.ts
+++ b/shadow-agent/tests/electron/renderer-host.test.ts
@@ -2,6 +2,15 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ShadowAgentBridge } from '../../src/shared/schema';
 import { createElectronHost, getShadowAgentBridge } from '../../src/electron/renderer-host';
 
+function makePrivacyPolicy() {
+  return {
+    allowRawTranscriptStorage: false,
+    allowOffHostInference: false,
+    processingMode: 'local-only' as const,
+    transcriptHandling: 'sanitized-by-default' as const
+  };
+}
+
 describe('electron renderer host', () => {
   afterEach(() => {
     Reflect.deleteProperty(globalThis, 'window');
@@ -13,6 +22,8 @@ describe('electron renderer host', () => {
       onLiveEvents: vi.fn(() => vi.fn()),
       getLiveSnapshot: vi.fn(async () => null),
       openReplayFile: vi.fn(),
+      getPrivacyPolicy: vi.fn(async () => makePrivacyPolicy()),
+      updatePrivacySettings: vi.fn(async () => makePrivacyPolicy()),
       exportReplayJsonl: vi.fn()
     };
 
@@ -37,6 +48,8 @@ describe('electron renderer host', () => {
       onLiveEvents: vi.fn(() => vi.fn()),
       getLiveSnapshot: vi.fn(async () => null),
       openReplayFile: vi.fn(async () => null),
+      getPrivacyPolicy: vi.fn(async () => makePrivacyPolicy()),
+      updatePrivacySettings: vi.fn(async () => makePrivacyPolicy()),
       exportReplayJsonl: vi.fn(async () => ({ canceled: true }))
     };
 

--- a/shadow-agent/tests/electron/start-main-process-privacy.test.ts
+++ b/shadow-agent/tests/electron/start-main-process-privacy.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import path from 'node:path';
+
+const DEFAULT_PRIVACY_SETTINGS = {
+  allowRawTranscriptStorage: false,
+  allowOffHostInference: false
+} as const;
+
+const OPTED_IN_PRIVACY_SETTINGS = {
+  allowRawTranscriptStorage: true,
+  allowOffHostInference: true
+} as const;
+
+const whenReadyMock = vi.fn(() => Promise.resolve());
+const appOnMock = vi.fn();
+const quitMock = vi.fn();
+const getPathMock = vi.fn(() => 'C:\\shadow-user-data');
+const handleMock = vi.fn();
+const removeHandlerMock = vi.fn();
+const browserWindowOnMock = vi.fn();
+const loadFileMock = vi.fn();
+const loadUrlMock = vi.fn();
+const browserWindowInstance = {
+  on: browserWindowOnMock,
+  loadFile: loadFileMock,
+  loadURL: loadUrlMock,
+  webContents: {}
+};
+const BrowserWindowMock = vi.fn(() => browserWindowInstance);
+
+const loadTranscriptPrivacySettingsMock = vi.fn(async () => OPTED_IN_PRIVACY_SETTINGS);
+
+const bufferMock = {
+  getAll: vi.fn(async () => []),
+  subscribe: vi.fn(() => () => undefined),
+  registerConsumer: vi.fn(),
+  readPending: vi.fn(),
+  commitCheckpoint: vi.fn(),
+  getMetrics: vi.fn(),
+  getBackpressure: vi.fn(),
+  setSession: vi.fn(),
+  push: vi.fn()
+};
+
+const sessionManagerMock = {
+  start: vi.fn(async () => undefined),
+  stop: vi.fn(),
+  getBuffer: vi.fn(() => bufferMock),
+  getCurrentSnapshot: vi.fn(async () => null)
+};
+
+const createSessionManagerMock = vi.fn(() => sessionManagerMock);
+
+const inferenceEngineMock = {
+  start: vi.fn(async () => undefined),
+  stop: vi.fn()
+};
+
+const createInferenceEngineMock = vi.fn(() => inferenceEngineMock);
+
+vi.mock('electron', () => ({
+  app: {
+    whenReady: whenReadyMock,
+    on: appOnMock,
+    quit: quitMock,
+    isReady: vi.fn(() => true),
+    getAppPath: vi.fn(() => 'C:\\tmp'),
+    getPath: getPathMock
+  },
+  BrowserWindow: BrowserWindowMock,
+  ipcMain: {
+    handle: handleMock,
+    removeHandler: removeHandlerMock
+  }
+}));
+
+vi.mock('../../src/shared/privacy', () => ({
+  DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS: DEFAULT_PRIVACY_SETTINGS,
+  loadTranscriptPrivacySettings: loadTranscriptPrivacySettingsMock
+}));
+
+vi.mock('../../src/electron/session-io', () => ({
+  buildFixtureSnapshot: vi.fn(),
+  loadSnapshotFromFile: vi.fn(),
+  pickOpenFile: vi.fn(),
+  saveReplayFile: vi.fn()
+}));
+
+vi.mock('../../src/capture/session-manager', () => ({
+  createSessionManager: createSessionManagerMock
+}));
+
+vi.mock('../../src/inference/shadow-inference-engine', () => ({
+  createInferenceEngine: createInferenceEngineMock
+}));
+
+async function flushStartup(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('startMainProcess privacy wiring', () => {
+  beforeEach(() => {
+    whenReadyMock.mockClear();
+    appOnMock.mockClear();
+    quitMock.mockClear();
+    getPathMock.mockClear();
+    handleMock.mockClear();
+    removeHandlerMock.mockClear();
+    BrowserWindowMock.mockClear();
+    browserWindowOnMock.mockClear();
+    loadFileMock.mockClear();
+    loadUrlMock.mockClear();
+    loadTranscriptPrivacySettingsMock.mockClear();
+    createSessionManagerMock.mockClear();
+    createInferenceEngineMock.mockClear();
+    inferenceEngineMock.start.mockClear();
+    inferenceEngineMock.stop.mockClear();
+    sessionManagerMock.start.mockClear();
+    sessionManagerMock.stop.mockClear();
+    sessionManagerMock.getBuffer.mockClear();
+    bufferMock.getAll.mockClear();
+    vi.resetModules();
+  });
+
+  it('forwards loaded privacy settings into both capture and inference startup', async () => {
+    const { startMainProcess } = await import('../../src/electron/start-main-process');
+
+    startMainProcess();
+    await flushStartup();
+
+    expect(loadTranscriptPrivacySettingsMock).toHaveBeenCalledOnce();
+    expect(createSessionManagerMock).toHaveBeenCalledOnce();
+    const [, sessionManagerOptions] = createSessionManagerMock.mock.calls[0] as [
+      () => unknown,
+      {
+        getPrivacy: () => typeof OPTED_IN_PRIVACY_SETTINGS;
+        queuePersistenceRoot: string;
+      }
+    ];
+    expect(sessionManagerOptions.queuePersistenceRoot).toBe(path.join('C:\\shadow-user-data', 'capture-queue'));
+    expect(sessionManagerOptions.getPrivacy()).toEqual(OPTED_IN_PRIVACY_SETTINGS);
+    expect(createInferenceEngineMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        buffer: bufferMock,
+        privacy: OPTED_IN_PRIVACY_SETTINGS,
+        onInsights: expect.any(Function),
+        getState: expect.any(Function)
+      })
+    );
+    expect(sessionManagerMock.start).toHaveBeenCalledOnce();
+    expect(inferenceEngineMock.start).toHaveBeenCalledOnce();
+  });
+});

--- a/shadow-agent/tests/electron/start-main-process-privacy.test.ts
+++ b/shadow-agent/tests/electron/start-main-process-privacy.test.ts
@@ -86,6 +86,10 @@ vi.mock('../../src/electron/session-io', () => ({
   saveReplayFile: vi.fn()
 }));
 
+vi.mock('../../src/capture/capture-transports', () => ({
+  resolveCaptureTransportOptionsFromEnv: vi.fn(() => ({ kind: 'file-tail' }))
+}));
+
 vi.mock('../../src/capture/session-manager', () => ({
   createSessionManager: createSessionManagerMock
 }));
@@ -95,8 +99,9 @@ vi.mock('../../src/inference/shadow-inference-engine', () => ({
 }));
 
 async function flushStartup(): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, 0));
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  await vi.waitFor(() => {
+    expect(createSessionManagerMock).toHaveBeenCalled();
+  });
 }
 
 describe('startMainProcess privacy wiring', () => {
@@ -120,7 +125,6 @@ describe('startMainProcess privacy wiring', () => {
     sessionManagerMock.stop.mockClear();
     sessionManagerMock.getBuffer.mockClear();
     bufferMock.getAll.mockClear();
-    vi.resetModules();
   });
 
   it('forwards loaded privacy settings into both capture and inference startup', async () => {
@@ -131,7 +135,7 @@ describe('startMainProcess privacy wiring', () => {
 
     expect(loadTranscriptPrivacySettingsMock).toHaveBeenCalledOnce();
     expect(createSessionManagerMock).toHaveBeenCalledOnce();
-    const [, sessionManagerOptions] = createSessionManagerMock.mock.calls[0] as [
+    const [, sessionManagerOptions] = createSessionManagerMock.mock.calls[0] as unknown as [
       () => unknown,
       {
         getPrivacy: () => typeof OPTED_IN_PRIVACY_SETTINGS;

--- a/shadow-agent/tests/electron/start-main-process.test.ts
+++ b/shadow-agent/tests/electron/start-main-process.test.ts
@@ -81,7 +81,16 @@ describe('registerIpcHandlers', () => {
     expect(removeHandlerMock).toHaveBeenCalledWith('shadow-agent:bootstrap');
     expect(removeHandlerMock).toHaveBeenCalledWith('shadow-agent:open-replay-file');
     expect(removeHandlerMock).toHaveBeenCalledWith('shadow-agent:export-replay-jsonl');
-    expect(handleMock).toHaveBeenCalledTimes(3);
+    expect(removeHandlerMock).toHaveBeenCalledWith('shadow-agent:get-privacy-policy');
+    expect(removeHandlerMock).toHaveBeenCalledWith('shadow-agent:update-privacy-settings');
+    const handledChannels = handleMock.mock.calls.map(([channel]) => channel);
+    expect(handledChannels).toEqual(expect.arrayContaining([
+      'shadow-agent:bootstrap',
+      'shadow-agent:open-replay-file',
+      'shadow-agent:export-replay-jsonl',
+      'shadow-agent:get-privacy-policy',
+      'shadow-agent:update-privacy-settings'
+    ]));
 
     const removeOrder = removeHandlerMock.mock.invocationCallOrder;
     const handleOrder = handleMock.mock.invocationCallOrder;
@@ -174,6 +183,41 @@ describe('registerIpcHandlers', () => {
     expect(result.error).toBe('disk full');
     expect(result.canceled).toBe(false);
   });
+
+  it('privacy handlers expose and update the current policy', async () => {
+    const { registerIpcHandlers } = await import('../../src/electron/start-main-process');
+    const updateSettings = vi.fn(async (updates: { allowOffHostInference?: boolean }) => ({
+      allowRawTranscriptStorage: true,
+      allowOffHostInference: updates.allowOffHostInference === true
+    }));
+
+    registerIpcHandlers(() => null, {
+      getSettings: () => ({
+        allowRawTranscriptStorage: false,
+        allowOffHostInference: false
+      }),
+      updateSettings
+    });
+
+    const getHandler = getHandlerFor('shadow-agent:get-privacy-policy');
+    const updateHandler = getHandlerFor('shadow-agent:update-privacy-settings');
+    const current = await getHandler() as SnapshotPayload['privacy'];
+    const next = await updateHandler(undefined, { allowOffHostInference: true }) as SnapshotPayload['privacy'];
+
+    expect(current).toEqual({
+      allowRawTranscriptStorage: false,
+      allowOffHostInference: false,
+      processingMode: 'local-only',
+      transcriptHandling: 'sanitized-by-default'
+    });
+    expect(updateSettings).toHaveBeenCalledWith({ allowOffHostInference: true });
+    expect(next).toEqual({
+      allowRawTranscriptStorage: true,
+      allowOffHostInference: true,
+      processingMode: 'off-host-opted-in',
+      transcriptHandling: 'sanitized-by-default'
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -189,6 +233,8 @@ describe('ShadowAgentBridge surface', () => {
       onLiveEvents: () => () => undefined,
       getLiveSnapshot: async () => null as SnapshotPayload | null,
       openReplayFile: async () => null as SnapshotPayload | null,
+      getPrivacyPolicy: async () => makeSnapshot().privacy,
+      updatePrivacySettings: async () => makeSnapshot().privacy,
       exportReplayJsonl: async (_events = [], _suggestedFileName?: string, _options?: { storeRawTranscript?: boolean }) => ({ canceled: true })
     };
     (globalThis as unknown as { window: { shadowAgent: typeof bridge } }).window = { shadowAgent: bridge };
@@ -203,8 +249,10 @@ describe('ShadowAgentBridge surface', () => {
       'bootstrap',
       'exportReplayJsonl',
       'getLiveSnapshot',
+      'getPrivacyPolicy',
       'onLiveEvents',
-      'openReplayFile'
+      'openReplayFile',
+      'updatePrivacySettings'
     ]);
 
     Reflect.deleteProperty(globalThis, 'window');

--- a/shadow-agent/tests/inference/inference-client-factory.test.ts
+++ b/shadow-agent/tests/inference/inference-client-factory.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as directApi from '../../src/inference/direct-api';
+import * as opencodeClient from '../../src/inference/opencode-client';
+import { createInferenceClient } from '../../src/inference/inference-client-factory';
+
+describe('createInferenceClient', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.SHADOW_INFERENCE_PROVIDER;
+  });
+
+  it('prefers the direct Anthropic client when SHADOW_INFERENCE_PROVIDER=anthropic', async () => {
+    process.env.SHADOW_INFERENCE_PROVIDER = 'anthropic';
+    const direct = { id: 'anthropic-direct-api', provider: 'anthropic' as const, infer: vi.fn() };
+    vi.spyOn(directApi, 'createDirectApiClient').mockResolvedValue(direct);
+    vi.spyOn(opencodeClient, 'createOpencodeClient').mockResolvedValue({
+      id: 'opencode-harness',
+      provider: 'opencode',
+      infer: vi.fn()
+    });
+
+    const client = await createInferenceClient();
+
+    expect(client).toBe(direct);
+    expect(opencodeClient.createOpencodeClient).not.toHaveBeenCalled();
+  });
+
+  it('uses OpenCode when available and no provider override is set', async () => {
+    const opencode = { id: 'opencode-harness', provider: 'opencode' as const, infer: vi.fn() };
+    vi.spyOn(opencodeClient, 'createOpencodeClient').mockResolvedValue(opencode);
+    vi.spyOn(directApi, 'createDirectApiClient').mockResolvedValue({
+      id: 'anthropic-direct-api',
+      provider: 'anthropic',
+      infer: vi.fn()
+    });
+
+    const client = await createInferenceClient();
+
+    expect(client).toBe(opencode);
+    expect(directApi.createDirectApiClient).not.toHaveBeenCalled();
+  });
+
+  it('falls back to Anthropic when OpenCode is unavailable', async () => {
+    const direct = { id: 'anthropic-direct-api', provider: 'anthropic' as const, infer: vi.fn() };
+    vi.spyOn(opencodeClient, 'createOpencodeClient').mockResolvedValue(null);
+    vi.spyOn(directApi, 'createDirectApiClient').mockResolvedValue(direct);
+
+    const client = await createInferenceClient();
+
+    expect(client).toBe(direct);
+  });
+});

--- a/shadow-agent/tests/inference/opencode-client.test.ts
+++ b/shadow-agent/tests/inference/opencode-client.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { createOpencodeClient } from '../../src/inference/opencode-client';
+
+describe('createOpencodeClient', () => {
+  it('returns null when the OpenCode SDK cannot be loaded', async () => {
+    const client = await createOpencodeClient({
+      loadSdk: async () => {
+        throw new Error('missing sdk');
+      }
+    });
+
+    expect(client).toBeNull();
+  });
+
+  it('returns null when the OpenCode server fails to start', async () => {
+    const client = await createOpencodeClient({
+      loadSdk: async () => ({
+        createOpencodeServer: async () => {
+          throw new Error('port in use');
+        },
+        createOpencodeClient: () => {
+          throw new Error('unreachable');
+        }
+      })
+    });
+
+    expect(client).toBeNull();
+  });
+
+  it('forwards prompts and polls for the assistant response', async () => {
+    const promptCalls: Array<{ system: string; user: string }> = [];
+    let pollCount = 0;
+
+    const client = await createOpencodeClient({
+      pollIntervalMs: 0,
+      pollTimeoutMs: 50,
+      now: () => 1_000,
+      loadSdk: async () => ({
+        createOpencodeServer: async () => ({ url: 'http://127.0.0.1:4097' }),
+        createOpencodeClient: () => ({
+          session: {
+            create: async () => ({ id: 'session-1' }),
+            promptAsync: async ({ body }) => {
+              promptCalls.push({
+                system: body.system,
+                user: body.parts[0]?.text ?? ''
+              });
+            },
+            messages: async () => {
+              pollCount += 1;
+              if (pollCount < 3) {
+                return { messages: [] };
+              }
+              return {
+                messages: [
+                  {
+                    role: 'assistant',
+                    parts: [{ type: 'text', text: '{"phase":"exploration"}' }]
+                  }
+                ]
+              };
+            }
+          }
+        })
+      })
+    });
+
+    expect(client).not.toBeNull();
+    expect(client?.provider).toBe('opencode');
+
+    const result = await client!.infer({
+      systemPrompt: 'shadow system',
+      userMessage: 'context packet'
+    });
+
+    expect(promptCalls).toEqual([
+      { system: 'shadow system', user: 'context packet' }
+    ]);
+    expect(result.text).toContain('exploration');
+    expect(result.model).toBe('anthropic/claude-sonnet-4-5');
+    expect(result.latencyMs).toBe(0);
+  });
+});

--- a/shadow-agent/tests/privacy.test.ts
+++ b/shadow-agent/tests/privacy.test.ts
@@ -3,8 +3,10 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  getTranscriptPrivacySettingsPath,
   loadTranscriptPrivacySettings,
   resolveTranscriptPrivacySettings,
+  saveTranscriptPrivacySettings,
   sanitizeTranscriptText
 } from '../src/shared/privacy';
 
@@ -74,6 +76,21 @@ describe('privacy sanitization', () => {
 
     await expect(loadTranscriptPrivacySettings({}, envPath, {})).resolves.toEqual({
       allowRawTranscriptStorage: false,
+      allowOffHostInference: false
+    });
+  });
+
+  it('loads persisted privacy settings when no env opt-in is present', async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'shadow-privacy-store-'));
+    tempDirs.push(tempDir);
+    const settingsPath = getTranscriptPrivacySettingsPath(tempDir);
+    await saveTranscriptPrivacySettings({
+      allowRawTranscriptStorage: true,
+      allowOffHostInference: false
+    }, settingsPath);
+
+    await expect(loadTranscriptPrivacySettings({}, path.join(tempDir, '.env'), {}, settingsPath)).resolves.toEqual({
+      allowRawTranscriptStorage: true,
       allowOffHostInference: false
     });
   });

--- a/shadow-agent/tests/renderer/app-state.test.ts
+++ b/shadow-agent/tests/renderer/app-state.test.ts
@@ -177,6 +177,25 @@ describe('appReducer — export flow', () => {
     expect(next.error).toBe('disk full');
     expect(next.snapshot).toBe(snapshot); // preserved
   });
+
+  it('PRIVACY_UPDATE_SUCCESS updates snapshot privacy and clears busy', () => {
+    const snapshot = makeSnapshot();
+    const prior: AppState = { busy: 'privacy', error: null, snapshot };
+    const next = appReducer(prior, {
+      type: 'PRIVACY_UPDATE_SUCCESS',
+      privacy: {
+        allowRawTranscriptStorage: true,
+        allowOffHostInference: true,
+        processingMode: 'off-host-opted-in',
+        transcriptHandling: 'sanitized-by-default'
+      }
+    });
+
+    expect(next.busy).toBeNull();
+    expect(next.error).toBeNull();
+    expect(next.snapshot?.privacy.processingMode).toBe('off-host-opted-in');
+    expect(next.snapshot?.privacy.allowRawTranscriptStorage).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/shadow-agent/tests/renderer/canvas-quality.test.ts
+++ b/shadow-agent/tests/renderer/canvas-quality.test.ts
@@ -38,6 +38,17 @@ describe('canvas quality controller', () => {
     expect(state.resourceBudgetTier).toBe('high');
   });
 
+  it('caps ultra tier under very large scenes', () => {
+    const heavyMetrics = makeMetrics({
+      nodeCount: 80,
+      edgeCount: 120,
+      particleCount: 400,
+      pixelCount: 3840 * 2160,
+      deviceMemoryGb: 4
+    });
+    expect(tierFromResourcePressure(estimateResourcePressure(heavyMetrics), false)).not.toBe('ultra');
+  });
+
   it('recovers one tier at a time without exceeding the resource budget', () => {
     const constrainedMetrics = makeMetrics({
       nodeCount: 24,

--- a/shadow-agent/tests/renderer/host.test.ts
+++ b/shadow-agent/tests/renderer/host.test.ts
@@ -44,6 +44,7 @@ describe('renderer host helpers', () => {
     await expect(host.loadInitialSnapshot()).resolves.toBe(snapshot);
     expect(getHostCapabilities(host)).toEqual({
       canOpenReplayFile: false,
+      canManagePrivacy: false,
       canExportReplayJsonl: false
     });
   });

--- a/shadow-agent/tests/renderer/renderer-surface-adapter.test.ts
+++ b/shadow-agent/tests/renderer/renderer-surface-adapter.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import CanvasRenderer from '../../src/renderer/canvas/CanvasRenderer';
+import ShadowPanel from '../../src/renderer/components/ShadowPanel';
+import TimelineScrubber from '../../src/renderer/components/TimelineScrubber';
+import { getRendererSurfaceAdapter } from '../../src/renderer/renderer-surface-adapter';
+
+describe('renderer surface adapter', () => {
+  it('keeps a stable boundary around the current renderer surfaces', () => {
+    const adapter = getRendererSurfaceAdapter();
+
+    expect(adapter.id).toBe('default-renderer-surfaces');
+    expect(adapter.GraphCanvas).toBe(CanvasRenderer);
+    expect(adapter.Timeline).toBe(TimelineScrubber);
+    expect(adapter.ShadowPanel).toBe(ShadowPanel);
+  });
+});

--- a/shadow-agent/tsconfig.json
+++ b/shadow-agent/tsconfig.json
@@ -14,7 +14,7 @@
       "@/*": ["src/*"]
     },
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
## **User description**
Re-introduces the pluggable capture transport system that was inadvertently pushed directly to main on commit 333830e. Main was reverted in da1bf2d to restore PR-based workflow; this PR re-applies the changes via cherry-pick (now f6d0274).

## Original commit body

Adds multiple transport implementations and refactors the capture layer:

- **New modules** (shadow-agent/src/capture/): capture-transport.ts, capture-transports.ts, http-stream-transport.ts, socket-transport.ts, websocket-transport.ts, renderer-surface-adapter.tsx
- **Updated capture modules**: session-manager.ts, transcript-watcher.ts, event-buffer.ts, ipc-bridge.ts
- **Electron**: start-main-process.ts, preload.ts
- **Inference**: shadow-inference-engine.ts, direct-api.ts
- **Renderer**: App.tsx, app-state.ts, host.ts, CanvasRenderer.tsx, ShadowPanel.tsx, TimelineScrubber.tsx
- **Shared**: privacy.ts, schema.ts
- **Tests**: new capture/electron/renderer/privacy test suites
- **Docs**: architecture, domain-events, domain-inference, getting-started, README

37 files changed, 2013 insertions(+), 245 deletions(-)


___

## **CodeAnt-AI Description**
**Add pluggable live capture transports and saved privacy controls**

### What Changed
- Live capture can now come from a transcript file, streaming HTTP, WebSocket, or raw socket feed, with automatic reconnects for network sources.
- File-based capture now replays replaced or rotated transcript files from the beginning instead of missing new events.
- The app now includes a Privacy panel where users can turn on off-host inference or raw transcript storage/export, and those choices are saved between runs.
- Export now defaults to sanitized replay output, and raw export stays unavailable until raw transcript storage is allowed.
- Shadow inference now uses OpenCode when available, with a direct Anthropic fallback if it is not.

### Impact
`✅ Fewer missed live events after transcript rotation`
`✅ Persistent privacy choices between app launches`
`✅ Safer default replay exports`
`✅ Broader capture source support`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Pluggable Capture Transport System for Shadow-Agent

## Overview

Re-introduces a pluggable capture transport system that was previously committed directly to main (commit 333830e) and subsequently reverted (da1bf2d). This PR applies those changes via proper PR workflow as a cherry-pick (f6d0274).

**Scope:** 37 files, +2,013 / -245 lines  
**Key Addition:** Modular capture transport architecture supporting file-tail, HTTP streaming, WebSocket, and raw socket inputs with automatic reconnection and rotation detection.

---

## Core Capture Transport System

### New Transport Modules

| Module | Purpose | Key Capabilities |
|--------|---------|------------------|
| `capture-transport.ts` | Type contracts | Defines `CaptureTransport`, `CaptureSession`, `CaptureTransportKind` enums |
| `capture-transports.ts` | Transport factory | Resolves transport options from environment; delegates to specific transport builders |
| `file-tail-transport.ts` | Local JSONL tailing | SHA1-based rotation detection; maintains offset; supports backpressure-aware pausing |
| `http-stream-transport.ts` | HTTP NDJSON streaming | Automatic reconnection; `TextDecoder` per connection; handles chunked responses |
| `websocket-transport.ts` | WebSocket framing | Converts binary/text to UTF-8 newline-delimited chunks; reconnect on unexpected close |
| `socket-transport.ts` | Raw TCP socket | Backpressure-aware throttling; automatic reconnection with clamped delay |

### Session & Capture Flow

- **Lifecycle Hooks:** `onSessionStarted`, `onSessionReset` (rotation/truncation/reconnect), `onChunk`, `stop()`
- **Environment Variables:**
  - `SHADOW_CAPTURE_TRANSPORT` (default: `file-tail`) — transport kind
  - `SHADOW_CAPTURE_FILE` — file-tail override path
  - `SHADOW_CAPTURE_HTTP_URL` or `SHADOW_CAPTURE_TARGET` — HTTP endpoint
  - `SHADOW_CAPTURE_WS_URL` or `SHADOW_CAPTURE_TARGET` — WebSocket endpoint
  - `SHADOW_CAPTURE_SOCKET_HOST`, `SHADOW_CAPTURE_SOCKET_PORT` — TCP socket
  - `SHADOW_CAPTURE_RECONNECT_MS` (min 50ms) — reconnection delay

---

## Privacy & Persistence

### Privacy Settings System

**New Exports:**
- `loadTranscriptPrivacySettings()` — reads from `.env` + persisted `~/.shadow-agent/privacy.json`
- `saveTranscriptPrivacySettings()` — persists boolean settings to disk
- `getTranscriptPrivacySettingsPath()` — resolves settings file path

**Electron Privacy Panel:**
- Toggles: `allowOffHostInference`, `allowRawTranscriptStorage`
- Persisted to `~/.shadow-agent/privacy.json`
- Environment variables override saved settings at runtime

**Snapshot Privacy:**
- `event-buffer.ts` sanitizes spill file contents via `prepareEventsForStorage()`
- `session-manager.ts` uses dynamic `getPrivacy()` instead of static privacy value
- IPC bridge evaluates privacy at flush time, not creation time

### Export Options

- **Sanitized replay** (default) — user/path redaction
- **Raw replay** — full transcript (gated by `allowRawTranscriptStorage` toggle)

---

## Inference Engine & OpenCode Integration

### New Modules

| Module | Purpose |
|--------|---------|
| `opencode-client.ts` | SDK-backed OpenCode client; lazy-loads SDK; polls for response stabilization |
| `inference-client-factory.ts` | Selects OpenCode or direct Anthropic based on `SHADOW_INFERENCE_PROVIDER` env |

### Provider Selection

1. **Explicit override:** `SHADOW_INFERENCE_PROVIDER=anthropic|opencode`
2. **Default:** Try OpenCode first, fall back to direct Anthropic
3. **Fallback:** Direct Anthropic if OpenCode unavailable

**Type Guard:** Replaced `supportsBufferedDrain` boolean with `isCheckpointedEventBuffer()` type guard for buffered-drain logic.

---

## Renderer & UI Components

### Privacy Panel

New `PrivacyPanel` component with:
- Processing mode indicator (local-only / off-host)
- Two consent toggles (disabled when `canManagePrivacy` is false or update in progress)
- Privacy policy driven by `snapshot?.privacy`

### Component Exports

Made public (previously internal):
- `CanvasRendererProps`
- `ShadowPanelProps`
- `TimelineScrubberProps`

### Renderer Surface Adapter

New module `renderer-surface-adapter.tsx`:
- `RendererSurfaceAdapter` interface — standardizes `GraphCanvas`, `Timeline`, `ShadowPanel`
- `getRendererSurfaceAdapter()` — returns shared default adapter
- Enables pluggable renderer implementations

### Canvas Improvements

- `drawGrid()` accepts optional `time` parameter for sinusoidal pulse animation
- Heavy-scene quality regression test added

---

## Electron IPC Expansion

### New Handlers

| Channel | Method |
|---------|--------|
| `shadow-agent:get-privacy-policy` | Returns current `PrivacyPolicy` snapshot |
| `shadow-agent:update-privacy-settings` | Persists updates; returns new policy; triggers inference engine refresh |

### Preload Bridge

Exposed methods:
- `getPrivacyPolicy(): Promise<PrivacyPolicy>`
- `updatePrivacySettings(updates: Partial<TranscriptPrivacySettings>): Promise<PrivacyPolicy>`

### Host Capabilities

Added to `ShadowAgentHostCapabilities`:
- `canManagePrivacy: boolean` — true when both privacy methods are implemented

---

## App State & Reducer

### New Action Types

| Action | Busy State | Behavior |
|--------|-----------|----------|
| `PRIVACY_UPDATE_START` | `'privacy'` | Clear error |
| `PRIVACY_UPDATE_SUCCESS` | cleared | Merge privacy into snapshot |
| `PRIVACY_UPDATE_ERROR` | cleared | Set error message |

### Export Modes

- `exportReplay()` — default sanitized
- `exportReplay({ storeRawTranscript: true })` — raw (if `allowRawTranscriptStorage` enabled)

---

## Testing Coverage

### New Test Suites

| Suite | Coverage |
|-------|----------|
| `capture.test.ts` | Event buffer spill sanitization |
| `capture/capture-transports.test.ts` | File-tail rotation, HTTP reconnect, WebSocket framing, socket reconnect (280 lines) |
| `capture/session-manager.test.ts` | Transport lifecycle integration (105 lines) |
| `electron/renderer-host.test.ts` | Privacy policy stubs in preload bridge |
| `electron/start-main-process-privacy.test.ts` | Privacy loading, session/inference engine setup (158 lines) |
| `electron/start-main-process.test.ts` | Privacy IPC handlers + bridge contract (extended) |
| `privacy.test.ts` | Persisted settings loading |
| `renderer/app-state.test.ts` | Privacy update reducer |
| `renderer/host.test.ts` | `canManagePrivacy` capability |
| `renderer/renderer-surface-adapter.test.ts` | Adapter stability and component references |
| `inference/opencode-client.test.ts` | SDK loading, server startup, inference polling (83 lines) |
| `inference/inference-client-factory.test.ts` | Provider selection logic (52 lines) |
| `renderer/canvas-quality.test.ts` | Heavy-scene tier regression |

**Status:** 250 tests pass; npm run build successful; pre-commit checks pass.

---

## Documentation Updates

| Document | Changes |
|----------|---------|
| `docs/architecture.md` | Updated auth & event-ingestion sections; clarified OpenCode credential migration; pluggable transport design |
| `docs/domain-events.md` | Replaced future adapters section with concrete transport enum (file-tail, HTTP, WebSocket, socket) |
| `docs/domain-inference.md` | Runtime order: OpenCode first, fallback direct Anthropic; privacy toggle persistence |
| `docs/getting-started.md` | New **Privacy Controls** section; local-only default; env var overrides |
| `shadow-agent/README.md` | Updated Privacy Defaults to reference Privacy panel & `~/.shadow-agent/privacy.json` |
| `docs/plans/plan-master-a-must-do.md` | Closed issues `#21`, `#24` (2026-04-20) |
| `docs/todo.md` | Removed obsolete implementation tasks |

---

## Configuration & Dependencies

- **TypeScript:** `moduleResolution` changed from `Node` to `bundler`
- **Dependencies:** Added `@opencode-ai/sdk@^1.15.5`

---

## Status & Notes

- **Current State:** Open, requires rebase (merge conflict with main)
- **Review Feedback:** Applied (commit c9c2533) with fixes to transcript-watcher, capture-transports validation, HTTP/WebSocket TextDecoder, event-buffer privacy, session-manager async sequencing, privacy override precedence, inference engine error handling
- **Ready to Merge:** Pending CI green + conflict resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->