### PR TITLE
test(integration): end-to-end fixture-pipeline gate (PR 4.5)

### DIFF
--- a/shadow-agent/tests/integration/e2e-jsonl-to-state.test.ts
+++ b/shadow-agent/tests/integration/e2e-jsonl-to-state.test.ts
@@ -1,0 +1,170 @@
+/**
+ * End-to-end integration gate (PR 4.5).
+ *
+ * The unit tests below this file in tests/capture/, tests/inference/, etc.
+ * each verify ONE layer of the pipeline. This test verifies the layers
+ * COMPOSE — proving the same byte-stream that a real Claude Code session
+ * writes today flows through the real transport, parser, driver, event
+ * buffer (including spill-to-disk + reload), and derive without losing
+ * the harness identity stamp.
+ *
+ * Why this exists (test-grader's "biggest blind spot"):
+ *   The whole multi-harness MVP rests on `harnessId` round-tripping from
+ *   normalizer → buffer → derive → AgentNode. The unit tests never run
+ *   that full pipe. This is the only test that does. If it goes red,
+ *   the multi-harness palette accent in PR 7 silently won't work.
+ *
+ * Findings logged by this test (followed up in PR 5):
+ *   - The live normalizer puts file paths under `payload.args.file_path`,
+ *     but `derive.ts:6 extractFilePath()` only looks at `payload.file_path`.
+ *     So `fileAttention` is empty for live capture today, while replay (via
+ *     transcript-adapter.ts which flattens input into payload) produces it
+ *     correctly. PR 5 (capability-driven derive) is the place to unify.
+ */
+import { copyFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { CanonicalEvent } from '../../src/shared/schema';
+import { deriveState } from '../../src/shared/derive';
+import { createEventBuffer, type EventBuffer } from '../../src/capture/event-buffer';
+import { createIncrementalParser } from '../../src/capture/incremental-parser';
+import { createFileTailCaptureTransport } from '../../src/capture/transcript-watcher';
+import { claudeCodeDriver } from '../../src/capture/drivers/claude-code';
+import type { CaptureTransportSubscription } from '../../src/capture/capture-transport';
+
+const TESTS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(TESTS_DIR, '../fixtures/transcripts/happy-path.jsonl');
+
+async function waitFor(
+  assertion: () => boolean | Promise<boolean>,
+  timeoutMs = 4_000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await assertion()) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`waitFor timed out after ${timeoutMs}ms`);
+}
+
+describe('end-to-end: jsonl fixture → real pipeline → DerivedState', () => {
+  const tmpRoots: string[] = [];
+  const subscriptions: CaptureTransportSubscription[] = [];
+  const buffers: EventBuffer[] = [];
+
+  afterEach(async () => {
+    for (const sub of subscriptions.splice(0)) {
+      try {
+        await sub.stop();
+      } catch {
+        /* ignore */
+      }
+    }
+    for (const buffer of buffers.splice(0)) {
+      try {
+        await buffer.clear();
+      } catch {
+        /* ignore */
+      }
+    }
+    for (const root of tmpRoots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves harnessId through transport → spill → reload → derive', async () => {
+    const tmpRoot = mkdtempSync(path.join(tmpdir(), 'shadow-e2e-'));
+    tmpRoots.push(tmpRoot);
+
+    const livePath = path.join(tmpRoot, 'live.jsonl');
+    copyFileSync(FIXTURE, livePath);
+
+    // memoryCapacity:2 forces 5 of the ~7 events to spill to disk, so the
+    // round-trip JSON.stringify → readFile → JSON.parse path is exercised.
+    const buffer = createEventBuffer({
+      persistenceRoot: path.join(tmpRoot, 'queue'),
+      memoryCapacity: 2,
+      totalCapacity: 100,
+    });
+    buffers.push(buffer);
+    await buffer.setSession('happy-path-e2e');
+
+    const parser = createIncrementalParser((entry) => {
+      const events = claudeCodeDriver.normalizeEntry(
+        entry,
+        'happy-path-e2e',
+        'claude-transcript'
+      );
+      if (events.length) {
+        void buffer.push(events);
+      }
+    });
+
+    const transport = createFileTailCaptureTransport({
+      kind: 'file-tail',
+      overridePath: livePath,
+      discoveryIntervalMs: 60_000,
+    });
+
+    const sub = await transport.start({
+      getBackpressure: () => buffer.getBackpressure(),
+      onSessionStarted: async () => undefined,
+      onSessionReset: async () => undefined,
+      onChunk: async ({ chunk }) => parser.push(chunk),
+    });
+    subscriptions.push(sub);
+
+    // happy-path.jsonl produces session_started + 2 messages + 2 tool_started
+    // + 2 tool_completed = 7 events (the user line is consumed as session_started
+    // by the normalizer's early-return when cwd is present).
+    await waitFor(async () => {
+      const all = await buffer.getAll();
+      return all.length >= 7;
+    });
+
+    const allEvents: CanonicalEvent[] = await buffer.getAll();
+
+    // 1. Pipeline composes — we got events out.
+    expect(allEvents.length).toBeGreaterThanOrEqual(7);
+
+    // 2. Harness identity survives the full pipe (including spill+reload).
+    //    This is THE assertion this test exists for.
+    expect(allEvents.every((e) => e.harnessId === 'claude-code')).toBe(true);
+
+    // 3. Source was set by the driver (not lost during spill).
+    expect(allEvents.every((e) => e.source === 'claude-transcript')).toBe(true);
+
+    // 4. Spill actually happened — prove the round-trip path was exercised
+    //    by checking buffer metrics, not just the in-memory window.
+    const metrics = buffer.getMetrics();
+    expect(metrics.spilledDepth).toBeGreaterThan(0);
+
+    // 5. Event kinds match the fixture shape.
+    const kinds = allEvents.map((e) => e.kind);
+    expect(kinds).toContain('session_started');
+    expect(kinds).toContain('message');
+    expect(kinds).toContain('tool_started');
+    expect(kinds).toContain('tool_completed');
+
+    // 6. Derive runs without crashing on a real pipeline's events.
+    const state = deriveState(allEvents);
+
+    // 7. Transcript surfaces the assistant messages.
+    expect(state.transcript.length).toBeGreaterThan(0);
+    const transcriptText = state.transcript.map((t) => t.text).join('\n');
+    expect(transcriptText.toLowerCase()).toContain('logger');
+
+    // 8. Phase detection ran on real tool names.
+    expect(state.activePhase).toMatch(/exploration|implementation|idle/);
+
+    // NOTE (PR 5 follow-up): fileAttention is empty here even though the
+    // fixture's Read/Write tools clearly target src/utils.ts and src/logger.ts.
+    // The live normalizer wraps file_path inside payload.args, but derive's
+    // extractFilePath() looks at payload.file_path directly. Capability-driven
+    // derive in PR 5 unifies the extraction strategy.
+    expect(state.fileAttention).toEqual([]);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

**PR 4.5 of the multi-harness MVP sprint** — a mid-sprint integration gate, inserted between PR 4 (pluggable discovery) and PR 5 (capability-driven derive) after the test-grading subagent flagged "no end-to-end test exists" as the suite's biggest blind spot.

A single new test file (`tests/integration/e2e-jsonl-to-state.test.ts`) runs `happy-path.jsonl` through:
- real `createFileTailCaptureTransport`
- real `createIncrementalParser`
- real `claudeCodeDriver.normalizeEntry` (with explicit `source` param threaded through, per PR #82's fix)
- real `createEventBuffer` with `memoryCapacity: 2` to **force spill+reload**
- real `deriveState`

And asserts:
- `harnessId === 'claude-code'` survives the full pipe **including the spill round-trip** — this is THE assertion this test exists for
- `source === 'claude-transcript'` survives identically
- `metrics.spilledDepth > 0` — proves the round-trip path was actually exercised
- Event kinds match the fixture shape
- Transcript + phase detection produce non-empty output via derive

## Findings logged for PR 5

The test surfaced one pre-existing divergence between the live and replay paths:
- Live `claude-code/normalizer.ts` nests `file_path` under `payload.args.file_path`
- `derive.ts:6 extractFilePath()` only looks at `payload.file_path` directly
- The replay path (`transcript-adapter.ts`) flattens, so `fileAttention` works in replay but is empty for live capture today

This is logged inline in the test (`fileAttention === []` asserted with a comment pointing to PR 5). Capability-driven derive in PR 5 is the right place to unify the extraction strategy.

## Test plan

- [x] 1 new test in `tests/integration/e2e-jsonl-to-state.test.ts`
- [x] All 393 tests pass (392 pre-existing + 1 new)
- [x] Test runs in ~34ms (small fixture, real file-tail transport)
- [x] `tsc --noEmit` clean

## Stacked on

PR #84 (`refactor(capture): pluggable session discovery per driver`)

https://claude.ai/code/session_014jr8rJz771wfE3ayd6eoQn

_Generated by [Claude Code](https://claude.ai/code/session_014jr8rJz771wfE3ayd6eoQn)_


___

## **CodeAnt-AI Description**
**Add an end-to-end gate for the real transcript-to-state pipeline**

### What Changed
- Adds a new integration test that sends a real JSONL fixture through capture, parsing, normalization, buffering, and state derivation
- Verifies harness identity and source survive a spill-to-disk and reload cycle
- Confirms the resulting events include session, message, and tool activity, and that derived transcript and phase data are produced
- Records a known mismatch for file-based tool attention in live capture so it can be fixed in the next PR

### Impact
`✅ Fewer hidden pipeline regressions`
`✅ Safer harness identity round-trips`
`✅ Earlier detection of live-vs-replay mismatches`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
