### PR TITLE
Harden transcript privacy gates

### DIFF
--- a/docs/domain-events.md
+++ b/docs/domain-events.md
@@ -67,7 +67,8 @@ A bounded event queue in the Electron main process with a hot in-memory window (
 capacity: 2000 events), spill-to-disk persistence, per-consumer checkpoints, and
 backpressure signals. Supports `push`, `getRecent(n)`, `getAll`, `subscribe(callback)`,
 `getSince(eventId)`, `registerConsumer`, `readPending`, and `commitCheckpoint` for
-catch-up. Both the renderer and the inference trigger consume from this queue.
+catch-up. Both the renderer and the inference trigger consume from this queue. Spill files
+are sanitized unless raw transcript storage has been explicitly enabled.
 
 ## IPC Bridge
 
@@ -78,7 +79,8 @@ Two patterns connect main process to renderer:
 
 **Pull (renderer → main):** On startup or reconnect, the renderer requests a full
 snapshot via `ipcMain.handle('shadow:snapshot')` or incremental catch-up via
-`ipcMain.handle('shadow:events-since', eventId)`.
+`ipcMain.handle('shadow:events-since', eventId)`. Both routes sanitize transcript-like
+payloads before sending data to the renderer.
 
 Canvas redraws are governed by requestAnimationFrame (max 60fps, natural throttle).
 

--- a/docs/domain-inference.md
+++ b/docs/domain-inference.md
@@ -53,6 +53,30 @@ Providers supported: anthropic, openai, openrouter, google, deepseek.
 - POSIX: if a temporary legacy `.env` is used for migration, keep it at `0600` and remove it after verification
 - Windows: keep secrets under the user's profile so inherited ACLs remain per-user; avoid shared directories
 
+Concrete checks:
+
+```bash
+stat -c '%a %n' ~/.shadow-agent ~/.shadow-agent/credentials.enc.json
+chmod 700 ~/.shadow-agent
+chmod 600 ~/.shadow-agent/credentials.enc.json
+```
+
+```powershell
+$storeDir = Join-Path $HOME '.shadow-agent'
+$storeFile = Join-Path $storeDir 'credentials.enc.json'
+$userSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+icacls $storeDir
+icacls $storeFile
+icacls $storeDir /inheritance:r
+icacls $storeDir /grant:r "*${userSid}:(OI)(CI)(F)" "*S-1-5-18:(OI)(CI)(F)" "*S-1-5-32-544:(OI)(CI)(F)"
+icacls $storeFile /inheritance:r
+icacls $storeFile /grant:r "*${userSid}:F" "*S-1-5-18:F" "*S-1-5-32-544:F"
+```
+
+Do not run with `SHADOW_ALLOW_FILE_CREDENTIAL_FALLBACK=1` as a steady-state setting.
+Use it for an intentional migration run only, then unset it and remove the temporary
+plaintext file after confirming the encrypted store loads.
+
 ## Prompt Strategy
 
 The system prompt defines Shadow as a passive observer that produces structured JSON:

--- a/docs/domain-inference.md
+++ b/docs/domain-inference.md
@@ -29,7 +29,8 @@ Inference delivery is local-only by default. Before any prompt is sent off-host,
 must explicitly opt in. Sanitized transcript content is the default payload, and raw
 transcript delivery requires a separate explicit opt-in. The Electron shell persists those
 privacy toggles in `~/.shadow-agent/privacy.json`; environment variables still override the
-saved file when present.
+saved file when present. In local-only mode, the inference engine does not load provider
+credentials or create remote clients.
 
 ## Auth Chain
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,6 +78,32 @@ Permission guidance:
 - Windows: leave the store inside your user profile so standard per-user ACLs protect it
 - Do not place credential files in shared folders, synced team drives, or repo working trees
 
+To check and repair POSIX permissions:
+
+```bash
+stat -c '%a %n' ~/.shadow-agent ~/.shadow-agent/credentials.enc.json
+chmod 700 ~/.shadow-agent
+chmod 600 ~/.shadow-agent/credentials.enc.json
+```
+
+To inspect Windows ACLs, keep access scoped to the current user, Administrators, and
+SYSTEM. If broad grants appear, reset the ACLs to those principals:
+
+```powershell
+$storeDir = Join-Path $HOME '.shadow-agent'
+$storeFile = Join-Path $storeDir 'credentials.enc.json'
+$userSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+icacls $storeDir
+icacls $storeFile
+icacls $storeDir /inheritance:r
+icacls $storeDir /grant:r "*${userSid}:(OI)(CI)(F)" "*S-1-5-18:(OI)(CI)(F)" "*S-1-5-32-544:(OI)(CI)(F)"
+icacls $storeFile /inheritance:r
+icacls $storeFile /grant:r "*${userSid}:F" "*S-1-5-18:F" "*S-1-5-32-544:F"
+```
+
+Treat `SHADOW_ALLOW_FILE_CREDENTIAL_FALLBACK=1` as a one-run migration consent, not a
+normal developer setting.
+
 ## Privacy Controls
 
 Shadow-agent starts in local-only mode. The Electron app's Privacy panel lets you explicitly opt in to:

--- a/shadow-agent/src/capture/event-buffer.ts
+++ b/shadow-agent/src/capture/event-buffer.ts
@@ -203,6 +203,7 @@ export function createEventBuffer(capacityOrOptions: number | EventBufferOptions
   let pendingWrites = 0;
   let operationChain: Promise<void> = Promise.resolve();
   let lastBackpressureLevel: EventQueueBackpressureLevel = 'normal';
+  let hydratedFromDisk = false;
 
   const sessionDir = () => path.join(persistenceRoot, encodeSessionId(sessionId));
   const spillPath = () => path.join(sessionDir(), SPILL_FILE);
@@ -287,10 +288,33 @@ export function createEventBuffer(capacityOrOptions: number | EventBufferOptions
     await writeCheckpointFile(checkpointPath(), checkpoints);
   };
 
+  const hydrateFromDisk = async () => {
+    if (hydratedFromDisk) {
+      return;
+    }
+
+    const spilled = await readSpillFile(spillPath());
+    if (spilled.length > 0) {
+      updateOffsets(spilled);
+      nextOffset = Math.max(nextOffset, (newestOffset ?? -1) + 1);
+    }
+
+    if (checkpoints.size === 0) {
+      const persisted = await readCheckpointFile(checkpointPath());
+      for (const [id, checkpoint] of persisted.entries()) {
+        checkpoints.set(id, checkpoint);
+      }
+    }
+
+    hydratedFromDisk = true;
+  };
+
   const ensureCheckpoint = async (
     consumerId: string,
     options?: { startAt?: 'latest' | 'earliest' }
   ): Promise<EventQueueCheckpoint> => {
+    await hydrateFromDisk();
+
     if (checkpoints.has(consumerId)) {
       return checkpoints.get(consumerId)!;
     }
@@ -299,18 +323,6 @@ export function createEventBuffer(capacityOrOptions: number | EventBufferOptions
       startAt: options?.startAt ?? consumerDefaults.get(consumerId)?.startAt ?? 'latest'
     } as const;
     consumerDefaults.set(consumerId, defaults);
-
-    // Lazy-load persisted checkpoints if this session already has them.
-    if (checkpoints.size === 0) {
-      const persisted = await readCheckpointFile(checkpointPath());
-      for (const [id, checkpoint] of persisted.entries()) {
-        checkpoints.set(id, checkpoint);
-      }
-      const restored = checkpoints.get(consumerId);
-      if (restored) {
-        return restored;
-      }
-    }
 
     const initialOffset =
       defaults.startAt === 'earliest'
@@ -328,7 +340,9 @@ export function createEventBuffer(capacityOrOptions: number | EventBufferOptions
   };
 
   const loadAllEnvelopes = async (): Promise<EventEnvelope[]> => {
-    const spilled = spilledDepth > 0 ? await readSpillFile(spillPath()) : [];
+    await hydrateFromDisk();
+    const spilled = await readSpillFile(spillPath());
+    updateOffsets(spilled);
     return [...spilled, ...memory];
   };
 
@@ -351,7 +365,6 @@ export function createEventBuffer(capacityOrOptions: number | EventBufferOptions
   return {
     async setSession(nextSessionId: string) {
       await enqueueMutation(async () => {
-        const previousDir = sessionDir();
         sessionId = nextSessionId;
         memory.length = 0;
         nextOffset = 0;
@@ -359,6 +372,7 @@ export function createEventBuffer(capacityOrOptions: number | EventBufferOptions
         oldestOffset = null;
         newestOffset = null;
         lastBackpressureLevel = 'normal';
+        hydratedFromDisk = false;
 
         const resetCheckpoints = new Map<string, EventQueueCheckpoint>();
         for (const consumerId of consumerDefaults.keys()) {
@@ -369,13 +383,16 @@ export function createEventBuffer(capacityOrOptions: number | EventBufferOptions
           });
         }
         checkpoints.clear();
-        for (const [consumerId, checkpoint] of resetCheckpoints.entries()) {
-          checkpoints.set(consumerId, checkpoint);
-        }
 
-        await rm(previousDir, { recursive: true, force: true });
-        await rm(sessionDir(), { recursive: true, force: true });
-        await persistCheckpoints();
+        await hydrateFromDisk();
+        for (const [consumerId, checkpoint] of resetCheckpoints.entries()) {
+          if (!checkpoints.has(consumerId)) {
+            checkpoints.set(consumerId, checkpoint);
+          }
+        }
+        if (resetCheckpoints.size > 0) {
+          await persistCheckpoints();
+        }
         logger.info('capture', 'buffer.session_set', { sessionId: nextSessionId });
       });
     },
@@ -393,6 +410,8 @@ export function createEventBuffer(capacityOrOptions: number | EventBufferOptions
       }
 
       return enqueueMutation(async () => {
+        await hydrateFromDisk();
+
         const acceptedEnvelopes = events.map((event) => ({
           offset: nextOffset++,
           event
@@ -400,7 +419,7 @@ export function createEventBuffer(capacityOrOptions: number | EventBufferOptions
         memory.push(...acceptedEnvelopes);
 
         const overflow = Math.max(0, memory.length - memoryCapacity);
-        let spilled = overflow > 0 ? await readSpillFile(spillPath()) : [];
+        let spilled = spilledDepth > 0 ? await readSpillFile(spillPath()) : [];
         let spilledCount = 0;
         let droppedCount = 0;
 

--- a/shadow-agent/src/capture/ipc-bridge.ts
+++ b/shadow-agent/src/capture/ipc-bridge.ts
@@ -91,7 +91,7 @@ export function createIpcBridge(opts: IpcBridgeOptions): IpcBridge {
       ipcMain.removeHandler('shadow:events-since');
       ipcMain.handle('shadow:events-since', async (_event, eventId: string) => {
         logger.debug('ipc', 'events_since_requested', { eventId });
-        return await buffer.getSince(eventId);
+        return prepareEventsForStorage(await buffer.getSince(eventId), getPrivacy());
       });
 
       return () => {

--- a/shadow-agent/src/inference/shadow-inference-engine.ts
+++ b/shadow-agent/src/inference/shadow-inference-engine.ts
@@ -145,8 +145,6 @@ export function createInferenceEngine(opts: InferenceEngineOptions): InferenceEn
 
   return {
     async start() {
-      await loadCredentials();
-
       if (!privacy.allowOffHostInference) {
         logger.info('inference', 'engine.local_only_mode', {
           message: 'Off-host inference is disabled until the user explicitly opts in.'
@@ -154,6 +152,7 @@ export function createInferenceEngine(opts: InferenceEngineOptions): InferenceEn
         return;
       }
 
+      await loadCredentials();
       client = opts.client ?? await createInferenceClient();
 
       if (!client) {

--- a/shadow-agent/src/shared/derive.ts
+++ b/shadow-agent/src/shared/derive.ts
@@ -197,6 +197,7 @@ function buildInsights(title: string, phase: string, riskSignals: string[], next
 
 export function deriveState(events: CanonicalEvent[], title = 'Observed session'): DerivedState {
   const sessionId = events[0]?.sessionId ?? 'unknown';
+  const sanitizedTitle = sanitizeTranscriptText(title);
   const phase = detectPhase(events);
   const riskSignals = collectRiskSignals(events);
   const nextMoves = buildNextMoves(phase, riskSignals);
@@ -205,7 +206,7 @@ export function deriveState(events: CanonicalEvent[], title = 'Observed session'
   const transcript: DerivedState['transcript'] = [];
   const timeline: DerivedState['timeline'] = [];
   const fileAttention = new Map<string, number>();
-  let currentObjective = title;
+  let currentObjective = sanitizedTitle;
 
   for (const event of events) {
     timeline.push({
@@ -224,7 +225,7 @@ export function deriveState(events: CanonicalEvent[], title = 'Observed session'
         timestamp: event.timestamp,
         redacted: sanitizedText !== event.payload.text
       });
-      if (event.actor === 'user' && currentObjective === title) {
+      if (event.actor === 'user' && currentObjective === sanitizedTitle) {
         currentObjective = sanitizedText;
       }
     }
@@ -260,14 +261,15 @@ export function deriveState(events: CanonicalEvent[], title = 'Observed session'
 
       const filePath = extractFilePath(event, getCapabilitiesForEvent(event));
       if (filePath) {
-        fileAttention.set(filePath, (fileAttention.get(filePath) ?? 0) + 1);
+        const sanitizedFilePath = sanitizeTranscriptText(filePath);
+        fileAttention.set(sanitizedFilePath, (fileAttention.get(sanitizedFilePath) ?? 0) + 1);
       }
     }
   }
 
   return {
     sessionId,
-    title,
+    title: sanitizedTitle,
     currentObjective,
     activePhase: phase,
     agentNodes: [...agentMap.values()],

--- a/shadow-agent/src/shared/renderer-input-adapter.ts
+++ b/shadow-agent/src/shared/renderer-input-adapter.ts
@@ -2,7 +2,8 @@ import { deriveState } from './derive';
 import {
   DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS,
   prepareEventsForStorage,
-  resolvePrivacyPolicy
+  resolvePrivacyPolicy,
+  sanitizeTranscriptText
 } from './privacy';
 import { buildSessionRecord } from './replay-store';
 import type {
@@ -58,15 +59,21 @@ export function inferRendererInputTitle(
 export const canonicalEventRendererInputAdapter: RendererInputAdapter<CanonicalEvent[]> = {
   id: 'canonical-event-renderer-input',
   build(events, options) {
-    const title = inferRendererInputTitle(events, options.fallbackTitle ?? options.source.label);
-    const record = buildSessionRecord(events, title);
     const privacySettings = options.privacySettings ?? DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS;
+    const sanitizedEvents = prepareEventsForStorage(events, privacySettings);
+    const title = sanitizeTranscriptText(inferRendererInputTitle(sanitizedEvents, options.fallbackTitle ?? options.source.label));
+    const record = buildSessionRecord(sanitizedEvents, title);
+    const source = {
+      ...options.source,
+      label: sanitizeTranscriptText(options.source.label),
+      path: options.source.path ? sanitizeTranscriptText(options.source.path) : undefined
+    };
 
     return {
-      source: options.source,
+      source,
       record,
-      state: deriveState(events, record.title),
-      events: prepareEventsForStorage(events, privacySettings),
+      state: deriveState(sanitizedEvents, record.title),
+      events: sanitizedEvents,
       privacy: resolvePrivacyPolicy(privacySettings)
     };
   }

--- a/shadow-agent/tests/capture/capture.test.ts
+++ b/shadow-agent/tests/capture/capture.test.ts
@@ -477,6 +477,62 @@ describe('createEventBuffer', () => {
     expect(buf.getMetrics().consumers[0]?.lag).toBe(3);
   });
 
+  it('hydrates spilled events when a queue is recreated for the same session', async () => {
+    const root = makeTempRoot();
+    const first = createEventBuffer({
+      memoryCapacity: 1,
+      totalCapacity: 5,
+      persistenceRoot: root,
+      sessionId: 'persisted-session'
+    });
+    await first.push([makeEvent('a'), makeEvent('b')]);
+
+    const restored = createEventBuffer({
+      memoryCapacity: 1,
+      totalCapacity: 5,
+      persistenceRoot: root,
+      sessionId: 'persisted-session'
+    });
+
+    expect((await restored.getAll()).map((event) => event.id)).toEqual(['a']);
+    expect(restored.getMetrics()).toMatchObject({
+      memoryDepth: 0,
+      spilledDepth: 1,
+      totalDepth: 1,
+      oldestOffset: 0,
+      newestOffset: 0
+    });
+  });
+
+  it('restores persisted consumer checkpoints when a queue is recreated', async () => {
+    const root = makeTempRoot();
+    const first = createEventBuffer({
+      memoryCapacity: 1,
+      totalCapacity: 5,
+      persistenceRoot: root,
+      sessionId: 'checkpoint-session'
+    });
+    await first.push([makeEvent('a'), makeEvent('b')]);
+    await first.registerConsumer('inference', { startAt: 'earliest' });
+    await first.commitCheckpoint('inference', 'a');
+
+    const restored = createEventBuffer({
+      memoryCapacity: 1,
+      totalCapacity: 5,
+      persistenceRoot: root,
+      sessionId: 'checkpoint-session'
+    });
+    await restored.registerConsumer('inference', { startAt: 'earliest' });
+
+    expect((await restored.readPending('inference')).events).toHaveLength(0);
+    expect(restored.getMetrics().consumers[0]).toMatchObject({
+      consumerId: 'inference',
+      lastOffset: 0,
+      lastEventId: 'a',
+      lag: 0
+    });
+  });
+
   it('reports high backpressure as the queue fills', async () => {
     const buf = createEventBuffer({
       memoryCapacity: 2,
@@ -606,8 +662,14 @@ describe('createIpcBridge', () => {
     expect(result).toBe(expected);
   });
 
-  it('shadow:events-since handler delegates to buffer.getSince and returns its result', async () => {
-    const events = [makeCanonicalEvent('a'), makeCanonicalEvent('b')];
+  it('shadow:events-since handler delegates to buffer.getSince and returns sanitized events', async () => {
+    const events = [
+      {
+        ...makeCanonicalEvent('a'),
+        payload: { text: 'Contact dev@example.com using sk-abcdefghijklmnop' }
+      },
+      makeCanonicalEvent('b')
+    ];
     const buffer = makeMockBuffer({
       getSince: vi.fn().mockResolvedValue(events),
     });
@@ -619,7 +681,13 @@ describe('createIpcBridge', () => {
     const result = await handler({} /* _event */, 'evt-a');
 
     expect(buffer.getSince).toHaveBeenCalledWith('evt-a');
-    expect(result).toEqual(events);
+    expect(result).toEqual([
+      {
+        ...events[0],
+        payload: { text: 'Contact [redacted-email] using [redacted-token]' }
+      },
+      events[1]
+    ]);
   });
 
   it('cleanup removes both IPC handlers from ipcMain', () => {

--- a/shadow-agent/tests/inference/local-only-privacy.test.ts
+++ b/shadow-agent/tests/inference/local-only-privacy.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { CanonicalEvent, DerivedState } from '../../src/shared/schema';
+import type { EventBufferLike } from '../../src/inference/inference-client';
+
+const { loadCredentialsMock, createInferenceClientMock } = vi.hoisted(() => ({
+  loadCredentialsMock: vi.fn(async () => undefined),
+  createInferenceClientMock: vi.fn(async () => null)
+}));
+
+vi.mock('../../src/inference/auth', () => ({
+  loadCredentials: loadCredentialsMock
+}));
+
+vi.mock('../../src/inference/inference-client-factory', () => ({
+  createInferenceClient: createInferenceClientMock
+}));
+
+function derivedState(): DerivedState {
+  return {
+    sessionId: 'local-only-session',
+    title: 'Local only',
+    currentObjective: 'Observe locally',
+    activePhase: 'observation',
+    agentNodes: [],
+    timeline: [],
+    transcript: [],
+    fileAttention: [],
+    riskSignals: [],
+    nextMoves: [],
+    shadowInsights: []
+  };
+}
+
+class FakeEventBuffer implements EventBufferLike {
+  private readonly events: CanonicalEvent[] = [];
+
+  async getAll(): Promise<CanonicalEvent[]> {
+    return this.events;
+  }
+
+  async getRecent(): Promise<CanonicalEvent[]> {
+    return this.events;
+  }
+
+  subscribe(): () => void {
+    return () => undefined;
+  }
+
+  get size(): number {
+    return this.events.length;
+  }
+}
+
+describe('createInferenceEngine local-only privacy gate', () => {
+  it('does not load credentials or create remote clients when off-host inference is disabled', async () => {
+    const { createInferenceEngine } = await import('../../src/inference/shadow-inference-engine');
+    const engine = createInferenceEngine({
+      buffer: new FakeEventBuffer(),
+      getState: derivedState,
+      onInsights: vi.fn(),
+      privacy: {
+        allowOffHostInference: false,
+        allowRawTranscriptStorage: false
+      }
+    });
+
+    await engine.start();
+
+    expect(loadCredentialsMock).not.toHaveBeenCalled();
+    expect(createInferenceClientMock).not.toHaveBeenCalled();
+    engine.stop();
+  });
+});

--- a/shadow-agent/tests/renderer/renderer-input-adapter.test.ts
+++ b/shadow-agent/tests/renderer/renderer-input-adapter.test.ts
@@ -38,23 +38,28 @@ describe('canonicalEventRendererInputAdapter', () => {
   it('builds renderer input with derived state and default privacy policy', () => {
     const snapshot = buildRendererInput(
       [
-        event({ kind: 'session_started', payload: { label: 'Session Label' } }),
+        event({ kind: 'session_started', payload: { label: 'Session Label for dev@example.com' } }),
         event({
           id: 'evt-2',
           kind: 'message',
           actor: 'user',
           payload: { text: 'Ship capture pipeline for dev@example.com from D:\\_projects\\AgentVisualCrazy' }
         }),
-        event({ id: 'evt-3', kind: 'tool_started', payload: { toolName: 'Read', file_path: 'src/main.ts' } })
+        event({
+          id: 'evt-3',
+          kind: 'tool_started',
+          payload: { toolName: 'Read', file_path: 'D:\\_projects\\AgentVisualCrazy\\src\\main.ts' }
+        })
       ],
       {
-        source: { kind: 'replay', label: 'custom-replay' }
+        source: { kind: 'replay', label: 'custom-replay', path: 'D:\\_projects\\AgentVisualCrazy\\session.jsonl' }
       }
     );
 
-    expect(snapshot.record.title).toBe('Session Label');
+    expect(snapshot.record.title).toBe('Session Label for [redacted-email]');
     expect(snapshot.state.currentObjective).toBe('Ship capture pipeline for [redacted-email] from [redacted-path]');
-    expect(snapshot.state.fileAttention).toEqual([{ filePath: 'src/main.ts', touches: 1 }]);
+    expect(snapshot.state.fileAttention).toEqual([{ filePath: '[redacted-path]', touches: 1 }]);
+    expect(snapshot.source.path).toBe('[redacted-path]');
     expect(snapshot.events[1]?.payload).toEqual({
       text: 'Ship capture pipeline for [redacted-email] from [redacted-path]'
     });
@@ -65,4 +70,5 @@ describe('canonicalEventRendererInputAdapter', () => {
       transcriptHandling: 'sanitized-by-default'
     });
   });
+
 });


### PR DESCRIPTION
## Summary
- keep off-host inference fully local-only until consent, including skipping credential loading before opt-in
- sanitize renderer snapshots, IPC catch-up events, transcript-derived titles, paths, and file attention
- hydrate sanitized spill/checkpoint data safely across queue restarts

## Verification
- npm run prompts:check
- npm test --prefix shadow-agent