### PR TITLE
feat(derive): capability-driven derivation via HarnessDriverRegistry

### DIFF
--- a/shadow-agent/src/capture/drivers/claude-code/capabilities.ts
+++ b/shadow-agent/src/capture/drivers/claude-code/capabilities.ts
@@ -1,5 +1,12 @@
 import type { HarnessCapabilities } from '../harness-driver';
 
+/**
+ * Risk heuristic IDs map 1:1 to checks in `shared/derive.ts:collectRiskSignals`.
+ * Derive only runs a check whose ID appears in this list, so adding a new
+ * harness with a different signal profile (e.g. an OTel-driven driver that
+ * has reliable token-spend visibility but no shell calls) is a pure
+ * capabilities edit, no derive.ts changes.
+ */
 export const claudeCodeCapabilities: HarnessCapabilities = {
   // Claude Code's Task tool spawns subagents, but the current normalizer
   // does not yet emit agent_spawned/agent_completed events for them. Keep
@@ -8,8 +15,8 @@ export const claudeCodeCapabilities: HarnessCapabilities = {
   emitsSubagentEvents: false,
   fileAttention: 'tool-args',
   riskHeuristics: [
-    'many_deletes',
-    'large_write',
-    'shell_exec',
+    'tool_failures',
+    'shell_churn',
+    'exploration_volume',
   ],
 };

--- a/shadow-agent/src/shared/derive.ts
+++ b/shadow-agent/src/shared/derive.ts
@@ -1,22 +1,68 @@
 import { CanonicalEvent, DerivedState, ShadowInsight } from './schema';
 import { sanitizeTranscriptText } from './privacy';
+import { driverRegistry } from '../capture/drivers';
+import type { HarnessCapabilities } from '../capture/drivers/harness-driver';
 
 const TOOL_FILE_KEYS = ['filePath', 'file_path', 'path'];
 
-function extractFilePath(payload: Record<string, unknown>): string | null {
-  for (const key of TOOL_FILE_KEYS) {
-    const value = payload[key];
-    if (typeof value === 'string' && value.length > 0) {
-      return value;
-    }
+/**
+ * Capabilities used when an event has no harnessId and the registry default
+ * is not yet available (e.g. very early bootstrap or tests with hand-rolled
+ * events). The registry's default driver covers the normal case.
+ */
+const FALLBACK_CAPABILITIES: HarnessCapabilities = {
+  emitsSubagentEvents: false,
+  fileAttention: 'tool-args',
+  riskHeuristics: ['tool_failures', 'shell_churn', 'exploration_volume'],
+};
+
+function getCapabilitiesForEvent(event: CanonicalEvent): HarnessCapabilities {
+  if (event.harnessId) {
+    const byId = driverRegistry.get(event.harnessId);
+    if (byId) return byId.capabilities;
   }
+  const bySource = driverRegistry.getForSource(event.source);
+  if (bySource) return bySource.capabilities;
+  try {
+    return driverRegistry.getDefault().capabilities;
+  } catch {
+    return FALLBACK_CAPABILITIES;
+  }
+}
+
+function normalizeToolName(rawName: string, capabilities: HarnessCapabilities): string {
+  const lowered = rawName.toLowerCase();
+  if (!capabilities.toolNameMap) return lowered;
+  return capabilities.toolNameMap(lowered).toLowerCase();
+}
+
+function extractFilePath(
+  event: CanonicalEvent,
+  capabilities: HarnessCapabilities
+): string | null {
+  if (capabilities.fileAttention === 'tool-args') {
+    for (const key of TOOL_FILE_KEYS) {
+      const value = event.payload[key];
+      if (typeof value === 'string' && value.length > 0) {
+        return value;
+      }
+    }
+    return null;
+  }
+  // 'explicit-event' and 'inferred-from-text' have no in-tree implementation
+  // yet — drivers that declare them must wire their own extraction or accept
+  // empty file attention until the work is done. Falling through silently is
+  // intentional: the capability is declarative, derive.ts is non-blocking.
   return null;
 }
 
 function detectPhase(events: CanonicalEvent[]): string {
   const toolNames = events
     .filter((event) => event.kind === 'tool_started' || event.kind === 'tool_completed' || event.kind === 'tool_failed')
-    .map((event) => String(event.payload.toolName ?? '').toLowerCase());
+    .map((event) => {
+      const caps = getCapabilitiesForEvent(event);
+      return normalizeToolName(String(event.payload.toolName ?? ''), caps);
+    });
 
   if (toolNames.some((name) => name.includes('write') || name.includes('edit'))) {
     return 'implementation';
@@ -33,31 +79,63 @@ function detectPhase(events: CanonicalEvent[]): string {
   return 'observation';
 }
 
+/**
+ * Each entry is a capability-gated risk check. Derive runs a check only when
+ * the corresponding ID appears in the event's driver's `riskHeuristics`. New
+ * harnesses opt in to checks by listing their IDs; they opt out of irrelevant
+ * checks by omitting them.
+ */
+const RISK_CHECKS: Record<string, (events: CanonicalEvent[]) => string | null> = {
+  tool_failures: (events) => {
+    const failedTools = events.filter((event) => event.kind === 'tool_failed');
+    if (failedTools.length === 0) return null;
+    return `${failedTools.length} failed tool call${failedTools.length === 1 ? '' : 's'} detected`;
+  },
+  shell_churn: (events) => {
+    const bashTools = events.filter((event) => {
+      if (event.kind !== 'tool_started' && event.kind !== 'tool_completed' && event.kind !== 'tool_failed') {
+        return false;
+      }
+      const caps = getCapabilitiesForEvent(event);
+      const name = normalizeToolName(String(event.payload.toolName ?? ''), caps);
+      return name.includes('bash');
+    });
+    if (bashTools.length < 4) return null;
+    return 'Heavy shell/tool churn suggests validation or recovery thrash';
+  },
+  exploration_volume: (events) => {
+    const repeatedReads = events.filter((event) => {
+      if (event.kind !== 'tool_started') return false;
+      const caps = getCapabilitiesForEvent(event);
+      const name = normalizeToolName(String(event.payload.toolName ?? ''), caps);
+      return name === 'read' || name === 'grep' || name === 'glob';
+    });
+    if (repeatedReads.length < 6) return null;
+    return 'Large exploration volume may indicate uncertainty or missing plan convergence';
+  },
+};
+
 function collectRiskSignals(events: CanonicalEvent[]): string[] {
+  // Union the heuristic IDs declared by every driver represented in this event
+  // batch. Single-harness sessions get exactly one driver's set; multi-harness
+  // sessions get the union, so a check supported by any participating driver
+  // runs over the full event list. A driver that explicitly declares an empty
+  // riskHeuristics list contributes nothing — derive must respect that, not
+  // override it with a fallback set.
+  const enabledIds = new Set<string>();
+  for (const event of events) {
+    for (const id of getCapabilitiesForEvent(event).riskHeuristics) {
+      enabledIds.add(id);
+    }
+  }
+
   const risks: string[] = [];
-  const failedTools = events.filter((event) => event.kind === 'tool_failed');
-  if (failedTools.length > 0) {
-    risks.push(`${failedTools.length} failed tool call${failedTools.length === 1 ? '' : 's'} detected`);
+  for (const id of enabledIds) {
+    const check = RISK_CHECKS[id];
+    if (!check) continue;
+    const signal = check(events);
+    if (signal) risks.push(signal);
   }
-
-  const bashTools = events.filter(
-    (event) =>
-      (event.kind === 'tool_started' || event.kind === 'tool_completed' || event.kind === 'tool_failed') &&
-      String(event.payload.toolName ?? '').toLowerCase().includes('bash')
-  );
-  if (bashTools.length >= 4) {
-    risks.push('Heavy shell/tool churn suggests validation or recovery thrash');
-  }
-
-  const repeatedReads = events.filter(
-    (event) =>
-      event.kind === 'tool_started' &&
-      ['read', 'grep', 'glob'].includes(String(event.payload.toolName ?? '').toLowerCase())
-  );
-  if (repeatedReads.length >= 6) {
-    risks.push('Large exploration volume may indicate uncertainty or missing plan convergence');
-  }
-
   return risks;
 }
 
@@ -152,10 +230,13 @@ export function deriveState(events: CanonicalEvent[], title = 'Observed session'
     }
 
     if (event.kind === 'agent_spawned' || event.kind === 'agent_idle' || event.kind === 'agent_completed') {
+      // emitsSubagentEvents is informational — if a driver never emits these
+      // event kinds, this branch never executes. No explicit gate needed.
       const existing = agentMap.get(event.actor) ?? {
         id: event.actor,
         label: String(event.payload.label ?? event.actor),
         parentId: typeof event.payload.parentId === 'string' ? event.payload.parentId : undefined,
+        harnessId: event.harnessId,
         state: 'active' as const,
         toolCount: 0
       };
@@ -170,13 +251,14 @@ export function deriveState(events: CanonicalEvent[], title = 'Observed session'
       const existing = agentMap.get(event.actor) ?? {
         id: event.actor,
         label: event.actor,
+        harnessId: event.harnessId,
         state: 'active' as const,
         toolCount: 0
       };
       existing.toolCount += 1;
       agentMap.set(event.actor, existing);
 
-      const filePath = extractFilePath(event.payload);
+      const filePath = extractFilePath(event, getCapabilitiesForEvent(event));
       if (filePath) {
         fileAttention.set(filePath, (fileAttention.get(filePath) ?? 0) + 1);
       }

--- a/shadow-agent/tests/derive-capabilities.test.ts
+++ b/shadow-agent/tests/derive-capabilities.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Capability-driven derive contract tests (PR 5).
+ *
+ * Verifies that derive.ts dispatches behavior through HarnessDriverRegistry
+ * rather than hardcoded branches. These tests mock the registry so they can
+ * inject fake drivers with controlled capabilities without polluting the
+ * singleton or requiring an unregister API.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { CanonicalEvent } from '../src/shared/schema';
+import type { HarnessCapabilities, HarnessDriver } from '../src/capture/drivers/harness-driver';
+
+// Hoist the mock setup so the registry stub exists before derive.ts imports it.
+const { mockRegistry } = vi.hoisted(() => {
+  return {
+    mockRegistry: {
+      drivers: new Map<string, HarnessDriver>(),
+      sources: new Map<string, HarnessDriver>(),
+      defaultDriverId: null as string | null,
+      get(id: string) {
+        return this.drivers.get(id);
+      },
+      getForSource(source: string) {
+        return this.sources.get(source);
+      },
+      getDefault() {
+        const driver = this.defaultDriverId ? this.drivers.get(this.defaultDriverId) : undefined;
+        if (!driver) throw new Error('mock registry empty');
+        return driver;
+      },
+      register(driver: HarnessDriver) {
+        this.drivers.set(driver.id, driver);
+        for (const source of driver.sources) this.sources.set(String(source), driver);
+        if (this.defaultDriverId === null) this.defaultDriverId = driver.id;
+        return this;
+      },
+      reset() {
+        this.drivers.clear();
+        this.sources.clear();
+        this.defaultDriverId = null;
+      },
+    },
+  };
+});
+
+vi.mock('../src/capture/drivers', () => ({
+  driverRegistry: mockRegistry,
+}));
+
+// Import after the mock is in place.
+const { deriveState } = await import('../src/shared/derive');
+
+function makeCaps(overrides: Partial<HarnessCapabilities> = {}): HarnessCapabilities {
+  return {
+    emitsSubagentEvents: false,
+    fileAttention: 'tool-args',
+    riskHeuristics: [],
+    ...overrides,
+  };
+}
+
+function makeDriver(id: string, caps: HarnessCapabilities, sources: string[] = [`${id}-source`]): HarnessDriver {
+  return {
+    id,
+    sources,
+    capabilities: caps,
+    normalizeEntry: () => [],
+  };
+}
+
+let eventCounter = 0;
+function makeEvent(overrides: Partial<CanonicalEvent>): CanonicalEvent {
+  eventCounter += 1;
+  return {
+    id: `e-${eventCounter}`,
+    sessionId: 'sess',
+    source: 'replay',
+    timestamp: `2026-01-01T00:00:${String(eventCounter).padStart(2, '0')}.000Z`,
+    actor: 'assistant',
+    kind: 'tool_started',
+    payload: {},
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockRegistry.reset();
+  eventCounter = 0;
+});
+
+// ---------------------------------------------------------------------------
+// riskHeuristics gating
+// ---------------------------------------------------------------------------
+
+describe('derive — riskHeuristics gating', () => {
+  it('emits no risk signals when the driver declares an empty heuristics list', () => {
+    mockRegistry.register(makeDriver('quiet', makeCaps({ riskHeuristics: [] })));
+    const events = [
+      makeEvent({ harnessId: 'quiet', kind: 'tool_failed', payload: { toolName: 'Bash' } }),
+      makeEvent({ harnessId: 'quiet', kind: 'tool_failed', payload: { toolName: 'Bash' } }),
+    ];
+    expect(deriveState(events).riskSignals).toEqual([]);
+  });
+
+  it('runs only the checks whose IDs the driver declares', () => {
+    // Driver supports tool_failures but not shell_churn.
+    mockRegistry.register(makeDriver('failures-only', makeCaps({
+      riskHeuristics: ['tool_failures'],
+    })));
+    const events = [
+      makeEvent({ harnessId: 'failures-only', kind: 'tool_failed', payload: { toolName: 'Bash' } }),
+      ...Array.from({ length: 6 }, () =>
+        makeEvent({ harnessId: 'failures-only', kind: 'tool_started', payload: { toolName: 'Bash' } })
+      ),
+    ];
+    const risks = deriveState(events).riskSignals;
+    expect(risks.some((r) => r.includes('failed tool call'))).toBe(true);
+    // shell_churn (>=4 bash) would have fired in the legacy code, but the
+    // driver doesn't claim that heuristic, so it must not appear.
+    expect(risks.some((r) => r.toLowerCase().includes('churn'))).toBe(false);
+  });
+
+  it('unions heuristic IDs across multiple harnesses in one event batch', () => {
+    mockRegistry.register(makeDriver('a', makeCaps({ riskHeuristics: ['tool_failures'] })));
+    mockRegistry.register(makeDriver('b', makeCaps({ riskHeuristics: ['shell_churn'] })));
+    const events = [
+      makeEvent({ harnessId: 'a', kind: 'tool_failed', payload: { toolName: 'Read' } }),
+      ...Array.from({ length: 4 }, () =>
+        makeEvent({ harnessId: 'b', kind: 'tool_started', payload: { toolName: 'Bash' } })
+      ),
+    ];
+    const risks = deriveState(events).riskSignals;
+    expect(risks.some((r) => r.includes('failed tool call'))).toBe(true);
+    expect(risks.some((r) => r.toLowerCase().includes('churn'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toolNameMap
+// ---------------------------------------------------------------------------
+
+describe('derive — toolNameMap', () => {
+  it('rewrites tool names before phase detection sees them', () => {
+    // A driver whose Edit tool is named 'apply_patch' (Codex flavour).
+    mockRegistry.register(makeDriver('codex', makeCaps({
+      toolNameMap: (name) => (name === 'apply_patch' ? 'edit' : name),
+    })));
+    const events = [
+      makeEvent({ harnessId: 'codex', kind: 'tool_started', payload: { toolName: 'apply_patch' } }),
+    ];
+    expect(deriveState(events).activePhase).toBe('implementation');
+  });
+
+  it('rewrites tool names before risk-heuristic shell_churn sees them', () => {
+    // A driver whose shell tool is 'execute_command' — without mapping, the
+    // shell_churn check (matches "bash") would never fire.
+    mockRegistry.register(makeDriver('codex', makeCaps({
+      riskHeuristics: ['shell_churn'],
+      toolNameMap: (name) => (name === 'execute_command' ? 'bash' : name),
+    })));
+    const events = Array.from({ length: 4 }, () =>
+      makeEvent({ harnessId: 'codex', kind: 'tool_started', payload: { toolName: 'execute_command' } })
+    );
+    expect(deriveState(events).riskSignals.some((r) => r.toLowerCase().includes('churn'))).toBe(true);
+  });
+
+  it('absence of toolNameMap leaves tool names lowercased only', () => {
+    mockRegistry.register(makeDriver('plain', makeCaps()));
+    const events = [
+      makeEvent({ harnessId: 'plain', kind: 'tool_started', payload: { toolName: 'Write' } }),
+    ];
+    // 'write' triggers implementation; no rewriting required.
+    expect(deriveState(events).activePhase).toBe('implementation');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fileAttention strategy
+// ---------------------------------------------------------------------------
+
+describe('derive — fileAttention strategy', () => {
+  it("tool-args strategy extracts filePath from tool payload", () => {
+    mockRegistry.register(makeDriver('claude-code', makeCaps({ fileAttention: 'tool-args' })));
+    const events = [
+      makeEvent({ harnessId: 'claude-code', kind: 'tool_started', payload: { toolName: 'Edit', filePath: 'src/x.ts' } }),
+      makeEvent({ harnessId: 'claude-code', kind: 'tool_started', payload: { toolName: 'Read', file_path: 'src/y.ts' } }),
+    ];
+    const paths = deriveState(events).fileAttention.map((f) => f.filePath).sort();
+    expect(paths).toEqual(['src/x.ts', 'src/y.ts']);
+  });
+
+  it("non-'tool-args' strategies do not extract from tool payloads", () => {
+    // 'inferred-from-text' has no in-tree implementation; derive.ts must not
+    // silently fall back to tool-args extraction or the capability flag
+    // becomes meaningless.
+    mockRegistry.register(makeDriver('aider-like', makeCaps({ fileAttention: 'inferred-from-text' })));
+    const events = [
+      makeEvent({ harnessId: 'aider-like', kind: 'tool_started', payload: { toolName: 'Edit', filePath: 'src/x.ts' } }),
+    ];
+    expect(deriveState(events).fileAttention).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// harnessId propagation onto AgentNode
+// ---------------------------------------------------------------------------
+
+describe('derive — harnessId on AgentNode', () => {
+  it('stamps harnessId onto agent nodes derived from tool events', () => {
+    mockRegistry.register(makeDriver('claude-code', makeCaps()));
+    const events = [
+      makeEvent({
+        harnessId: 'claude-code',
+        kind: 'tool_started',
+        actor: 'assistant',
+        payload: { toolName: 'Read', filePath: 'x.ts' },
+      }),
+    ];
+    const nodes = deriveState(events).agentNodes;
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]?.harnessId).toBe('claude-code');
+  });
+
+  it('stamps harnessId onto agent nodes derived from agent_spawned events', () => {
+    mockRegistry.register(makeDriver('claude-code', makeCaps({ emitsSubagentEvents: true })));
+    const events = [
+      makeEvent({
+        harnessId: 'claude-code',
+        kind: 'agent_spawned',
+        actor: 'subagent-1',
+        payload: { label: 'Researcher' },
+      }),
+    ];
+    const nodes = deriveState(events).agentNodes;
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]?.harnessId).toBe('claude-code');
+    expect(nodes[0]?.label).toBe('Researcher');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fallback when no driver matches
+// ---------------------------------------------------------------------------
+
+describe('derive — capability fallback', () => {
+  it('uses the registry default when an event has no matching harnessId or source', () => {
+    mockRegistry.register(makeDriver('claude-code', makeCaps({
+      riskHeuristics: ['tool_failures'],
+    })));
+    // Event has no harnessId, source 'replay' is not registered — must
+    // fall back to the default driver (claude-code) and pick up its
+    // riskHeuristics.
+    const events = [
+      makeEvent({ kind: 'tool_failed', payload: { toolName: 'Read' } }),
+    ];
+    expect(deriveState(events).riskSignals.some((r) => r.includes('failed tool call'))).toBe(true);
+  });
+
+  it('uses the static fallback heuristics when the registry is empty', () => {
+    // Registry empty: derive must still emit risk signals using the
+    // hardcoded fallback list so legacy fixtures keep working.
+    const events = [
+      makeEvent({ kind: 'tool_failed', payload: { toolName: 'Read' } }),
+    ];
+    expect(deriveState(events).riskSignals.some((r) => r.includes('failed tool call'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

PR 5 in the multi-harness sprint. **Final PR in the sprint** — PRs 6, 7, 8 are deferred along with the Cursor driver. After this lands, the plan is to live-test against a real Claude Code session before planning the post-sprint multi-session redesign.

`derive.ts` no longer hardcodes which checks run; it asks `driverRegistry` for each event's driver capabilities and dispatches accordingly. The registry becomes the source of truth for both ingestion (PRs 2-4) and insight extraction.

### What changed

- `shared/derive.ts` looks up capabilities per-event via `event.harnessId` (falls back to source, then registry default, then a hardcoded safety-net)
- Risk heuristics are now ID-keyed (`tool_failures`, `shell_churn`, `exploration_volume`). Drivers list the IDs they support; derive runs only those checks
- Phase detection and `shell_churn` apply `capabilities.toolNameMap` (when present) before string matching — so a Codex driver mapping `apply_patch` → `edit` would work without derive.ts changes
- File attention dispatches on `capabilities.fileAttention`. Only `'tool-args'` has an in-tree implementation; `'explicit-event'` and `'inferred-from-text'` return null (declarative-only until a driver wires them)
- `AgentNode` is stamped with `event.harnessId` so PR 7's per-harness palette accent has a key to read

### What did NOT change

- Existing Claude behavior preserved — `claudeCodeCapabilities` declares the three heuristic IDs that match the in-tree checks. All 24 prior `derive.test.ts` tests pass unchanged
- `emitsSubagentEvents` remains informational metadata; derive.ts does NOT gate the subagent topology block on it (the block self-gates by event kind — if a driver never emits `agent_spawned`, the branch never runs)
- IPC contract unchanged. No method signatures touched

### Tests

`tests/derive-capabilities.test.ts` — 12 new tests using `vi.mock` to swap the singleton registry per test. Covers:

- `riskHeuristics: []` truly opts out (no fallback override)
- Only declared check IDs run; non-declared IDs are silently skipped
- Multi-harness batches union heuristic IDs
- `toolNameMap` rewrites flow through phase detection AND `shell_churn`
- `fileAttention: 'tool-args'` extracts from tool payloads
- `fileAttention: 'inferred-from-text'` returns no file attention (declarative-only)
- `harnessId` stamped on AgentNode from both tool events and `agent_spawned` events
- Registry-default fallback when event has no harnessId and source isn't registered
- Static fallback when registry is empty

405 tests passing (393 prior + 12 new). `npm run build` clean.

## Test plan

- [x] `npm test --prefix shadow-agent` — 405/405 passing
- [x] `npm run build --prefix shadow-agent` — clean
- [ ] CI green
- [ ] Manual: review the in-flight risk to make sure I haven't accidentally removed a check that the existing fixtures rely on (the `derive.test.ts` suite would catch this; double-check the risk-signal expectations)

## Stacked on

PR 4.5 (`claude/multi-harness-pr4.5-e2e-gate`)

## Sprint stop

After this merges, the original PR 6 (Cursor driver), PR 7 (palette accent), and PR 8 (cross-harness e2e) are **out of sprint scope**. Live-test Claude → post-sprint redesign of internal communication (single-session EventBuffer → multi-session-native) is the next workstream.

https://claude.ai/code/session_014jr8rJz771wfE3ayd6eoQn

_Generated by [Claude Code](https://claude.ai/code/session_014jr8rJz771wfE3ayd6eoQn)_


___

## **CodeAnt-AI Description**
**Make session analysis follow each harness’s capabilities**

### What Changed
- Session insights now use the matching harness’s capabilities instead of one fixed set of rules, so different drivers can produce the right phase, risk, and file-focus signals
- Tool names can be translated before analysis, which lets harnesses with different tool labels still show the correct phase and shell-churn signals
- File attention is only extracted when the harness says it comes from tool arguments; other declared file-attention styles no longer fall back to the wrong behavior
- Agent entries now keep the harness ID they came from, which supports harness-specific presentation later on

### Impact
`✅ Correct session insights across multiple harnesses`
`✅ Fewer missing or false phase detections`
`✅ Clearer file focus tracking`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
