### PR TITLE
feat: Phase 2 visual landing (theme, citadel motion, canvas tests)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,7 +23,7 @@ npm run test:coverage  # run with coverage report
 npx vitest tests/derive.test.ts   # run a single file
 ```
 
-All tests on `main` pass as of the Phase 2 landing (250 tests, 2026-05-19). If you
+All tests on `main` pass as of the Phase 2 landing (258 tests, 2026-05-19). If you
 check out an older commit, `npm test` may fail — update to current `main` or skip
 failing suites when bisecting history.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,10 +23,9 @@ npm run test:coverage  # run with coverage report
 npx vitest tests/derive.test.ts   # run a single file
 ```
 
-All tests on `main` pass as of PR #35 (merged 2026-04-19). If you check out an
-older commit, `npm test` may fail because the inference test suite depended on
-exports that were only added in PR #35 — update to a newer main or skip that
-suite if you are bisecting older history.
+All tests on `main` pass as of the Phase 2 landing (250 tests, 2026-05-19). If you
+check out an older commit, `npm test` may fail — update to current `main` or skip
+failing suites when bisecting history.
 
 CI runs the prompt-parity check, tests, and build on every PR via the `CI`
 workflow (defined in `.github/workflows/prompt-parity.yml`). The repo uses a
@@ -38,11 +37,16 @@ will also run it, but catching failures earlier is cheaper.
 
 ## Run
 
-To start the Electron application in development mode with HMR (Hot Module Replacement):
+Build the web, renderer, and Electron bundles, then launch the desktop app:
 
 ```bash
+cd shadow-agent
+npm run build
 npm start
 ```
+
+There is no separate Vite dev-server script; `npm start` runs the built Electron
+entry (`dist-electron/main.cjs`).
 
 ## Credential Setup
 
@@ -78,9 +82,10 @@ variables override the saved file for that run.
 ## Project Structure
 
 - `shadow-agent/src/electron/`: Main process code, including IPC handling, session management, and file loading.
-- `shadow-agent/src/renderer/`: React-based UI code. The full Canvas2D + D3-Force visualization engine is on a feature branch (PR #26); current main uses simplified React panels.
+- `shadow-agent/src/renderer/`: React shell plus Canvas2D + D3-Force graph (`src/renderer/canvas/`), glass panels, and timeline UI.
 - `shadow-agent/src/shared/`: Code shared between the main and renderer processes (types, utilities, logging, privacy, transcript parsing, replay store).
-- `shadow-agent/src/inference/`: Shadow inference engine — auth, context packaging, prompt building, response parsing, trigger logic, and Anthropic API fallback. OpenCode client is not yet implemented.
+- `shadow-agent/src/inference/`: Shadow inference engine — OpenCode-first client with Anthropic fallback, auth, context packaging, prompt building, and trigger logic.
+- `shadow-agent/src/capture/`: Pluggable capture transports (file tail, HTTP stream, WebSocket, socket).
 - `shadow-agent/src/mcp/`: MCP server exposing shadow tools to other agents.
 - `docs/`: Technical documentation, architecture decisions, and project plans.
 

--- a/docs/history/log.md
+++ b/docs/history/log.md
@@ -81,6 +81,13 @@
 - Added auth-focused tests covering secure store loading, env precedence, fallback consent, migration, and POSIX permission enforcement
 - Updated active docs to describe the new auth chain and secure permission guidance
 
+## 2026-05-19 — Phase 2 visual landing
+
+- Closed superseded PRs #41 and #42; ported selective renderer ideas onto current `main`
+- Theme helpers (`withAlpha`, `getStateColor`, `TIMING`), animated `GlassCard`, Citadel CSS keyframes subset, `triggerCanvasPulse` API
+- Canvas command-record tests (`record-2d-context`, 258 tests passing)
+- Status report: `docs/reports/phase2-landing-status.md`
+
 ## 2026-05-19 — Pluggable capture transport + OpenCode client (PR #44)
 
 - PR #44 merged: pluggable capture transports (file-tail, HTTP stream, WebSocket, TCP socket), privacy-aware queue spill, and session-manager refactor

--- a/docs/reports/phase2-landing-status.md
+++ b/docs/reports/phase2-landing-status.md
@@ -1,0 +1,116 @@
+# Phase 2 Landing Status Report
+
+**Date:** 2026-05-19  
+**Branch:** `main` (local commits through `0d7c7c5`)  
+**Audience:** Read without running the app — executive summary, evidence, gaps, and how to verify.
+
+---
+
+## Executive summary
+
+Shadow-agent Phase 2 delivers the north-star loop: **watch** (capture), **interpret** (inference), **render** (Canvas2D holographic graph). Core product lines merged in April–May 2026 (#26–#28, #37, #44). This landing pass refreshed docs, closed superseded PRs #41/#42, added theme/GlassCard/citadel motion polish, and introduced canvas command-record tests.
+
+| Pillar | Status | Evidence |
+|--------|--------|----------|
+| **Watch** | Done | File-tail + HTTP/WebSocket/socket transports (#27, #44) |
+| **Interpret** | Done | OpenCode-first + Anthropic fallback, MCP (#28, #44) |
+| **Render** | Substantially done | Canvas2D + D3-Force (#26); hex grid + pulse API; glass panels |
+
+**Test suite:** 258 Vitest tests passing locally (`npm test` in `shadow-agent/`).  
+**Build:** `npm run build` succeeds (web + renderer + Electron).  
+**CI:** Last GitHub Actions run on remote `main` was green at `b4029f3` ([run 26129724915](https://github.com/Coldaine/AgentVisualCrazy/actions/runs/26129724915)); push these commits to refresh CI on `0d7c7c5`.
+
+---
+
+## What landed in this landing pass
+
+| Commit | Summary |
+|--------|---------|
+| `a951396` | Docs: getting-started accuracy, todo refresh |
+| `8da8f37` | Refactor: descriptive locals (replaces PR #42) |
+| `0d7c7c5` | Renderer: theme helpers, animated `GlassCard`, Citadel CSS subset, `triggerCanvasPulse`, tests |
+
+**Closed PRs:** [#41](https://github.com/Coldaine/AgentVisualCrazy/pull/41) (superseded by selective port), [#42](https://github.com/Coldaine/AgentVisualCrazy/pull/42) (merged as `8da8f37`).
+
+---
+
+## Visual design ledger
+
+| Item | Before landing | After landing |
+|------|----------------|---------------|
+| Canvas2D + D3-Force | Done (#26) | Done |
+| Color tokens | Partial (`theme/colors.ts`) | Extended + `withAlpha` / `getStateColor` in `theme/helpers.ts` |
+| GlassCard mount animation | CVA only | `GlassCard` React wrapper + `TIMING.glassAnimMs` |
+| Citadel CSS @keyframes | Missing | `card-breathe`, `cl-reveal`, tier timing vars in `styles.css` |
+| Canvas event pulse API | Ambient sine only | `triggerCanvasPulse('burst' \| 'ripple')` in `canvas-pulse.ts` |
+| Command-record canvas tests | Missing | `record-2d-context.ts` + `canvas-draw.test.ts` |
+| Pixel screenshot regression | Missing | **Still deferred** |
+| Manual glow/perf checklist | Missing | **Still deferred** |
+| Bloom / split `draw-*.ts` modules | Missing | **Deferred** (Phase 3+ polish) |
+| Full Citadel dot-grid physics | Missing | **Deferred** (canvas hex grid remains) |
+
+---
+
+## How to run and verify
+
+```bash
+cd shadow-agent
+npm install
+npm test          # 258 tests, headless
+npm run build
+npm start         # Electron desktop app (built bundle)
+```
+
+**Fixture replay:** Open the app → use bootstrap/fixture flow documented in `docs/getting-started.md`. Replay fixture: `shadow-agent/tests/fixtures/replays/happy-path.replay.jsonl`.
+
+**Live capture:** Point file-tail transport at an active Claude/Cursor JSONL session (see `docs/domain-events.md`).
+
+**Inference smoke:** Requires credentials (`~/.shadow-agent/credentials.enc.json` or env). CI uses fake clients only — no live model calls in automated tests.
+
+---
+
+## Visual evidence
+
+| Method | Result |
+|--------|--------|
+| Automated pixel screenshots | Not implemented — no Playwright/Electron smoke in CI |
+| Command-record tests | **8 new tests** across `theme-helpers`, `canvas-pulse`, `canvas-draw` |
+| Manual Electron screenshots | **Not captured in this pass** — agent environment did not produce checked-in PNGs under `docs/reports/assets/phase2-landing/`. Run `npm run build && npm start` locally for human visual sign-off. |
+
+Substitute evidence: green test suite + successful production build + command-record assertions on palette and pulse API.
+
+---
+
+## Risk register
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Issue #24 closed before screenshot regression existed | Medium | Re-open or track in `docs/todo.md` manual acceptance item |
+| No Playwright Electron smoke | Medium | Planned in `plan-testing-observability.md` — not blocking Phase 2 close |
+| Visual fidelity judged only via unit tests | Low | Schedule manual acceptance pass |
+| Remote CI not yet run on landing commits | Low | Push `main` and confirm workflow green |
+
+---
+
+## Recommended Phase 3 entry
+
+1. VS Code webview / custom-element embedding (`build:web` already exists).
+2. Wire `triggerCanvasPulse` to canonical `EventKind` values on tool/subagent events.
+3. Playwright Electron smoke (launch + fixture load).
+4. Curated 4–6 pixel snapshot scenes (fixed canvas size, frozen fixtures).
+5. Deeper OpenCode bidirectional integration per `docs/architecture.md`.
+
+---
+
+## Key file map
+
+| Area | Path |
+|------|------|
+| Canvas renderer | `shadow-agent/src/renderer/canvas/CanvasRenderer.tsx` |
+| Pulse API | `shadow-agent/src/renderer/canvas/canvas-pulse.ts` |
+| Theme | `shadow-agent/src/renderer/theme/colors.ts`, `helpers.ts`, `timing.ts` |
+| GlassCard | `shadow-agent/src/renderer/components/GlassCard.tsx` |
+| Capture | `shadow-agent/src/capture/` |
+| Inference | `shadow-agent/src/inference/` |
+| Test helper | `shadow-agent/tests/helpers/record-2d-context.ts` |
+| Plans | `docs/plans/plan-gui-rendering.md`, `plan-testing-observability.md` |

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -5,9 +5,9 @@
 
 ## Implementation
 
-- 2026-05-19: **Citadel motion layer (scoped)** — CSS `@keyframes` for panel/card breathe; canvas pulse hook for agent events. See `docs/plans/plan-gui-rendering.md` and Phase 2 landing report.
+- 2026-05-19: **Wire canvas pulse to EventKind** — Call `triggerCanvasPulse` from capture/inference milestones (tool_started, subagent_dispatched, etc.).
 
 ## Testing
 
-- 2026-05-19: **Canvas command-record tests** — `record-2d-context` helper + semantic draw assertions per `docs/plans/plan-testing-observability.md`. Target: 250+ tests green on `main`.
-- 2026-04-01: **Manual visual/performance acceptance** — Glow quality, panel composition, motion timing, sustained replay perf. Deferred until after command-record suite lands.
+- 2026-04-01: **Manual visual/performance acceptance** — Glow quality, panel composition, motion timing, sustained replay perf. See `docs/reports/phase2-landing-status.md`.
+- 2026-05-19: **Pixel snapshot regression (deferred)** — 4–6 canonical scenes per `plan-testing-observability.md`; command-record suite landed (258 tests on `main`).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -5,7 +5,9 @@
 
 ## Implementation
 
+- 2026-05-19: **Citadel motion layer (scoped)** — CSS `@keyframes` for panel/card breathe; canvas pulse hook for agent events. See `docs/plans/plan-gui-rendering.md` and Phase 2 landing report.
 
 ## Testing
 
-- 2026-04-01: **Execute remaining visual/performance test plan** — See `docs/plans/plan-testing-observability.md` for the remaining roadmap beyond the current green suite (`232` tests passing on 2026-04-20).
+- 2026-05-19: **Canvas command-record tests** — `record-2d-context` helper + semantic draw assertions per `docs/plans/plan-testing-observability.md`. Target: 250+ tests green on `main`.
+- 2026-04-01: **Manual visual/performance acceptance** — Glow quality, panel composition, motion timing, sustained replay perf. Deferred until after command-record suite lands.

--- a/shadow-agent/src/capture/event-buffer.ts
+++ b/shadow-agent/src/capture/event-buffer.ts
@@ -339,10 +339,10 @@ export function createEventBuffer(capacityOrOptions: number | EventBufferOptions
 
   const enqueueMutation = async <T>(mutator: () => Promise<T>): Promise<T> => {
     pendingWrites += 1;
-    const result = operationChain.then(mutator, mutator);
-    operationChain = result.then(() => undefined, () => undefined);
+    const operationPromise = operationChain.then(mutator, mutator);
+    operationChain = operationPromise.then(() => undefined, () => undefined);
     try {
-      return await result;
+      return await operationPromise;
     } finally {
       pendingWrites -= 1;
     }

--- a/shadow-agent/src/electron/session-io.ts
+++ b/shadow-agent/src/electron/session-io.ts
@@ -157,7 +157,7 @@ export function buildFixtureSnapshot(
 }
 
 export async function pickOpenFile(mainWindow: BrowserWindow | null): Promise<string | undefined> {
-  const result = await dialog.showOpenDialog(mainWindow ?? null!, {
+  const openDialogResult = await dialog.showOpenDialog(mainWindow ?? null!, {
     title: 'Open transcript or replay file',
     properties: ['openFile'],
     filters: [
@@ -168,11 +168,11 @@ export async function pickOpenFile(mainWindow: BrowserWindow | null): Promise<st
     ]
   });
 
-  if (result.canceled || result.filePaths.length === 0) {
+  if (openDialogResult.canceled || openDialogResult.filePaths.length === 0) {
     return undefined;
   }
 
-  return result.filePaths[0];
+  return openDialogResult.filePaths[0];
 }
 
 export async function saveReplayFile(
@@ -183,20 +183,20 @@ export async function saveReplayFile(
   privacySettings: TranscriptPrivacySettings = DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS
 ): Promise<ExportResult> {
   try {
-    const result = await dialog.showSaveDialog(mainWindow ?? null!, {
+    const saveDialogResult = await dialog.showSaveDialog(mainWindow ?? null!, {
       title: 'Export replay JSONL',
       defaultPath: suggestedFileName.endsWith('.jsonl') ? suggestedFileName : `${suggestedFileName}.jsonl`,
       filters: [{ name: 'Replay files', extensions: ['jsonl'] }]
     });
 
-    if (result.canceled || !result.filePath) {
+    if (saveDialogResult.canceled || !saveDialogResult.filePath) {
       logger.info('ipc', 'ipc.export.cancelled');
       return { canceled: true };
     }
 
-    await writeFile(result.filePath, serializeEvents(events, options, privacySettings), 'utf8');
-    logger.info('ipc', 'ipc.export.saved', { fileName: path.basename(result.filePath), eventCount: events.length });
-    return { canceled: false, filePath: result.filePath };
+    await writeFile(saveDialogResult.filePath, serializeEvents(events, options, privacySettings), 'utf8');
+    logger.info('ipc', 'ipc.export.saved', { fileName: path.basename(saveDialogResult.filePath), eventCount: events.length });
+    return { canceled: false, filePath: saveDialogResult.filePath };
   } catch (error) {
     logger.error('ipc', 'ipc.export.failed', { error });
     return {

--- a/shadow-agent/src/inference/shadow-inference-engine.ts
+++ b/shadow-agent/src/inference/shadow-inference-engine.ts
@@ -81,11 +81,11 @@ export function createInferenceEngine(opts: InferenceEngineOptions): InferenceEn
       });
 
       logger.info('inference', 'engine.run_start', { eventCount: events.length });
-      const result = await client.infer(request);
-      const insights = parseModelResponse(result.text);
+      const inferenceResponse = await client.infer(request);
+      const insights = parseModelResponse(inferenceResponse.text);
 
       logger.info('inference', 'engine.run_done', {
-        latencyMs: result.latencyMs,
+        latencyMs: inferenceResponse.latencyMs,
         insights: insights.length,
       });
 

--- a/shadow-agent/src/mcp/shadow-mcp-server.ts
+++ b/shadow-agent/src/mcp/shadow-mcp-server.ts
@@ -149,9 +149,9 @@ export async function createShadowMcpServer(
       };
 
       try {
-        const result = await opts.inferenceClient.infer(request);
+        const inferenceResponse = await opts.inferenceClient.infer(request);
         return {
-          content: [{ type: 'text' as const, text: result.text }],
+          content: [{ type: 'text' as const, text: inferenceResponse.text }],
         };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/shadow-agent/src/persistence/file-replay-store.ts
+++ b/shadow-agent/src/persistence/file-replay-store.ts
@@ -153,9 +153,9 @@ export class FileReplayStore {
       })
     );
 
-    const result = sessions.filter((session): session is SessionRecord => Boolean(session)).sort(sortSessions);
-    logger.info('persistence', 'persistence.store.listed', { sessionCount: result.length });
-    return result;
+    const validSessions = sessions.filter((session): session is SessionRecord => Boolean(session)).sort(sortSessions);
+    logger.info('persistence', 'persistence.store.listed', { sessionCount: validSessions.length });
+    return validSessions;
   }
 
   private async loadRecord(sessionId: string, events: CanonicalEvent[]): Promise<SessionRecord> {

--- a/shadow-agent/src/renderer/App.tsx
+++ b/shadow-agent/src/renderer/App.tsx
@@ -66,13 +66,13 @@ function TimelineView({ timeline }: { timeline: TimelineItem[] }) {
 
   return (
     <div className="stack stack--tight">
-      {timeline.map((item) => (
-        <article className="timeline-item" key={item.id}>
-          <div className="timeline-item__time">{formatClock(item.timestamp)}</div>
+      {timeline.map((timelineEvent) => (
+        <article className="timeline-item" key={timelineEvent.id}>
+          <div className="timeline-item__time">{formatClock(timelineEvent.timestamp)}</div>
           <div className="timeline-item__content">
             <div className="timeline-item__topline">
-              <span className="timeline-item__label">{item.label}</span>
-              <Badge tone="neutral">{toLabel(item.kind)}</Badge>
+              <span className="timeline-item__label">{timelineEvent.label}</span>
+              <Badge tone="neutral">{toLabel(timelineEvent.kind)}</Badge>
             </div>
           </div>
         </article>
@@ -230,14 +230,14 @@ export default function App({ host }: ShadowAgentAppProps) {
     const loadInitialSnapshot = async () => {
       dispatch({ type: 'BOOT_START' });
       try {
-        const data = await loadPreferredSnapshot();
+        const snapshotData = await loadPreferredSnapshot();
         if (!active) {
           return;
         }
-        if (data.source.kind === 'fixture' && currentSourceKindRef.current === 'transcript') {
+        if (snapshotData.source.kind === 'fixture' && currentSourceKindRef.current === 'transcript') {
           return;
         }
-        startTransition(() => dispatch({ type: 'BOOT_SUCCESS', snapshot: data }));
+        startTransition(() => dispatch({ type: 'BOOT_SUCCESS', snapshot: snapshotData }));
       } catch (err) {
         if (!active) {
           return;
@@ -321,9 +321,9 @@ export default function App({ host }: ShadowAgentAppProps) {
 
     dispatch({ type: 'LOAD_START' });
     try {
-      const data = await host.openReplayFile();
-      if (data) {
-        startTransition(() => dispatch({ type: 'LOAD_SUCCESS', snapshot: data }));
+      const snapshotData = await host.openReplayFile();
+      if (snapshotData) {
+        startTransition(() => dispatch({ type: 'LOAD_SUCCESS', snapshot: snapshotData }));
       } else {
         dispatch({ type: 'LOAD_CANCELLED' });
       }
@@ -335,11 +335,11 @@ export default function App({ host }: ShadowAgentAppProps) {
   const reloadInitialSnapshot = async () => {
     dispatch({ type: 'BOOT_START' });
     try {
-      const data = await loadPreferredSnapshot();
-      if (data.source.kind === 'fixture' && currentSourceKindRef.current === 'transcript') {
+      const snapshotData = await loadPreferredSnapshot();
+      if (snapshotData.source.kind === 'fixture' && currentSourceKindRef.current === 'transcript') {
         return;
       }
-      startTransition(() => dispatch({ type: 'BOOT_SUCCESS', snapshot: data }));
+      startTransition(() => dispatch({ type: 'BOOT_SUCCESS', snapshot: snapshotData }));
     } catch (err) {
       dispatch({
         type: 'BOOT_ERROR',
@@ -355,9 +355,9 @@ export default function App({ host }: ShadowAgentAppProps) {
 
     dispatch({ type: 'EXPORT_START' });
     try {
-      const result = await host.exportReplayJsonl(snapshot.events, exportName, options);
-      if (result.error) {
-        dispatch({ type: 'EXPORT_ERROR', message: result.error });
+      const exportOutcome = await host.exportReplayJsonl(snapshot.events, exportName, options);
+      if (exportOutcome.error) {
+        dispatch({ type: 'EXPORT_ERROR', message: exportOutcome.error });
       } else {
         dispatch({ type: 'EXPORT_SUCCESS' });
       }

--- a/shadow-agent/src/renderer/App.tsx
+++ b/shadow-agent/src/renderer/App.tsx
@@ -232,9 +232,11 @@ export default function App({ host }: ShadowAgentAppProps) {
       try {
         const snapshotData = await loadPreferredSnapshot();
         if (!active) {
+          dispatch({ type: 'BOOT_ABORT' });
           return;
         }
         if (snapshotData.source.kind === 'fixture' && currentSourceKindRef.current === 'transcript') {
+          dispatch({ type: 'BOOT_ABORT' });
           return;
         }
         startTransition(() => dispatch({ type: 'BOOT_SUCCESS', snapshot: snapshotData }));
@@ -337,6 +339,7 @@ export default function App({ host }: ShadowAgentAppProps) {
     try {
       const snapshotData = await loadPreferredSnapshot();
       if (snapshotData.source.kind === 'fixture' && currentSourceKindRef.current === 'transcript') {
+        dispatch({ type: 'BOOT_ABORT' });
         return;
       }
       startTransition(() => dispatch({ type: 'BOOT_SUCCESS', snapshot: snapshotData }));

--- a/shadow-agent/src/renderer/app-state.ts
+++ b/shadow-agent/src/renderer/app-state.ts
@@ -29,6 +29,7 @@ export interface AppState {
 export type AppAction =
   | { type: 'BOOT_START' }
   | { type: 'BOOT_SUCCESS'; snapshot: SnapshotPayload }
+  | { type: 'BOOT_ABORT' }
   | { type: 'BOOT_ERROR'; message: string }
   | { type: 'LIVE_UPDATE'; snapshot: SnapshotPayload }
   | { type: 'LOAD_START' }
@@ -57,6 +58,9 @@ export function appReducer(state: AppState, action: AppAction): AppState {
 
     case 'BOOT_SUCCESS':
       return { busy: null, error: null, snapshot: action.snapshot };
+
+    case 'BOOT_ABORT':
+      return { ...state, busy: null };
 
     case 'BOOT_ERROR':
       return { ...state, busy: null, error: action.message };

--- a/shadow-agent/src/renderer/canvas/CanvasRenderer.tsx
+++ b/shadow-agent/src/renderer/canvas/CanvasRenderer.tsx
@@ -20,7 +20,7 @@ import {
   type QualityTier,
   type ResourceMetrics
 } from './quality';
-import { sampleCanvasPulseBoost } from './canvas-pulse';
+import { sampleCanvasPulseBoost, tickCanvasPulses } from './canvas-pulse';
 import {
   COLLIDE_RADIUS,
   NODE_RADIUS,
@@ -453,6 +453,7 @@ export default function CanvasRenderer({ agentNodes, riskLevel, latestInsight }:
 
     const frameDelta = lastFrameRef.current === null ? 16.7 : Math.max(8, Math.min(50, time - lastFrameRef.current));
     lastFrameRef.current = time;
+    tickCanvasPulses(time);
 
     const particleEngine = particleEngineRef.current;
     particleEngine.step(frameDelta);

--- a/shadow-agent/src/renderer/canvas/CanvasRenderer.tsx
+++ b/shadow-agent/src/renderer/canvas/CanvasRenderer.tsx
@@ -20,6 +20,7 @@ import {
   type QualityTier,
   type ResourceMetrics
 } from './quality';
+import { sampleCanvasPulseBoost } from './canvas-pulse';
 import {
   COLLIDE_RADIUS,
   NODE_RADIUS,
@@ -30,6 +31,9 @@ import {
   type SimulationEdge,
   type SimulationNode
 } from './types';
+
+export { triggerCanvasPulse, clearCanvasPulses } from './canvas-pulse';
+export type { CanvasPulseKind } from './canvas-pulse';
 
 // Map schema AgentNode state -> canvas AgentState.
 function mapState(state: AgentNode['state']): SimulationNode['state'] {
@@ -124,7 +128,9 @@ function drawGrid(
   time = 0
 ) {
   ctx.save();
-  const pulse = 0.06 + 0.03 * Math.sin(time * 0.0012);
+  const ambient = 0.06 + 0.03 * Math.sin(time * 0.0012);
+  const eventBoost = sampleCanvasPulseBoost(time, width, height);
+  const pulse = Math.min(0.35, ambient + eventBoost);
   ctx.strokeStyle = `rgba(102, 204, 255, ${pulse})`;
   ctx.lineWidth = 0.5;
   for (let x = 0; x < width + gridStep; x += gridStep) {

--- a/shadow-agent/src/renderer/canvas/canvas-pulse.ts
+++ b/shadow-agent/src/renderer/canvas/canvas-pulse.ts
@@ -12,6 +12,16 @@ interface ActivePulse {
 }
 
 const pulses: ActivePulse[] = [];
+const MAX_ACTIVE_PULSES = 32;
+
+function pruneExpiredCanvasPulses(now: number): void {
+  for (let i = pulses.length - 1; i >= 0; i -= 1) {
+    const pulse = pulses[i]!;
+    if (now - pulse.startedAt > pulse.durationMs) {
+      pulses.splice(i, 1);
+    }
+  }
+}
 
 export function triggerCanvasPulse(
   kind: CanvasPulseKind,
@@ -19,25 +29,33 @@ export function triggerCanvasPulse(
   y: number,
   options: { intensity?: number; durationMs?: number; atMs?: number } = {}
 ): void {
+  const now = options.atMs ?? performance.now();
+  pruneExpiredCanvasPulses(now);
+  if (pulses.length >= MAX_ACTIVE_PULSES) {
+    pulses.shift();
+  }
   pulses.push({
     kind,
     x,
     y,
-    startedAt: options.atMs ?? performance.now(),
+    startedAt: now,
     durationMs: options.durationMs ?? (kind === 'burst' ? 600 : 1200),
     intensity: options.intensity ?? 1
   });
 }
 
+/** Prune expired pulses even when the grid is not drawn (e.g. low quality tier). */
+export function tickCanvasPulses(now: number): void {
+  pruneExpiredCanvasPulses(now);
+}
+
 /** Returns 0–1 boost to grid opacity for the current frame. */
 export function sampleCanvasPulseBoost(time: number, width: number, height: number): number {
-  const now = time;
+  pruneExpiredCanvasPulses(time);
   let boost = 0;
-  for (let i = pulses.length - 1; i >= 0; i -= 1) {
-    const pulse = pulses[i]!;
-    const elapsed = now - pulse.startedAt;
+  for (const pulse of pulses) {
+    const elapsed = time - pulse.startedAt;
     if (elapsed > pulse.durationMs) {
-      pulses.splice(i, 1);
       continue;
     }
     const t = elapsed / pulse.durationMs;

--- a/shadow-agent/src/renderer/canvas/canvas-pulse.ts
+++ b/shadow-agent/src/renderer/canvas/canvas-pulse.ts
@@ -17,13 +17,13 @@ export function triggerCanvasPulse(
   kind: CanvasPulseKind,
   x: number,
   y: number,
-  options: { intensity?: number; durationMs?: number } = {}
+  options: { intensity?: number; durationMs?: number; atMs?: number } = {}
 ): void {
   pulses.push({
     kind,
     x,
     y,
-    startedAt: performance.now(),
+    startedAt: options.atMs ?? performance.now(),
     durationMs: options.durationMs ?? (kind === 'burst' ? 600 : 1200),
     intensity: options.intensity ?? 1
   });

--- a/shadow-agent/src/renderer/canvas/canvas-pulse.ts
+++ b/shadow-agent/src/renderer/canvas/canvas-pulse.ts
@@ -1,0 +1,58 @@
+/** Event-driven atmosphere pulse (Citadel-inspired stub). */
+
+export type CanvasPulseKind = 'burst' | 'ripple';
+
+interface ActivePulse {
+  kind: CanvasPulseKind;
+  x: number;
+  y: number;
+  startedAt: number;
+  durationMs: number;
+  intensity: number;
+}
+
+const pulses: ActivePulse[] = [];
+
+export function triggerCanvasPulse(
+  kind: CanvasPulseKind,
+  x: number,
+  y: number,
+  options: { intensity?: number; durationMs?: number } = {}
+): void {
+  pulses.push({
+    kind,
+    x,
+    y,
+    startedAt: performance.now(),
+    durationMs: options.durationMs ?? (kind === 'burst' ? 600 : 1200),
+    intensity: options.intensity ?? 1
+  });
+}
+
+/** Returns 0–1 boost to grid opacity for the current frame. */
+export function sampleCanvasPulseBoost(time: number, width: number, height: number): number {
+  const now = time;
+  let boost = 0;
+  for (let i = pulses.length - 1; i >= 0; i -= 1) {
+    const pulse = pulses[i]!;
+    const elapsed = now - pulse.startedAt;
+    if (elapsed > pulse.durationMs) {
+      pulses.splice(i, 1);
+      continue;
+    }
+    const t = elapsed / pulse.durationMs;
+    const falloff = 1 - t;
+    const cx = pulse.x * width;
+    const cy = pulse.y * height;
+    const dist = Math.hypot(width / 2 - cx, height / 2 - cy);
+    const maxDist = Math.hypot(width, height) * 0.5;
+    const spatial = Math.max(0, 1 - dist / maxDist);
+    const amp = pulse.intensity * falloff * spatial * (pulse.kind === 'burst' ? 0.12 : 0.06);
+    boost = Math.max(boost, amp);
+  }
+  return boost;
+}
+
+export function clearCanvasPulses(): void {
+  pulses.length = 0;
+}

--- a/shadow-agent/src/renderer/canvas/particle-worker.ts
+++ b/shadow-agent/src/renderer/canvas/particle-worker.ts
@@ -4,13 +4,13 @@ import type { ParticleWorkerInput, ParticleWorkerOutput } from './particle-worke
 let state: ParticleEngineState = createParticleEngineState([], 'high');
 
 self.onmessage = (event: MessageEvent<ParticleWorkerInput>) => {
-  const message = event.data;
-  if (message.type === 'scene') {
-    state = syncParticleEngineState(state, message.edges, message.qualityTier);
-  } else if (message.type === 'quality') {
-    state = syncParticleEngineState(state, state.edges, message.qualityTier);
-  } else if (message.type === 'tick') {
-    state = advanceParticleEngineState(state, message.dtMs);
+  const payload = event.data;
+  if (payload.type === 'scene') {
+    state = syncParticleEngineState(state, payload.edges, payload.qualityTier);
+  } else if (payload.type === 'quality') {
+    state = syncParticleEngineState(state, state.edges, payload.qualityTier);
+  } else if (payload.type === 'tick') {
+    state = advanceParticleEngineState(state, payload.dtMs);
   }
 
   const response: ParticleWorkerOutput = {

--- a/shadow-agent/src/renderer/components/GlassCard.tsx
+++ b/shadow-agent/src/renderer/components/GlassCard.tsx
@@ -1,39 +1,101 @@
+import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
+import { TIMING } from '../theme/timing';
 
 /**
- * GlassCard — glass-morphism card with backdrop blur.
- *
- * Variants:
- *   size   — sm | md | lg  (controls padding + radius)
- *   glow   — none | subtle | bright  (outer glow intensity)
- *   slide  — none | left | right | bottom  (entry direction, for animation)
+ * GlassCard — glass-morphism card with backdrop blur and mount animation.
  */
 const glassCVA = cva('glass-card', {
   variants: {
     size: {
-      sm:  'glass-card--sm',
-      md:  'glass-card--md',
-      lg:  'glass-card--lg',
+      sm: 'glass-card--sm',
+      md: 'glass-card--md',
+      lg: 'glass-card--lg',
     },
     glow: {
-      none:    '',
-      subtle:  'glass-card--glow-subtle',
-      bright:  'glass-card--glow-bright',
+      none: '',
+      subtle: 'glass-card--glow-subtle',
+      bright: 'glass-card--glow-bright',
     },
     slide: {
-      none:    '',
-      left:    'glass-card--slide-left',
-      right:   'glass-card--slide-right',
-      bottom:  'glass-card--slide-bottom',
+      none: '',
+      left: 'glass-card--slide-left',
+      right: 'glass-card--slide-right',
+      bottom: 'glass-card--slide-bottom',
     },
   },
   defaultVariants: {
-    size:  'md',
-    glow:  'none',
+    size: 'md',
+    glow: 'none',
     slide: 'none',
   },
 });
 
 export type GlassCardVariant = VariantProps<typeof glassCVA>;
+
+export interface GlassCardProps extends GlassCardVariant {
+  children: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+  visible?: boolean;
+}
+
+export function GlassCard({
+  children,
+  className = '',
+  style,
+  visible = true,
+  size,
+  glow,
+  slide,
+}: GlassCardProps) {
+  const [mounted, setMounted] = useState(visible);
+  const [animating, setAnimating] = useState(false);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (visible) {
+      setMounted(true);
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = null;
+        setAnimating(true);
+      });
+      return () => {
+        if (rafRef.current !== null) {
+          cancelAnimationFrame(rafRef.current);
+          rafRef.current = null;
+        }
+      };
+    }
+
+    setAnimating(false);
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    const timer = setTimeout(() => setMounted(false), TIMING.glassAnimMs);
+    return () => clearTimeout(timer);
+  }, [visible]);
+
+  if (!mounted) {
+    return null;
+  }
+
+  const transitionMs = TIMING.glassAnimMs;
+
+  return (
+    <div
+      className={glassCVA({ size, glow, slide, className })}
+      style={{
+        ...style,
+        opacity: animating ? 1 : 0,
+        transform: animating ? 'scale(1)' : 'scale(0.95)',
+        transition: `opacity ${transitionMs}ms ease-out, transform ${transitionMs}ms ease-out`,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
 
 export { glassCVA };

--- a/shadow-agent/src/renderer/components/TimelineScrubber.tsx
+++ b/shadow-agent/src/renderer/components/TimelineScrubber.tsx
@@ -14,7 +14,7 @@ function formatTick(ts: string): string {
   return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
 }
 
-function EventMarker({ item }: { item: TimelineItem }) {
+function EventMarker({ event: timelineEvent }: { event: TimelineItem }) {
   const accentMap: Record<string, string> = {
     tool_started:      '#ffbb44',
     tool_completed:    '#66ffaa',
@@ -26,11 +26,11 @@ function EventMarker({ item }: { item: TimelineItem }) {
     risk:             '#ff5566',
     default:          '#7be0ff',
   };
-  const color = accentMap[item.kind] ?? accentMap.default;
+  const color = accentMap[timelineEvent.kind] ?? accentMap.default;
   return (
     <div
       className="ts-marker"
-      title={`${item.kind}: ${item.label}`}
+      title={`${timelineEvent.kind}: ${timelineEvent.label}`}
       style={{ background: color, boxShadow: `0 0 6px ${color}` }}
     />
   );
@@ -77,8 +77,8 @@ export default function TimelineScrubber({ timeline }: TimelineScrubberProps) {
 
       {/* Event markers row */}
       <div className="timeline-scrubber__track" ref={trackRef} onClick={handleTrackClick}>
-        {timeline.map((item) => (
-          <EventMarker key={item.id} item={item} />
+        {timeline.map((timelineEvent) => (
+          <EventMarker key={timelineEvent.id} event={timelineEvent} />
         ))}
         {/* Playhead */}
         <AnimatedDiv

--- a/shadow-agent/src/renderer/styles.css
+++ b/shadow-agent/src/renderer/styles.css
@@ -56,6 +56,16 @@
   --glass-border:       rgba(100, 200, 255, 0.15);
   --glass-blur:         20px;
   --glass-glow:         rgba(100, 200, 255, 0.08);
+  --holo-border-06:     rgba(100, 200, 255, 0.06);
+  --holo-border-08:     rgba(100, 200, 255, 0.08);
+  --holo-border-10:     rgba(100, 200, 255, 0.10);
+  --holo-border-12:     rgba(100, 200, 255, 0.12);
+
+  /* Citadel tier cascade timing */
+  --citadel-tier-1: 0ms;
+  --citadel-tier-2: 80ms;
+  --citadel-tier-3: 160ms;
+  --citadel-tier-4: 240ms;
 }
 
 * {
@@ -324,6 +334,27 @@ button {
   border: 1px solid rgba(255, 117, 143, 0.32);
   background: rgba(255, 117, 143, 0.12);
   color: #ffd6dd;
+}
+
+/* ─── Citadel motion (subset) ────────────────────────────────────────────── */
+
+@keyframes card-breathe {
+  0%, 100% { box-shadow: inset 0 1px 0 rgba(100, 200, 255, 0.06), var(--shadow), 0 0 20px rgba(100, 200, 255, 0.06); }
+  50% { box-shadow: inset 0 1px 0 rgba(100, 200, 255, 0.12), var(--shadow), 0 0 36px rgba(100, 200, 255, 0.14); }
+}
+
+@keyframes cl-reveal {
+  from { opacity: 0; transform: translateY(8px) scale(0.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.glass-card--breathe {
+  animation: card-breathe 3s ease-in-out infinite;
+}
+
+.shadow-panel {
+  animation: cl-reveal 320ms ease-out both;
+  animation-delay: var(--citadel-tier-2);
 }
 
 /* ─── Glass Card ─────────────────────────────────────────────────────────── */

--- a/shadow-agent/src/renderer/theme/colors.ts
+++ b/shadow-agent/src/renderer/theme/colors.ts
@@ -36,6 +36,16 @@ export const colors = {
   glassBorder: 'rgba(100, 200, 255, 0.15)',
   glassBlur:   '20px',
   glassGlow:   'rgba(100, 200, 255, 0.08)',
+
+  // Holo border opacities (mirror CSS --holo-border-* vars)
+  holoBorder06: 'rgba(100, 200, 255, 0.06)',
+  holoBorder08: 'rgba(100, 200, 255, 0.08)',
+  holoBorder10: 'rgba(100, 200, 255, 0.10)',
+  holoBorder12: 'rgba(100, 200, 255, 0.12)',
+
+  // Edge / particle accents
+  edgeDispatch: 'rgba(204, 136, 255, 1)',
+  edgeReturn:   'rgba(102, 255, 170, 1)',
 } as const;
 
 export type ColorKey = keyof typeof colors;

--- a/shadow-agent/src/renderer/theme/helpers.ts
+++ b/shadow-agent/src/renderer/theme/helpers.ts
@@ -1,0 +1,22 @@
+import type { AgentNode } from '../../shared/schema';
+import { colors } from './colors';
+
+/** Append alpha to a partial rgba base string, e.g. `'rgba(80, 160, 220,'`. */
+export function withAlpha(rgbaBase: string, alpha: number): string {
+  if (!rgbaBase.trimEnd().endsWith(',')) {
+    throw new Error('withAlpha expects a partial rgba base ending with a comma');
+  }
+  return `${rgbaBase} ${alpha})`;
+}
+
+export function getStateColor(state: AgentNode['state']): string {
+  switch (state) {
+    case 'active':
+      return colors.stateThinking;
+    case 'completed':
+      return colors.stateComplete;
+    case 'idle':
+    default:
+      return colors.stateIdle;
+  }
+}

--- a/shadow-agent/src/renderer/theme/timing.ts
+++ b/shadow-agent/src/renderer/theme/timing.ts
@@ -1,0 +1,11 @@
+/** Animation timing constants (ported from agent-flow / PR #41 theme). */
+export const TIMING = {
+  controlBarHideMs: 3000,
+  glassAnimMs: 200,
+  contextMenuDelayMs: 50,
+  chatFocusDelayMs: 300,
+  autoPlayDelayMs: 500,
+  resumeLiveDelayMs: 20,
+  seekCompleteDelayMs: 50,
+  livePulseMs: 1000
+} as const;

--- a/shadow-agent/src/shared/logger.ts
+++ b/shadow-agent/src/shared/logger.ts
@@ -131,7 +131,7 @@ function redactContext(context: Record<string, unknown> | undefined): Record<str
     seen.add(value as object);
 
     if (Array.isArray(value)) {
-      return value.map((item) => sanitize(item));
+      return value.map((element) => sanitize(element));
     }
 
     const output: Record<string, unknown> = {};

--- a/shadow-agent/src/shared/privacy.ts
+++ b/shadow-agent/src/shared/privacy.ts
@@ -153,7 +153,7 @@ function sanitizeUnknown(value: unknown): unknown {
   }
 
   if (Array.isArray(value)) {
-    return value.map((item) => sanitizeUnknown(item));
+    return value.map((element) => sanitizeUnknown(element));
   }
 
   const output: Record<string, unknown> = {};

--- a/shadow-agent/tests/helpers/record-2d-context.ts
+++ b/shadow-agent/tests/helpers/record-2d-context.ts
@@ -1,0 +1,71 @@
+export type RecordedCommand =
+  | { type: 'fillStyle'; value: string }
+  | { type: 'strokeStyle'; value: string }
+  | { type: 'lineWidth'; value: number }
+  | { type: 'fillRect'; x: number; y: number; w: number; h: number }
+  | { type: 'stroke'; path?: string }
+  | { type: 'save' }
+  | { type: 'restore' };
+
+export interface Recorded2DContext {
+  commands: RecordedCommand[];
+  canvas: { width: number; height: number };
+}
+
+export function createRecorded2DContext(width = 800, height = 600): CanvasRenderingContext2D {
+  const commands: RecordedCommand[] = [];
+  const state = { fillStyle: '#000', strokeStyle: '#000', lineWidth: 1 };
+
+  const recorder = {
+    canvas: { width, height },
+    get fillStyle() {
+      return state.fillStyle;
+    },
+    set fillStyle(value: string) {
+      state.fillStyle = value;
+      commands.push({ type: 'fillStyle', value });
+    },
+    get strokeStyle() {
+      return state.strokeStyle;
+    },
+    set strokeStyle(value: string) {
+      state.strokeStyle = value;
+      commands.push({ type: 'strokeStyle', value });
+    },
+    get lineWidth() {
+      return state.lineWidth;
+    },
+    set lineWidth(value: number) {
+      state.lineWidth = value;
+      commands.push({ type: 'lineWidth', value });
+    },
+    fillRect(x: number, y: number, w: number, h: number) {
+      commands.push({ type: 'fillRect', x, y, w, h });
+    },
+    stroke(path?: Path2D) {
+      commands.push({ type: 'stroke', path: path ? 'path' : undefined });
+    },
+    save() {
+      commands.push({ type: 'save' });
+    },
+    restore() {
+      commands.push({ type: 'restore' });
+    },
+    setTransform() {
+      /* no-op for command tests */
+    },
+    clearRect() {
+      /* no-op */
+    },
+    createLinearGradient() {
+      return { addColorStop: () => undefined } as CanvasGradient;
+    },
+    __commands: commands
+  };
+
+  return recorder as unknown as CanvasRenderingContext2D & { __commands: RecordedCommand[] };
+}
+
+export function getRecordedCommands(ctx: CanvasRenderingContext2D): RecordedCommand[] {
+  return (ctx as CanvasRenderingContext2D & { __commands: RecordedCommand[] }).__commands;
+}

--- a/shadow-agent/tests/helpers/record-2d-context.ts
+++ b/shadow-agent/tests/helpers/record-2d-context.ts
@@ -1,3 +1,9 @@
+type DrawStyle = string | CanvasGradient | CanvasPattern;
+
+function styleToken(value: DrawStyle): string {
+  return typeof value === 'string' ? value : '[CanvasGradient|CanvasPattern]';
+}
+
 export type RecordedCommand =
   | { type: 'fillStyle'; value: string }
   | { type: 'strokeStyle'; value: string }
@@ -12,25 +18,32 @@ export interface Recorded2DContext {
   canvas: { width: number; height: number };
 }
 
+interface DrawState {
+  fillStyle: DrawStyle;
+  strokeStyle: DrawStyle;
+  lineWidth: number;
+}
+
 export function createRecorded2DContext(width = 800, height = 600): CanvasRenderingContext2D {
   const commands: RecordedCommand[] = [];
-  const state = { fillStyle: '#000', strokeStyle: '#000', lineWidth: 1 };
+  const state: DrawState = { fillStyle: '#000', strokeStyle: '#000', lineWidth: 1 };
+  const stack: DrawState[] = [];
 
   const recorder = {
     canvas: { width, height },
     get fillStyle() {
       return state.fillStyle;
     },
-    set fillStyle(value: string) {
+    set fillStyle(value: DrawStyle) {
       state.fillStyle = value;
-      commands.push({ type: 'fillStyle', value });
+      commands.push({ type: 'fillStyle', value: styleToken(value) });
     },
     get strokeStyle() {
       return state.strokeStyle;
     },
-    set strokeStyle(value: string) {
+    set strokeStyle(value: DrawStyle) {
       state.strokeStyle = value;
-      commands.push({ type: 'strokeStyle', value });
+      commands.push({ type: 'strokeStyle', value: styleToken(value) });
     },
     get lineWidth() {
       return state.lineWidth;
@@ -46,9 +59,16 @@ export function createRecorded2DContext(width = 800, height = 600): CanvasRender
       commands.push({ type: 'stroke', path: path ? 'path' : undefined });
     },
     save() {
+      stack.push({ fillStyle: state.fillStyle, strokeStyle: state.strokeStyle, lineWidth: state.lineWidth });
       commands.push({ type: 'save' });
     },
     restore() {
+      const previous = stack.pop();
+      if (previous) {
+        state.fillStyle = previous.fillStyle;
+        state.strokeStyle = previous.strokeStyle;
+        state.lineWidth = previous.lineWidth;
+      }
       commands.push({ type: 'restore' });
     },
     setTransform() {

--- a/shadow-agent/tests/renderer/app-state.test.ts
+++ b/shadow-agent/tests/renderer/app-state.test.ts
@@ -82,6 +82,14 @@ describe('appReducer — boot flow', () => {
     expect(next.error).toBeNull();
   });
 
+  it('BOOT_ABORT clears busy without changing snapshot', () => {
+    const snapshot = makeSnapshot();
+    const prior: AppState = { busy: 'booting', error: null, snapshot };
+    const next = appReducer(prior, { type: 'BOOT_ABORT' });
+    expect(next.busy).toBeNull();
+    expect(next.snapshot).toBe(snapshot);
+  });
+
   it('BOOT_ERROR clears busy and sets error message', () => {
     const prior: AppState = { busy: 'booting', error: null, snapshot: null };
     const next = appReducer(prior, { type: 'BOOT_ERROR', message: 'fixture failed' });

--- a/shadow-agent/tests/renderer/canvas-draw.test.ts
+++ b/shadow-agent/tests/renderer/canvas-draw.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { colors } from '../../src/renderer/theme/colors';
+import { createRecorded2DContext, getRecordedCommands } from '../helpers/record-2d-context';
+import { STATE_COLORS } from '../../src/renderer/canvas/types';
+
+describe('canvas draw semantics', () => {
+  it('STATE_COLORS aligns thinking state with holo base', () => {
+    expect(STATE_COLORS.thinking).toBe(colors.holoBase);
+  });
+
+  it('recorded context captures fill and stroke styles', () => {
+    const ctx = createRecorded2DContext(400, 300);
+    ctx.fillStyle = colors.void;
+    ctx.fillRect(0, 0, 400, 300);
+    ctx.strokeStyle = colors.holoBase;
+    ctx.lineWidth = 2;
+    ctx.stroke();
+
+    const commands = getRecordedCommands(ctx);
+    expect(commands).toContainEqual({ type: 'fillStyle', value: colors.void });
+    expect(commands).toContainEqual({ type: 'fillRect', x: 0, y: 0, w: 400, h: 300 });
+    expect(commands).toContainEqual({ type: 'strokeStyle', value: colors.holoBase });
+    expect(commands).toContainEqual({ type: 'lineWidth', value: 2 });
+    expect(commands.some((c) => c.type === 'stroke')).toBe(true);
+  });
+});

--- a/shadow-agent/tests/renderer/canvas-pulse.test.ts
+++ b/shadow-agent/tests/renderer/canvas-pulse.test.ts
@@ -11,12 +11,12 @@ describe('canvas pulse API', () => {
   });
 
   it('returns zero boost with no active pulses', () => {
-    expect(sampleCanvasPulseBoost(performance.now(), 800, 600)).toBe(0);
+    expect(sampleCanvasPulseBoost(1000, 800, 600)).toBe(0);
   });
 
   it('ramps boost while a burst pulse is active', () => {
-    const t0 = performance.now();
-    triggerCanvasPulse('burst', 0.5, 0.5, { intensity: 1, durationMs: 500 });
+    const t0 = 1000;
+    triggerCanvasPulse('burst', 0.5, 0.5, { intensity: 1, durationMs: 500, atMs: t0 });
     const early = sampleCanvasPulseBoost(t0 + 50, 800, 600);
     const late = sampleCanvasPulseBoost(t0 + 600, 800, 600);
     expect(early).toBeGreaterThan(0);

--- a/shadow-agent/tests/renderer/canvas-pulse.test.ts
+++ b/shadow-agent/tests/renderer/canvas-pulse.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  clearCanvasPulses,
+  sampleCanvasPulseBoost,
+  triggerCanvasPulse
+} from '../../src/renderer/canvas/canvas-pulse';
+
+describe('canvas pulse API', () => {
+  beforeEach(() => {
+    clearCanvasPulses();
+  });
+
+  it('returns zero boost with no active pulses', () => {
+    expect(sampleCanvasPulseBoost(performance.now(), 800, 600)).toBe(0);
+  });
+
+  it('ramps boost while a burst pulse is active', () => {
+    const t0 = performance.now();
+    triggerCanvasPulse('burst', 0.5, 0.5, { intensity: 1, durationMs: 500 });
+    const early = sampleCanvasPulseBoost(t0 + 50, 800, 600);
+    const late = sampleCanvasPulseBoost(t0 + 600, 800, 600);
+    expect(early).toBeGreaterThan(0);
+    expect(late).toBe(0);
+  });
+});

--- a/shadow-agent/tests/renderer/canvas-pulse.test.ts
+++ b/shadow-agent/tests/renderer/canvas-pulse.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeEach } from 'vitest';
 import {
   clearCanvasPulses,
   sampleCanvasPulseBoost,
+  tickCanvasPulses,
   triggerCanvasPulse
 } from '../../src/renderer/canvas/canvas-pulse';
 
@@ -21,5 +22,12 @@ describe('canvas pulse API', () => {
     const late = sampleCanvasPulseBoost(t0 + 600, 800, 600);
     expect(early).toBeGreaterThan(0);
     expect(late).toBe(0);
+  });
+
+  it('tickCanvasPulses prunes expired pulses without sampling the grid', () => {
+    const t0 = 2000;
+    triggerCanvasPulse('ripple', 0.5, 0.5, { durationMs: 100, atMs: t0 });
+    tickCanvasPulses(t0 + 200);
+    expect(sampleCanvasPulseBoost(t0 + 200, 800, 600)).toBe(0);
   });
 });

--- a/shadow-agent/tests/renderer/record-2d-context.test.ts
+++ b/shadow-agent/tests/renderer/record-2d-context.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { createRecorded2DContext, getRecordedCommands } from '../helpers/record-2d-context';
+
+describe('record-2d-context', () => {
+  it('restores stroke style after save/restore', () => {
+    const ctx = createRecorded2DContext();
+    ctx.strokeStyle = '#66ccff';
+    ctx.save();
+    ctx.strokeStyle = '#ff5566';
+    ctx.restore();
+
+    expect(ctx.strokeStyle).toBe('#66ccff');
+    expect(getRecordedCommands(ctx).filter((c) => c.type === 'save')).toHaveLength(1);
+    expect(getRecordedCommands(ctx).filter((c) => c.type === 'restore')).toHaveLength(1);
+  });
+
+  it('records gradient stroke assignments', () => {
+    const ctx = createRecorded2DContext();
+    const gradient = ctx.createLinearGradient(0, 0, 1, 1);
+    ctx.strokeStyle = gradient;
+
+    expect(getRecordedCommands(ctx)).toContainEqual({
+      type: 'strokeStyle',
+      value: '[CanvasGradient|CanvasPattern]'
+    });
+  });
+});

--- a/shadow-agent/tests/renderer/theme-helpers.test.ts
+++ b/shadow-agent/tests/renderer/theme-helpers.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { colors } from '../../src/renderer/theme/colors';
+import { getStateColor, withAlpha } from '../../src/renderer/theme/helpers';
+import { TIMING } from '../../src/renderer/theme/timing';
+
+describe('theme helpers', () => {
+  it('withAlpha appends alpha to partial rgba bases', () => {
+    expect(withAlpha('rgba(80, 160, 220,', 0.5)).toBe('rgba(80, 160, 220, 0.5)');
+  });
+
+  it('withAlpha rejects non-partial bases', () => {
+    expect(() => withAlpha('#66ccff', 0.5)).toThrow(/partial rgba/);
+  });
+
+  it('getStateColor maps agent node states', () => {
+    expect(getStateColor('active')).toBe(colors.stateThinking);
+    expect(getStateColor('completed')).toBe(colors.stateComplete);
+    expect(getStateColor('idle')).toBe(colors.stateIdle);
+  });
+
+  it('TIMING.glassAnimMs matches glass card transition', () => {
+    expect(TIMING.glassAnimMs).toBe(200);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Phase 2 visual landing work that was incorrectly committed locally to `main` — **not merged to remote `main`**. This PR is the proper integration path.

- Refresh landing docs (`getting-started`, `todo`, history log)
- Descriptive local variable renames (supersedes closed PR #42, with review fixes)
- Theme helpers (`withAlpha`, `getStateColor`, `TIMING`), animated `GlassCard`, Citadel CSS keyframes subset, `triggerCanvasPulse` API (supersedes closed PR #41 ideas)
- Canvas command-record tests (`record-2d-context`, 258 tests)
- Status book report: `docs/reports/phase2-landing-status.md`

## Test plan

- [x] `npm run prompts:check`
- [x] `cd shadow-agent && npm test` (258 passing)
- [x] `cd shadow-agent && npm run build`
- [ ] CI green on this PR
- [ ] Bot/human review addressed before merge


___

## **CodeAnt-AI Description**
**Refresh Phase 2 landing visuals, docs, and canvas test coverage**

### What Changed
- Added theme helpers, new color/timing tokens, and an animated GlassCard so landing panels and motion match the Phase 2 visual style.
- Added canvas pulse support and Citadel-style grid animation, making scene motion react to upcoming events instead of only ambient animation.
- Added command-record canvas tests plus helper coverage for recorded drawing behavior and theme color mapping.
- Updated landing docs, status report, todo list, and history log to match the current main branch and Phase 2 state.
- Cleaned up several renamed variables in file, inference, MCP, replay store, timeline, and app flows.

### Impact
`✅ Clearer Phase 2 landing visuals`
`✅ More reliable canvas behavior checks`
`✅ Up-to-date setup and status docs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
