### PR TITLE
feat(shadow-agent): Phoenix OTel ingestion transport

### DIFF
--- a/docs/domain-events.md
+++ b/docs/domain-events.md
@@ -95,9 +95,22 @@ come from, and the live runtime now supports multiple capture transports:
   and reconnects after disconnects.
 - **Socket**: Reads raw TCP streams, applies light backpressure-aware pausing, and
   reconnects after disconnects.
+- **Phoenix**: Polls the Arize Phoenix REST API (`/v1/spans`) for new spans every 2 s
+  (configurable via `SHADOW_CAPTURE_RECONNECT_MS`). This is the **default transport**.
+  Supported sources: Claude Code CLI (with `CLAUDE_CODE_ENABLE_TELEMETRY=1`), OpenCode SDK,
+  Codex CLI, and any OpenInference-instrumented SDK (Anthropic, OpenAI, LangChain, LlamaIndex,
+  CrewAI, etc.). Requires `SHADOW_CAPTURE_PHOENIX_URL` pointing at a running Phoenix instance
+  (e.g. `http://localhost:6006`). Optional: `SHADOW_CAPTURE_PHOENIX_PROJECT` (default:
+  `"default"`), `SHADOW_CAPTURE_PHOENIX_API_KEY`. Spans are normalised by
+  `otel-normalizer.ts` which dispatches on OpenInference span kinds (`LLM`, `TOOL`, `AGENT`)
+  and Claude Code log event names (`user_prompt`, `tool_decision`, `tool_result`, `file_edit`).
 
 Each transport feeds the same incremental parser and normalizer pipeline so the downstream
 event buffer, IPC bridge, renderer, and inference consumers stay unchanged.
+
+> **Known gap**: Claude Code's OTel emission does not appear to include extended-thinking
+> blocks. If you need thinking-block visibility, set `SHADOW_CAPTURE_TRANSPORT=file-tail`
+> to use the JSONL path while this is investigated.
 
 ## File Map
 

--- a/shadow-agent/src/capture/capture-transport.ts
+++ b/shadow-agent/src/capture/capture-transport.ts
@@ -1,6 +1,6 @@
 import type { EventQueueBackpressureState, EventSource } from '../shared/schema';
 
-export type CaptureTransportKind = 'file-tail' | 'http-stream' | 'websocket' | 'socket';
+export type CaptureTransportKind = 'file-tail' | 'http-stream' | 'websocket' | 'socket' | 'phoenix';
 export type CaptureTransportResetReason = 'rotation' | 'truncation' | 'reconnect';
 
 export interface CaptureSession {
@@ -67,9 +67,20 @@ export interface SocketCaptureTransportOptions {
   sessionLabel?: string;
 }
 
+export interface PhoenixCaptureTransportOptions {
+  kind: 'phoenix';
+  url: string;
+  projectName?: string;
+  pollIntervalMs?: number;
+  apiKey?: string;
+  sessionId?: string;
+  sessionLabel?: string;
+}
+
 export type CaptureTransportOptions =
   | FileTailCaptureTransportOptions
   | HttpStreamCaptureTransportOptions
   | WebSocketCaptureTransportOptions
-  | SocketCaptureTransportOptions;
+  | SocketCaptureTransportOptions
+  | PhoenixCaptureTransportOptions;
 

--- a/shadow-agent/src/capture/capture-transports.ts
+++ b/shadow-agent/src/capture/capture-transports.ts
@@ -1,10 +1,11 @@
-import type { CaptureTransport, CaptureTransportOptions, HttpStreamCaptureTransportOptions, SocketCaptureTransportOptions, WebSocketCaptureTransportOptions } from './capture-transport';
+import type { CaptureTransport, CaptureTransportOptions, HttpStreamCaptureTransportOptions, PhoenixCaptureTransportOptions, SocketCaptureTransportOptions, WebSocketCaptureTransportOptions } from './capture-transport';
 import { createHttpStreamCaptureTransport } from './http-stream-transport';
+import { createPhoenixCaptureTransport } from './phoenix-transport';
 import { createSocketCaptureTransport } from './socket-transport';
 import { createFileTailCaptureTransport } from './transcript-watcher';
 import { createWebSocketCaptureTransport } from './websocket-transport';
 
-const DEFAULT_CAPTURE_TRANSPORT = 'file-tail';
+const DEFAULT_CAPTURE_TRANSPORT = 'phoenix';
 
 function parseReconnectDelayMs(raw: string | undefined): number | undefined {
   if (!raw?.trim()) {
@@ -76,6 +77,19 @@ export function resolveCaptureTransportOptionsFromEnv(
         sessionId: env.SHADOW_CAPTURE_SESSION_ID?.trim() || undefined,
         sessionLabel: env.SHADOW_CAPTURE_SESSION_LABEL?.trim() || undefined
       } satisfies SocketCaptureTransportOptions;
+    case 'phoenix':
+      return {
+        kind: 'phoenix',
+        url: requiredEnv(
+          env.SHADOW_CAPTURE_PHOENIX_URL ?? env.SHADOW_CAPTURE_TARGET,
+          'SHADOW_CAPTURE_PHOENIX_URL'
+        ),
+        projectName: env.SHADOW_CAPTURE_PHOENIX_PROJECT?.trim() || undefined,
+        pollIntervalMs: parseReconnectDelayMs(env.SHADOW_CAPTURE_RECONNECT_MS),
+        apiKey: env.SHADOW_CAPTURE_PHOENIX_API_KEY?.trim() || undefined,
+        sessionId: env.SHADOW_CAPTURE_SESSION_ID?.trim() || undefined,
+        sessionLabel: env.SHADOW_CAPTURE_SESSION_LABEL?.trim() || undefined
+      } satisfies PhoenixCaptureTransportOptions;
     default:
       throw new Error(`Unsupported SHADOW_CAPTURE_TRANSPORT: ${kind}`);
   }
@@ -91,5 +105,7 @@ export function createCaptureTransport(options: CaptureTransportOptions): Captur
       return createWebSocketCaptureTransport(options);
     case 'socket':
       return createSocketCaptureTransport(options);
+    case 'phoenix':
+      return createPhoenixCaptureTransport(options);
   }
 }

--- a/shadow-agent/src/capture/otel-normalizer.ts
+++ b/shadow-agent/src/capture/otel-normalizer.ts
@@ -1,0 +1,206 @@
+/**
+ * Normalizes Phoenix / OpenTelemetry spans and Claude Code OTel log events
+ * into CanonicalEvents.
+ *
+ * Dispatches on two namespaces:
+ *   - OpenInference (openinference.span.kind present): LLM, TOOL, AGENT, CHAIN spans
+ *   - Claude Code log events (name = user_prompt | tool_decision | tool_result | file_edit | …)
+ *
+ * Extended-thinking blocks are NOT present in Claude Code's OTel emission as of 2026-05;
+ * if that changes, add a 'thinking' case to normalizeClaudeCodeLogEvent below.
+ */
+import { randomUUID } from 'node:crypto';
+import type { CanonicalEvent, EventKind } from '../shared/schema';
+
+type OtelEntry = Record<string, unknown>;
+
+const CLAUDE_CODE_LOG_EVENTS = new Set([
+  'user_prompt',
+  'tool_decision',
+  'tool_result',
+  'file_edit',
+  'api_request',
+  'api_error',
+]);
+
+function str(v: unknown): string {
+  if (typeof v === 'string') return v;
+  if (v != null) return String(v);
+  return '';
+}
+
+function tryJson(v: unknown): unknown {
+  if (typeof v === 'string') {
+    try {
+      return JSON.parse(v);
+    } catch {
+      /* not JSON */
+    }
+  }
+  return v;
+}
+
+function event(
+  kind: EventKind,
+  actor: string,
+  sessionId: string,
+  timestamp: string,
+  payload: Record<string, unknown>
+): CanonicalEvent {
+  return { id: randomUUID(), sessionId, source: 'phoenix', timestamp, actor, kind, payload };
+}
+
+function normalizeOpenInferenceSpan(span: OtelEntry, sessionId: string): CanonicalEvent[] {
+  const events: CanonicalEvent[] = [];
+  const attrs = (span.attributes as Record<string, unknown>) ?? {};
+  const spanKind = str(
+    span.span_kind ?? attrs['openinference.span.kind'] ?? ''
+  ).toUpperCase();
+  const ctx = (span.context as Record<string, unknown>) ?? {};
+  const spanId = str(ctx.span_id ?? '');
+  const traceId = str(ctx.trace_id ?? '');
+  const parentId = span.parent_id != null ? str(span.parent_id) : null;
+  const startTime = str(span.start_time ?? new Date().toISOString());
+  const endTime = str(span.end_time ?? startTime);
+  const statusCode = str(span.status_code ?? 'OK').toUpperCase();
+  const isError = statusCode === 'ERROR';
+
+  switch (spanKind) {
+    case 'LLM': {
+      const inputMessages = attrs['llm.input_messages'];
+      if (Array.isArray(inputMessages)) {
+        for (const msg of inputMessages as OtelEntry[]) {
+          const role = str(msg['message.role'] ?? 'unknown');
+          const content = str(msg['message.content'] ?? '');
+          if (content) {
+            events.push(event('message', role === 'user' ? 'user' : 'assistant', sessionId, startTime, { text: content }));
+          }
+        }
+      }
+      const outputMessages = attrs['llm.output_messages'];
+      if (Array.isArray(outputMessages)) {
+        for (const msg of outputMessages as OtelEntry[]) {
+          const content = str(msg['message.content'] ?? '');
+          if (content) {
+            events.push(event('message', 'assistant', sessionId, endTime, { text: content }));
+          }
+          const toolCalls = msg['message.tool_calls'];
+          if (Array.isArray(toolCalls)) {
+            for (const tc of toolCalls as OtelEntry[]) {
+              const toolUseId = str(tc['tool_call.id'] ?? randomUUID());
+              const toolName = str(tc['tool_call.function.name'] ?? 'unknown');
+              const args = tryJson(tc['tool_call.function.arguments']) ?? {};
+              events.push(event('tool_started', 'assistant', sessionId, endTime, { toolName, toolUseId, args }));
+            }
+          }
+        }
+      }
+      break;
+    }
+
+    case 'TOOL': {
+      const toolName = str(attrs['tool.name'] ?? span.name ?? 'unknown');
+      const toolUseId = spanId || randomUUID();
+      const args = tryJson(attrs['tool.inputs']) ?? {};
+      const output = tryJson(attrs['tool.outputs']) ?? null;
+      events.push(event('tool_started', 'assistant', sessionId, startTime, { toolName, toolUseId, args }));
+      events.push(event(
+        isError ? 'tool_failed' : 'tool_completed',
+        'tool',
+        sessionId,
+        endTime,
+        isError
+          ? { toolUseId, error: str(span.status_message ?? 'Tool failed') }
+          : { toolUseId, output }
+      ));
+      break;
+    }
+
+    case 'AGENT': {
+      if (parentId) {
+        events.push(event('subagent_dispatched', 'system', sessionId, startTime, { agentId: spanId, traceId, parentSpanId: parentId }));
+        events.push(event('subagent_returned', 'system', sessionId, endTime, { agentId: spanId, traceId }));
+      } else {
+        events.push(event('session_started', 'system', sessionId, startTime, { traceId }));
+      }
+      break;
+    }
+
+    default: {
+      // CHAIN / RETRIEVER / generic — emit input/output as messages if present
+      const inputText = str(attrs['input.value'] ?? '');
+      if (inputText) events.push(event('message', 'user', sessionId, startTime, { text: inputText }));
+      const outputText = str(attrs['output.value'] ?? '');
+      if (outputText) events.push(event('message', 'assistant', sessionId, endTime, { text: outputText }));
+      break;
+    }
+  }
+
+  return events;
+}
+
+function normalizeClaudeCodeLogEvent(span: OtelEntry, sessionId: string): CanonicalEvent[] {
+  const events: CanonicalEvent[] = [];
+  const attrs = (span.attributes as Record<string, unknown>) ?? {};
+  const ts = str(span.start_time ?? new Date().toISOString());
+  const name = str(span.name ?? '');
+
+  switch (name) {
+    case 'user_prompt': {
+      const text = str(attrs['prompt'] ?? attrs['input.value'] ?? '');
+      if (text) events.push(event('message', 'user', sessionId, ts, { text }));
+      break;
+    }
+    case 'tool_decision': {
+      const toolName = str(attrs['tool_name'] ?? attrs['tool.name'] ?? 'unknown');
+      const toolUseId = str(attrs['tool_use_id'] ?? randomUUID());
+      const args = tryJson(attrs['tool_input'] ?? attrs['tool.inputs']) ?? {};
+      events.push(event('tool_started', 'assistant', sessionId, ts, { toolName, toolUseId, args }));
+      break;
+    }
+    case 'tool_result': {
+      const toolUseId = str(attrs['tool_use_id'] ?? '');
+      const isError = attrs['is_error'] === true || attrs['is_error'] === 'true';
+      const output = attrs['tool_result'] ?? attrs['output.value'] ?? null;
+      events.push(event(
+        isError ? 'tool_failed' : 'tool_completed',
+        'tool',
+        sessionId,
+        ts,
+        isError ? { toolUseId, error: str(output) } : { toolUseId, output }
+      ));
+      break;
+    }
+    case 'file_edit': {
+      const filePath = str(attrs['file_path'] ?? attrs['path'] ?? '');
+      events.push(event('tool_started', 'assistant', sessionId, ts, {
+        toolName: 'file_edit',
+        toolUseId: randomUUID(),
+        args: { path: filePath }
+      }));
+      break;
+    }
+    case 'api_error': {
+      const errMsg = str(attrs['error'] ?? attrs['message'] ?? 'API error');
+      events.push(event('tool_failed', 'system', sessionId, ts, { toolUseId: '', error: errMsg }));
+      break;
+    }
+    // api_request: useful for inference context but not a canvas event; skip
+    default:
+      break;
+  }
+
+  return events;
+}
+
+export function normalizeOtelSpan(entry: Record<string, unknown>, sessionId: string): CanonicalEvent[] {
+  const attrs = (entry.attributes as Record<string, unknown>) ?? {};
+  const spanKind = str(entry.span_kind ?? attrs['openinference.span.kind'] ?? '');
+  const name = str(entry.name ?? '');
+
+  if (!spanKind && CLAUDE_CODE_LOG_EVENTS.has(name)) {
+    return normalizeClaudeCodeLogEvent(entry, sessionId);
+  }
+
+  return normalizeOpenInferenceSpan(entry, sessionId);
+}

--- a/shadow-agent/src/capture/phoenix-transport.ts
+++ b/shadow-agent/src/capture/phoenix-transport.ts
@@ -1,0 +1,132 @@
+import { createLogger } from '../shared/logger';
+import type {
+  CaptureSession,
+  CaptureTransport,
+  CaptureTransportContext,
+  CaptureTransportSubscription,
+  PhoenixCaptureTransportOptions
+} from './capture-transport';
+
+const logger = createLogger({ minLevel: 'info' });
+const DEFAULT_POLL_INTERVAL_MS = 2_000;
+const DEFAULT_PROJECT_NAME = 'default';
+
+interface PhoenixSpan {
+  name: string;
+  span_kind?: string;
+  context?: { span_id?: string; trace_id?: string };
+  parent_id?: string | null;
+  start_time: string;
+  end_time?: string | null;
+  status_code?: string;
+  status_message?: string;
+  attributes?: Record<string, unknown>;
+  project_name?: string;
+}
+
+interface PhoenixSpansResponse {
+  data?: PhoenixSpan[];
+  next_cursor?: string | null;
+}
+
+function buildSession(options: PhoenixCaptureTransportOptions): CaptureSession {
+  const projectName = options.projectName ?? DEFAULT_PROJECT_NAME;
+  return {
+    sessionId: options.sessionId ?? `phoenix-${projectName}`,
+    label: options.sessionLabel ?? `Phoenix: ${projectName}`,
+    source: 'phoenix',
+    path: options.url,
+    transportId: 'phoenix'
+  };
+}
+
+export function createPhoenixCaptureTransport(
+  options: PhoenixCaptureTransportOptions
+): CaptureTransport {
+  return {
+    id: 'phoenix',
+    kind: 'phoenix',
+    async start(context: CaptureTransportContext): Promise<CaptureTransportSubscription> {
+      const session = buildSession(options);
+      const pollIntervalMs = Math.max(500, options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
+      const projectName = options.projectName ?? DEFAULT_PROJECT_NAME;
+      const baseUrl = options.url.replace(/\/$/, '');
+      const headers: Record<string, string> = { Accept: 'application/json' };
+      if (options.apiKey) {
+        headers['Authorization'] = `Bearer ${options.apiKey}`;
+      }
+
+      let stopped = false;
+      let pollTimer: ReturnType<typeof setTimeout> | null = null;
+      let lastStartTime: string | null = null;
+      let hasConnected = false;
+
+      const clearTimer = () => {
+        if (pollTimer) {
+          clearTimeout(pollTimer);
+          pollTimer = null;
+        }
+      };
+
+      const schedulePoll = () => {
+        if (stopped || pollTimer) return;
+        pollTimer = setTimeout(() => {
+          pollTimer = null;
+          void poll();
+        }, pollIntervalMs);
+      };
+
+      const fetchSpans = async (): Promise<PhoenixSpan[]> => {
+        const params = new URLSearchParams({ project_name: projectName, limit: '200' });
+        if (lastStartTime) params.set('start_time', lastStartTime);
+        const url = `${baseUrl}/v1/spans?${params.toString()}`;
+        const response = await fetch(url, { headers });
+        if (!response.ok) {
+          throw new Error(`Phoenix API ${response.status} ${response.statusText}`);
+        }
+        const body = (await response.json()) as PhoenixSpansResponse;
+        const spans = body.data ?? [];
+        // sort ascending so events arrive in causal order
+        return spans.sort(
+          (a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime()
+        );
+      };
+
+      const poll = async (): Promise<void> => {
+        if (stopped) return;
+        try {
+          const spans = await fetchSpans();
+
+          if (!hasConnected) {
+            await context.onSessionStarted(session);
+            hasConnected = true;
+          }
+
+          if (spans.length > 0) {
+            const ndjson = spans.map((s) => JSON.stringify(s)).join('\n') + '\n';
+            await context.onChunk({ session, chunk: ndjson });
+            const newest = spans[spans.length - 1];
+            const newestMs = new Date(newest.start_time).getTime();
+            lastStartTime = new Date(newestMs + 1).toISOString();
+          }
+        } catch (error) {
+          if (!stopped) {
+            logger.warn('capture', 'transport.phoenix.poll_error', { url: baseUrl, error });
+          }
+        } finally {
+          if (!stopped) schedulePoll();
+        }
+      };
+
+      void poll();
+
+      return {
+        stop() {
+          stopped = true;
+          clearTimer();
+          logger.info('capture', 'transport.phoenix.stopped', { url: baseUrl });
+        }
+      };
+    }
+  };
+}

--- a/shadow-agent/src/capture/session-manager.ts
+++ b/shadow-agent/src/capture/session-manager.ts
@@ -11,6 +11,7 @@ import type { SnapshotPayload, LoadedSource, TranscriptPrivacySettings } from '.
 import { buildRendererInput } from '../shared/renderer-input-adapter';
 import { createIncrementalParser } from './incremental-parser';
 import { normalizeEntry } from './normalizer';
+import { normalizeOtelSpan } from './otel-normalizer';
 import { createEventBuffer, type EventBuffer } from './event-buffer';
 import { createIpcBridge } from './ipc-bridge';
 import { createLogger } from '../shared/logger';
@@ -20,7 +21,7 @@ import type {
   CaptureTransportOptions,
   CaptureTransportSubscription
 } from './capture-transport';
-import { createCaptureTransport } from './capture-transports';
+import { createCaptureTransport, resolveCaptureTransportOptionsFromEnv } from './capture-transports';
 
 const logger = createLogger({ minLevel: 'info' });
 
@@ -57,7 +58,9 @@ export function createSessionManager(
   const transport =
     options.transport && 'start' in options.transport
       ? options.transport
-      : createCaptureTransport(options.transport ?? { kind: 'file-tail' });
+      : createCaptureTransport(options.transport ?? resolveCaptureTransportOptionsFromEnv());
+
+  const resolvedNormalizer = transport.kind === 'phoenix' ? normalizeOtelSpan : normalizeEntry;
 
   const buildSnapshot = async (): Promise<SnapshotPayload | null> => {
     const events = await buffer.getAll();
@@ -88,7 +91,7 @@ export function createSessionManager(
     await buffer.setSession(session.sessionId);
     activeSession = session;
     activeParser = createIncrementalParser((entry) => {
-      const events = normalizeEntry(entry, session.sessionId);
+      const events = resolvedNormalizer(entry, session.sessionId);
       if (events.length === 0) {
         return;
       }

--- a/shadow-agent/src/shared/schema.ts
+++ b/shadow-agent/src/shared/schema.ts
@@ -1,4 +1,4 @@
-export type EventSource = 'claude-hook' | 'claude-transcript' | 'replay' | 'shadow-runtime';
+export type EventSource = 'claude-hook' | 'claude-transcript' | 'replay' | 'shadow-runtime' | 'phoenix';
 
 export type EventKind =
   | 'session_started'


### PR DESCRIPTION
## Summary

- Adds `phoenix-transport.ts`: polls Arize Phoenix `/v1/spans` every 2 s, feeds spans as NDJSON into the existing incremental-parser pipeline
- Adds `otel-normalizer.ts`: maps OpenInference span kinds (`LLM`, `TOOL`, `AGENT`) and Claude Code OTel log event names (`user_prompt`, `tool_decision`, `tool_result`, `file_edit`) → `CanonicalEvent`
- Makes **Phoenix the default** `SHADOW_CAPTURE_TRANSPORT`; all existing transports remain selectable via env var
- `session-manager.ts` picks normalizer by transport kind; default transport now reads from `resolveCaptureTransportOptionsFromEnv()` instead of hardcoding `file-tail`
- `EventSource` extended with `'phoenix'`

## Covered sources

| Source | How |
|---|---|
| Claude Code CLI | `CLAUDE_CODE_ENABLE_TELEMETRY=1` + unredaction envs → Anthropic-namespace log events |
| OpenCode SDK | native OTLP |
| Codex CLI | native OTLP |
| Anthropic / OpenAI / LangChain / LlamaIndex / CrewAI / etc. | OpenInference instrumentors |

## Required env vars

```
SHADOW_CAPTURE_PHOENIX_URL=http://localhost:6006   # required
SHADOW_CAPTURE_PHOENIX_PROJECT=default             # optional
SHADOW_CAPTURE_PHOENIX_API_KEY=...                 # optional
```

For Claude Code as source, also set on the observed process:
```
CLAUDE_CODE_ENABLE_TELEMETRY=1
OTEL_METRICS_EXPORTER=otlp
OTEL_LOGS_EXPORTER=otlp
OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
OTEL_LOG_USER_PROMPTS=1
OTEL_LOG_TOOL_DETAILS=1
OTEL_LOG_TOOL_CONTENT=1
```

## Known gap

Claude Code's OTel emission does not include extended-thinking blocks. Set `SHADOW_CAPTURE_TRANSPORT=file-tail` if thinking-block visibility is needed. Documented in `docs/domain-events.md`.

## Test plan

- [ ] Stand up `docker run -p 6006:6006 -p 4317:4317 arizephoenix/phoenix`, run a Claude Code session, confirm `tool_started`/`tool_completed`/`message` events flow through the live canvas
- [ ] Run a LangChain or Anthropic SDK script with an OpenInference instrumentor; confirm LLM + TOOL spans normalise correctly
- [ ] Verify existing Vitest suite still passes (file-tail and replay paths untouched)
- [ ] Add unit tests for `otel-normalizer.ts` against canned span fixtures (follow-up)

---
_Generated by [Claude Code](https://claude.ai/code/session_014ybVR9w3c7WMYTJhKMLWQ3)_