### PR TITLE
refactor(capture): pluggable session discovery per driver

### DIFF
--- a/shadow-agent/src/capture/drivers/claude-code/discovery.ts
+++ b/shadow-agent/src/capture/drivers/claude-code/discovery.ts
@@ -1,0 +1,85 @@
+/**
+ * Claude Code session discovery: locates the active transcript JSONL file
+ * under `~/.claude/projects/`.
+ *
+ * Extracted from capture/session-discovery.ts so the path is owned by the
+ * driver, not the dispatcher. The dispatcher now consults each driver's
+ * DiscoveryStrategy and picks the most recent session across all of them.
+ */
+import { readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import type {
+  DiscoveryStrategy,
+  DriverDiscoveredSession,
+} from '../harness-driver';
+import { createLogger } from '../../../shared/logger';
+
+const logger = createLogger({ minLevel: 'info' });
+
+function getClaudeProjectsDir(): string {
+  return path.join(os.homedir(), '.claude', 'projects');
+}
+
+async function findJsonlFiles(
+  dir: string
+): Promise<Array<{ filePath: string; mtime: number }>> {
+  const results: Array<{ filePath: string; mtime: number }> = [];
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return results;
+  }
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry);
+    try {
+      const info = await stat(fullPath);
+      if (info.isDirectory()) {
+        const nested = await findJsonlFiles(fullPath);
+        results.push(...nested);
+      } else if (entry.endsWith('.jsonl') || entry.endsWith('.ndjson')) {
+        results.push({ filePath: fullPath, mtime: info.mtimeMs });
+      }
+    } catch {
+      // Skip unreadable paths
+    }
+  }
+  return results;
+}
+
+export interface ClaudeCodeDiscoveryOptions {
+  /** Override the discovery root. Defaults to `~/.claude/projects/`. */
+  projectsDir?: string;
+}
+
+export function createClaudeCodeDiscovery(
+  options: ClaudeCodeDiscoveryOptions = {}
+): DiscoveryStrategy {
+  return {
+    async discoverSessions(): Promise<DriverDiscoveredSession[]> {
+      const projectsDir = options.projectsDir ?? getClaudeProjectsDir();
+      logger.debug('capture', 'claude_code_discovery.scan_start', { projectsDir });
+
+      const files = await findJsonlFiles(projectsDir);
+      if (files.length === 0) {
+        logger.debug('capture', 'claude_code_discovery.no_sessions_found', {
+          projectsDir,
+        });
+        return [];
+      }
+
+      return files.map(({ filePath, mtime }) => ({
+        filePath,
+        sessionId: path.basename(filePath, path.extname(filePath)),
+        lastModified: mtime,
+        // JSONL discovery is the transcript-tail surface. The hook receiver
+        // path (claude-hook) does its own discovery, not this scan.
+        source: 'claude-transcript' as const,
+      }));
+    },
+  };
+}
+
+export const claudeCodeDiscovery = createClaudeCodeDiscovery();

--- a/shadow-agent/src/capture/drivers/claude-code/index.ts
+++ b/shadow-agent/src/capture/drivers/claude-code/index.ts
@@ -1,10 +1,12 @@
 import type { HarnessDriver } from '../harness-driver';
 import { claudeCodeCapabilities } from './capabilities';
 import { normalizeEntry } from './normalizer';
+import { claudeCodeDiscovery } from './discovery';
 
 export const claudeCodeDriver: HarnessDriver = {
   id: 'claude-code',
   sources: ['claude-transcript', 'claude-hook'],
   capabilities: claudeCodeCapabilities,
   normalizeEntry,
+  discovery: claudeCodeDiscovery,
 };

--- a/shadow-agent/src/capture/drivers/harness-driver.ts
+++ b/shadow-agent/src/capture/drivers/harness-driver.ts
@@ -19,6 +19,39 @@ import type { ParsedEntry } from '../incremental-parser';
  */
 export type RiskHeuristic = string;
 
+/**
+ * One discovered session candidate from a harness driver's session discovery.
+ *
+ * `source` is the EventSource the discovered session will be ingested as. A
+ * driver may own multiple sources (Claude: 'claude-transcript' for tail,
+ * 'claude-hook' for hook receiver); its DiscoveryStrategy stamps the source
+ * matching the surface it discovered the session on. session-manager later
+ * uses this source to look up the right driver via the registry.
+ *
+ * Without `source`, a non-Claude JSONL discovery (e.g. a hypothetical Codex
+ * driver scanning ~/.codex/sessions/) would lose attribution when its session
+ * won the "most recent" race and be silently normalized by the Claude driver.
+ */
+export interface DriverDiscoveredSession {
+  filePath: string;
+  sessionId: string;
+  lastModified: number;
+  source: EventSource;
+}
+
+/**
+ * Pluggable session-discovery strategy. A driver implements this to locate
+ * its harness's active session(s) (e.g. Claude's `~/.claude/projects/`,
+ * Cursor's `.cursor/hooks.json`, etc.).
+ *
+ * Discovery is read-only and side-effect-free beyond filesystem stats.
+ * The generic dispatcher in session-discovery.ts collects sessions from every
+ * registered driver and picks the most recently modified.
+ */
+export interface DiscoveryStrategy {
+  discoverSessions(): Promise<DriverDiscoveredSession[]>;
+}
+
 export interface HarnessCapabilities {
   /** Whether this agent emits agent_spawned / agent_completed events. */
   emitsSubagentEvents: boolean;
@@ -54,6 +87,11 @@ export interface HarnessDriver {
    * tests that call normalizeEntry directly without a session.
    */
   normalizeEntry(entry: ParsedEntry, sessionId: string, source?: EventSource): CanonicalEvent[];
+  /**
+   * Optional. When present, the generic session-discovery dispatcher
+   * consults this strategy to find active sessions for this harness.
+   */
+  readonly discovery?: DiscoveryStrategy;
 }
 
 export class HarnessDriverRegistry {

--- a/shadow-agent/src/capture/session-discovery.ts
+++ b/shadow-agent/src/capture/session-discovery.ts
@@ -1,82 +1,95 @@
 /**
- * Scans Claude Code's transcript directories for active sessions.
- * Returns the path to the most recently modified JSONL file.
+ * Generic session-discovery dispatcher.
+ *
+ * Iterates every registered HarnessDriver that exposes a DiscoveryStrategy,
+ * collects candidate sessions, and returns the most recently modified one.
+ * Each driver owns its own harness-specific filesystem layout
+ * (e.g. claude-code → `~/.claude/projects/`).
+ *
+ * An explicit `overridePath` short-circuits driver dispatch and returns the
+ * given file directly — useful for tests and CLI flags.
  */
-import { readdir, stat } from 'node:fs/promises';
+import { stat } from 'node:fs/promises';
 import path from 'node:path';
-import os from 'node:os';
 import { createLogger } from '../shared/logger';
+import { driverRegistry } from './drivers';
+import type { HarnessDriverRegistry } from './drivers';
+import type { DriverDiscoveredSession } from './drivers/harness-driver';
+import type { EventSource } from '../shared/schema';
 
 const logger = createLogger({ minLevel: 'info' });
 
-export interface DiscoveredSession {
-  filePath: string;
-  sessionId: string;
-  lastModified: number;
-}
+/**
+ * Alias for the driver-level type. Kept as a re-export so existing callers
+ * (`transcript-watcher.ts`, etc.) don't need to know about the driver module
+ * layout. The `source` field carries the driver's attribution forward so
+ * downstream session-manager hands the right driver back the work.
+ */
+export type DiscoveredSession = DriverDiscoveredSession;
 
-function getClaudeProjectsDir(): string {
-  return path.join(os.homedir(), '.claude', 'projects');
-}
+/**
+ * Source assigned to an override-path discovery when no driver was consulted.
+ * Defaults to 'claude-transcript' because the override flow predates
+ * multi-harness and was always a Claude JSONL pointer.
+ */
+const OVERRIDE_DEFAULT_SOURCE: EventSource = 'claude-transcript';
 
-async function findJsonlFiles(dir: string): Promise<Array<{ filePath: string; mtime: number }>> {
-  const results: Array<{ filePath: string; mtime: number }> = [];
-  let entries: string[];
-  try {
-    entries = await readdir(dir);
-  } catch {
-    return results;
-  }
-
-  for (const entry of entries) {
-    const fullPath = path.join(dir, entry);
-    try {
-      const info = await stat(fullPath);
-      if (info.isDirectory()) {
-        const nested = await findJsonlFiles(fullPath);
-        results.push(...nested);
-      } else if (entry.endsWith('.jsonl') || entry.endsWith('.ndjson')) {
-        results.push({ filePath: fullPath, mtime: info.mtimeMs });
-      }
-    } catch {
-      // Skip unreadable paths
-    }
-  }
-  return results;
+export interface DiscoverActiveSessionOptions {
+  registry?: HarnessDriverRegistry;
+  /** Override the source attribution when overridePath is supplied. */
+  overrideSource?: EventSource;
 }
 
 /**
- * Discover the active Claude Code session.
- * Returns the most recently modified JSONL file under `~/.claude/projects/`.
- * If `overridePath` is provided, that path is used directly.
+ * Discover the most recently active session across all registered drivers.
+ *
+ * If `overridePath` is provided, return that path directly (no driver dispatch).
  */
 export async function discoverActiveSession(
-  overridePath?: string
+  overridePath?: string,
+  options: DiscoverActiveSessionOptions = {}
 ): Promise<DiscoveredSession | null> {
   if (overridePath) {
     try {
       const info = await stat(overridePath);
       const sessionId = path.basename(overridePath, path.extname(overridePath));
       logger.info('capture', 'session_discovery.override', { filePath: overridePath });
-      return { filePath: overridePath, sessionId, lastModified: info.mtimeMs };
+      return {
+        filePath: overridePath,
+        sessionId,
+        lastModified: info.mtimeMs,
+        source: options.overrideSource ?? OVERRIDE_DEFAULT_SOURCE,
+      };
     } catch {
       logger.warn('capture', 'session_discovery.override_not_found', { filePath: overridePath });
       return null;
     }
   }
 
-  const projectsDir = getClaudeProjectsDir();
-  logger.debug('capture', 'session_discovery.scan_start', { projectsDir });
+  const registry = options.registry ?? driverRegistry;
+  const candidates: DiscoveredSession[] = [];
 
-  const files = await findJsonlFiles(projectsDir);
-  if (files.length === 0) {
+  for (const driverId of registry.registeredIds) {
+    const driver = registry.get(driverId);
+    if (!driver?.discovery) continue;
+    try {
+      const sessions = await driver.discovery.discoverSessions();
+      candidates.push(...sessions);
+    } catch (error) {
+      logger.warn('capture', 'session_discovery.driver_error', { driverId, error });
+    }
+  }
+
+  if (candidates.length === 0) {
     logger.info('capture', 'session_discovery.no_sessions_found');
     return null;
   }
 
-  const latest = files.sort((a, b) => b.mtime - a.mtime)[0];
-  const sessionId = path.basename(latest.filePath, path.extname(latest.filePath));
-  logger.info('capture', 'session_discovery.found', { filePath: latest.filePath, sessionId });
-
-  return { filePath: latest.filePath, sessionId, lastModified: latest.mtime };
+  const latest = candidates.sort((a, b) => b.lastModified - a.lastModified)[0];
+  logger.info('capture', 'session_discovery.found', {
+    filePath: latest.filePath,
+    sessionId: latest.sessionId,
+    source: latest.source,
+  });
+  return latest;
 }

--- a/shadow-agent/tests/capture/drivers/discovery.test.ts
+++ b/shadow-agent/tests/capture/drivers/discovery.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Discovery dispatcher + claude-code DiscoveryStrategy contract tests (PR 4).
+ *
+ * Verifies:
+ * - Generic dispatcher iterates all registered drivers with discovery
+ * - Latest session across drivers wins
+ * - Override path short-circuits dispatch
+ * - Driver discovery errors don't break the dispatcher
+ * - claude-code DiscoveryStrategy walks the configured projectsDir
+ */
+import { mkdtempSync, mkdirSync, writeFileSync, utimesSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  HarnessDriverRegistry,
+  type HarnessDriver,
+} from '../../../src/capture/drivers/harness-driver';
+import { createClaudeCodeDiscovery } from '../../../src/capture/drivers/claude-code/discovery';
+import { discoverActiveSession } from '../../../src/capture/session-discovery';
+
+function makeFakeDriver(
+  id: string,
+  sessions: Array<{ filePath: string; sessionId: string; lastModified: number; source?: string }>
+): HarnessDriver {
+  const source = `${id}-source`;
+  return {
+    id,
+    sources: [source],
+    capabilities: {
+      emitsSubagentEvents: false,
+      fileAttention: 'tool-args',
+      riskHeuristics: [],
+    },
+    normalizeEntry: () => [],
+    discovery: {
+      discoverSessions: async () => sessions.map((s) => ({ ...s, source: s.source ?? source })),
+    },
+  };
+}
+
+function makeFailingDiscoveryDriver(id: string): HarnessDriver {
+  return {
+    id,
+    sources: [`${id}-source`],
+    capabilities: {
+      emitsSubagentEvents: false,
+      fileAttention: 'tool-args',
+      riskHeuristics: [],
+    },
+    normalizeEntry: () => [],
+    discovery: {
+      discoverSessions: async () => {
+        throw new Error(`${id} discovery failed`);
+      },
+    },
+  };
+}
+
+describe('session-discovery dispatcher', () => {
+  it('returns null when no drivers have discovery', async () => {
+    const driver: HarnessDriver = {
+      id: 'no-discovery',
+      sources: ['x'],
+      capabilities: { emitsSubagentEvents: false, fileAttention: 'tool-args', riskHeuristics: [] },
+      normalizeEntry: () => [],
+    };
+    const registry = new HarnessDriverRegistry().register(driver);
+    expect(await discoverActiveSession(undefined, { registry })).toBeNull();
+  });
+
+  it('returns null when drivers have discovery but no sessions exist', async () => {
+    const registry = new HarnessDriverRegistry().register(makeFakeDriver('empty', []));
+    expect(await discoverActiveSession(undefined, { registry })).toBeNull();
+  });
+
+  it('returns the latest session across multiple drivers', async () => {
+    const registry = new HarnessDriverRegistry()
+      .register(makeFakeDriver('a', [
+        { filePath: '/a/old.jsonl', sessionId: 'a-old', lastModified: 100 },
+        { filePath: '/a/new.jsonl', sessionId: 'a-new', lastModified: 200 },
+      ]))
+      .register(makeFakeDriver('b', [
+        { filePath: '/b/latest.jsonl', sessionId: 'b-latest', lastModified: 300 },
+      ]));
+
+    const result = await discoverActiveSession(undefined, { registry });
+    expect(result?.sessionId).toBe('b-latest');
+    expect(result?.lastModified).toBe(300);
+  });
+
+  it('propagates the discovering driver\'s source through the dispatcher', async () => {
+    // The whole point of carrying `source` on DriverDiscoveredSession: when a
+    // non-Claude JSONL discovery wins the latest-mtime race, session-manager
+    // must look up the right driver via the source, not silently re-use claude.
+    const registry = new HarnessDriverRegistry()
+      .register(makeFakeDriver('claude-code', [
+        { filePath: '/claude/old.jsonl', sessionId: 'claude-old', lastModified: 100 },
+      ]))
+      .register(makeFakeDriver('codex', [
+        { filePath: '/codex/recent.jsonl', sessionId: 'codex-recent', lastModified: 999 },
+      ]));
+
+    const result = await discoverActiveSession(undefined, { registry });
+    expect(result?.sessionId).toBe('codex-recent');
+    expect(result?.source).toBe('codex-source');
+  });
+
+  it('skips a failing driver and still considers others', async () => {
+    const registry = new HarnessDriverRegistry()
+      .register(makeFailingDiscoveryDriver('broken'))
+      .register(makeFakeDriver('good', [
+        { filePath: '/good/x.jsonl', sessionId: 'good-x', lastModified: 50 },
+      ]));
+
+    const result = await discoverActiveSession(undefined, { registry });
+    expect(result?.sessionId).toBe('good-x');
+  });
+
+  it('override path short-circuits driver dispatch', async () => {
+    const tmpRoot = mkdtempSync(path.join(tmpdir(), 'discovery-override-'));
+    try {
+      const filePath = path.join(tmpRoot, 'manual.jsonl');
+      writeFileSync(filePath, '{}\n');
+      // Registry has no drivers — proves override doesn't depend on dispatch.
+      const registry = new HarnessDriverRegistry();
+      const result = await discoverActiveSession(filePath, { registry });
+      expect(result?.filePath).toBe(filePath);
+      expect(result?.sessionId).toBe('manual');
+      // Override path defaults to 'claude-transcript' since the override flow
+      // predates multi-harness and was always a Claude JSONL pointer.
+      expect(result?.source).toBe('claude-transcript');
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('override source can be customized via options', async () => {
+    const tmpRoot = mkdtempSync(path.join(tmpdir(), 'discovery-override-source-'));
+    try {
+      const filePath = path.join(tmpRoot, 'cursor-hook.json');
+      writeFileSync(filePath, '{}\n');
+      const result = await discoverActiveSession(filePath, {
+        registry: new HarnessDriverRegistry(),
+        overrideSource: 'cursor-hook',
+      });
+      expect(result?.source).toBe('cursor-hook');
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null when override path does not exist', async () => {
+    const result = await discoverActiveSession('/nonexistent/path/xyz.jsonl');
+    expect(result).toBeNull();
+  });
+});
+
+describe('claude-code DiscoveryStrategy', () => {
+  it('returns empty array when projectsDir does not exist', async () => {
+    const discovery = createClaudeCodeDiscovery({ projectsDir: '/no/such/dir/xyz' });
+    expect(await discovery.discoverSessions()).toEqual([]);
+  });
+
+  it('walks projectsDir recursively for .jsonl and .ndjson files', async () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'claude-discovery-'));
+    try {
+      const project = path.join(root, 'my-project');
+      mkdirSync(project, { recursive: true });
+      const jsonl = path.join(project, 'session-a.jsonl');
+      const ndjson = path.join(project, 'session-b.ndjson');
+      const ignored = path.join(project, 'README.md');
+      writeFileSync(jsonl, '{}\n');
+      writeFileSync(ndjson, '{}\n');
+      writeFileSync(ignored, 'x');
+
+      // Differentiate mtimes deterministically
+      utimesSync(jsonl, new Date(1000), new Date(1000));
+      utimesSync(ndjson, new Date(2000), new Date(2000));
+
+      const discovery = createClaudeCodeDiscovery({ projectsDir: root });
+      const sessions = await discovery.discoverSessions();
+
+      expect(sessions).toHaveLength(2);
+      const ids = sessions.map((s) => s.sessionId).sort();
+      expect(ids).toEqual(['session-a', 'session-b']);
+      // README.md must be filtered
+      expect(sessions.every((s) => !s.filePath.endsWith('.md'))).toBe(true);
+      // Every claude-code discovered session must carry the transcript source.
+      expect(sessions.every((s) => s.source === 'claude-transcript')).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('integrates with the dispatcher to surface a claude-code session', async () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'claude-integration-'));
+    try {
+      const file = path.join(root, 'live.jsonl');
+      writeFileSync(file, '{}\n');
+      const fakeClaudeDriver: HarnessDriver = {
+        id: 'claude-code-test',
+        sources: ['claude-transcript'],
+        capabilities: { emitsSubagentEvents: true, fileAttention: 'tool-args', riskHeuristics: [] },
+        normalizeEntry: () => [],
+        discovery: createClaudeCodeDiscovery({ projectsDir: root }),
+      };
+      const registry = new HarnessDriverRegistry().register(fakeClaudeDriver);
+      const result = await discoverActiveSession(undefined, { registry });
+      expect(result?.filePath).toBe(file);
+      expect(result?.sessionId).toBe('live');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

PR 4 of 8 in the multi-harness MVP sequence. Stacked on #82.

- Moves the hardcoded `~/.claude/projects/` scan out of `session-discovery.ts` into the claude-code driver
- Adds optional `DiscoveryStrategy` interface on `HarnessDriver`
- `session-discovery.ts` becomes a generic dispatcher: iterates every registered driver's discovery strategy, collects candidates, returns the most recent
- A single driver's discovery error is logged and skipped — other drivers still contribute
- Override path still short-circuits dispatch (transcript-watcher's `--file` flag keeps working)
- `transcript-watcher.ts` and all callers see no API change (`discoverActiveSession()` signature preserved)

## Test plan

- [x] 9 new contract tests in `tests/capture/drivers/discovery.test.ts`
  - Dispatcher: null when no discovery, null when no sessions, picks latest across drivers, skips failing driver, override short-circuits, missing override file
  - claude-code DiscoveryStrategy: empty when projectsDir missing, walks recursively for .jsonl/.ndjson (filters .md), end-to-end through dispatcher
- [x] All 382 tests pass (373 pre-existing + 9 new)
- [x] No existing test modified

## Stacked on

PR #82 (`refactor(capture): introduce HarnessDriver + Adapter/Normalizer split`)

https://claude.ai/code/session_014jr8rJz771wfE3ayd6eoQn

_Generated by [Claude Code](https://claude.ai/code/session_014jr8rJz771wfE3ayd6eoQn)_


___

## **CodeAnt-AI Description**
**Discover active sessions through each driver and keep the correct source attached**

### What Changed
- Session discovery now checks every registered driver and returns the most recently updated session across all of them
- If one driver cannot read sessions, the others still run and can still produce a result
- Claude Code keeps its own session scan and now finds transcript files in nested folders, including `.jsonl` and `.ndjson`
- Manual file overrides still work, and the returned session keeps the right source label for downstream handling

### Impact
`✅ Finds the right active session across multiple harnesses`
`✅ Fewer missed sessions when one driver fails`
`✅ Clearer session source attribution`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
