### PR TITLE
test: harden flaky async transport and logger tests

### DIFF
--- a/shadow-agent/tests/capture/capture-transports.test.ts
+++ b/shadow-agent/tests/capture/capture-transports.test.ts
@@ -1,3 +1,4 @@
+import { waitFor } from '../helpers/wait-for';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import http from 'node:http';
 import net from 'node:net';
@@ -19,16 +20,6 @@ const tempDirs: string[] = [];
 const subscriptions: CaptureTransportSubscription[] = [];
 const servers: Array<{ close: () => Promise<void> }> = [];
 
-async function waitFor(assertion: () => boolean | Promise<boolean>, timeoutMs = 4_000): Promise<void> {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    if (await assertion()) {
-      return;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-  throw new Error(`Timed out after ${timeoutMs}ms`);
-}
 
 function createContext() {
   const sessions: CaptureSession[] = [];

--- a/shadow-agent/tests/capture/session-manager.test.ts
+++ b/shadow-agent/tests/capture/session-manager.test.ts
@@ -1,3 +1,4 @@
+import { waitFor } from '../helpers/wait-for';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mkdtemp, rm } from 'node:fs/promises';
 import path from 'node:path';
@@ -25,16 +26,6 @@ import { createSessionManager } from '../../src/capture/session-manager';
 
 const tempDirs: string[] = [];
 
-async function waitFor(assertion: () => boolean | Promise<boolean>, timeoutMs = 4_000): Promise<void> {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    if (await assertion()) {
-      return;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-  throw new Error(`Timed out after ${timeoutMs}ms`);
-}
 
 afterEach(async () => {
   handleMock.mockReset();

--- a/shadow-agent/tests/helpers/wait-for.ts
+++ b/shadow-agent/tests/helpers/wait-for.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared async polling for integration tests. Prefer event-driven assertions when possible.
+ * Default timeout matches transport suite budget (4s) documented in plan-testing-observability.md.
+ */
+import { vi } from 'vitest';
+
+export async function waitFor(
+  assertion: () => boolean | Promise<boolean>,
+  options: { timeout?: number; interval?: number } = {}
+): Promise<void> {
+  const { timeout = 4_000, interval = 20 } = options;
+  await vi.waitFor(
+    async () => {
+      if (!(await assertion())) {
+        throw new Error('waitFor: condition not met yet');
+      }
+    },
+    { timeout, interval }
+  );
+}

--- a/shadow-agent/tests/logger.test.ts
+++ b/shadow-agent/tests/logger.test.ts
@@ -1,3 +1,4 @@
+import { waitFor } from './helpers/wait-for';
 import { describe, expect, it, afterEach } from 'vitest';
 import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import os from 'node:os';
@@ -220,16 +221,10 @@ describe('structured logger — file rotation', () => {
     logger.info('app', 'after_rotation');
 
     // Wait for the async write to complete
-    for (let i = 0; i < 50; i++) {
-      const recent = logger.getWriteFailureCount() + logger.getDroppedWriteCount();
-      if (recent === 0) {
-        try {
-          const contents = await readFile(logFile, 'utf8');
-          if (contents.includes('after_rotation')) break;
-        } catch { /* not written yet */ }
-      }
-      await new Promise((r) => setTimeout(r, 10));
-    }
+    await waitFor(async () => {
+      const contents = await readFile(logFile, 'utf8');
+      return contents.includes('after_rotation');
+    }, { timeout: 2_000, interval: 10 });
 
     // The rotated file should still contain the pre-fill data
     const rotated = await readFile(`${logFile}.1`, 'utf8');

--- a/shadow-agent/tests/vitest-env.d.ts
+++ b/shadow-agent/tests/vitest-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@testing-library/jest-dom/vitest" />

--- a/shadow-agent/vitest.config.ts
+++ b/shadow-agent/vitest.config.ts
@@ -3,6 +3,7 @@ import viteConfig from './vite.config';
 
 export default mergeConfig(viteConfig, defineConfig({
   test: {
+    setupFiles: ['tests/setup.ts'],
     silent: true,
     reporters: [['default', { summary: true }]],
   },


### PR DESCRIPTION
## **User description**
## Summary
- Shared `tests/helpers/wait-for.ts` wraps `vi.waitFor` (4s default transport budget).
- Removed duplicate polling helpers from capture transport and session manager tests.
- Logger rotation test uses bounded `waitFor` instead of a 50-iteration busy loop.
- `vitest.config.ts` loads `tests/setup.ts` for `@testing-library/jest-dom` matchers.

Closes #59.

## Test plan
- [x] `cd shadow-agent && npm test` (355 tests)


___

## **CodeAnt-AI Description**
**Stabilize async tests and load DOM matchers for the test suite**

### What Changed
- Shared async polling is now used across transport, session manager, and logger tests instead of custom loops in each file
- The logger rotation test waits for the rotated log file to appear with a time limit instead of repeatedly checking in a busy loop
- The test setup now loads the DOM matcher package automatically so those matchers are available in the suite
- The Vitest type reference file was added to support the test environment

### Impact
`✅ Fewer flaky test failures`
`✅ More reliable CI test runs`
`✅ Fewer test setup/type errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
