### PR TITLE
[codex] enforce transcript privacy gates

### DIFF
--- a/shadow-agent/src/inference/shadow-inference-engine.ts
+++ b/shadow-agent/src/inference/shadow-inference-engine.ts
@@ -145,8 +145,6 @@ export function createInferenceEngine(opts: InferenceEngineOptions): InferenceEn
 
   return {
     async start() {
-      await loadCredentials();
-
       if (!privacy.allowOffHostInference) {
         logger.info('inference', 'engine.local_only_mode', {
           message: 'Off-host inference is disabled until the user explicitly opts in.'
@@ -154,6 +152,7 @@ export function createInferenceEngine(opts: InferenceEngineOptions): InferenceEn
         return;
       }
 
+      await loadCredentials();
       client = opts.client ?? await createInferenceClient();
 
       if (!client) {

--- a/shadow-agent/src/shared/renderer-input-adapter.ts
+++ b/shadow-agent/src/shared/renderer-input-adapter.ts
@@ -2,7 +2,8 @@ import { deriveState } from './derive';
 import {
   DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS,
   prepareEventsForStorage,
-  resolvePrivacyPolicy
+  resolvePrivacyPolicy,
+  sanitizeTranscriptText
 } from './privacy';
 import { buildSessionRecord } from './replay-store';
 import type {
@@ -58,15 +59,22 @@ export function inferRendererInputTitle(
 export const canonicalEventRendererInputAdapter: RendererInputAdapter<CanonicalEvent[]> = {
   id: 'canonical-event-renderer-input',
   build(events, options) {
-    const title = inferRendererInputTitle(events, options.fallbackTitle ?? options.source.label);
-    const record = buildSessionRecord(events, title);
     const privacySettings = options.privacySettings ?? DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS;
+    const sanitizedEvents = prepareEventsForStorage(events, privacySettings);
+    const source = {
+      ...options.source,
+      label: sanitizeTranscriptText(options.source.label),
+      path: options.source.path ? sanitizeTranscriptText(options.source.path) : undefined
+    };
+    const fallbackTitle = sanitizeTranscriptText(options.fallbackTitle ?? source.label);
+    const title = inferRendererInputTitle(sanitizedEvents, fallbackTitle);
+    const record = buildSessionRecord(sanitizedEvents, title);
 
     return {
-      source: options.source,
+      source,
       record,
-      state: deriveState(events, record.title),
-      events: prepareEventsForStorage(events, privacySettings),
+      state: deriveState(sanitizedEvents, record.title),
+      events: sanitizedEvents,
       privacy: resolvePrivacyPolicy(privacySettings)
     };
   }

--- a/shadow-agent/tests/inference/privacy-startup.test.ts
+++ b/shadow-agent/tests/inference/privacy-startup.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { CanonicalEvent, DerivedState } from '../../src/shared/schema';
+import type { EventBufferLike } from '../../src/inference/inference-client';
+
+const loadCredentialsMock = vi.hoisted(() => vi.fn().mockResolvedValue({}));
+
+vi.mock('../../src/inference/auth', () => ({
+  loadCredentials: loadCredentialsMock
+}));
+
+vi.mock('../../src/inference/inference-client-factory', () => ({
+  createInferenceClient: vi.fn().mockResolvedValue(null)
+}));
+
+import { createInferenceEngine } from '../../src/inference/shadow-inference-engine';
+
+class EmptyEventBuffer implements EventBufferLike {
+  async getAll(): Promise<CanonicalEvent[]> {
+    return [];
+  }
+
+  async getRecent(): Promise<CanonicalEvent[]> {
+    return [];
+  }
+
+  get size(): number {
+    return 0;
+  }
+
+  subscribe(): () => void {
+    return () => {};
+  }
+}
+
+function state(): DerivedState {
+  return {
+    sessionId: 'privacy-session',
+    title: 'Privacy',
+    currentObjective: 'Protect local transcripts',
+    activePhase: 'observation',
+    agentNodes: [],
+    timeline: [],
+    transcript: [],
+    fileAttention: [],
+    riskSignals: [],
+    nextMoves: [],
+    shadowInsights: []
+  };
+}
+
+describe('inference startup privacy gates', () => {
+  it('does not load provider credentials while local-only processing is active', async () => {
+    const engine = createInferenceEngine({
+      buffer: new EmptyEventBuffer(),
+      getState: state,
+      onInsights: vi.fn(),
+      privacy: {
+        allowOffHostInference: false,
+        allowRawTranscriptStorage: false
+      }
+    });
+
+    await engine.start();
+
+    expect(loadCredentialsMock).not.toHaveBeenCalled();
+    engine.stop();
+  });
+});

--- a/shadow-agent/tests/renderer/renderer-input-adapter.test.ts
+++ b/shadow-agent/tests/renderer/renderer-input-adapter.test.ts
@@ -65,4 +65,34 @@ describe('canonicalEventRendererInputAdapter', () => {
       transcriptHandling: 'sanitized-by-default'
     });
   });
+
+  it('sanitizes derived renderer titles and file attention before display', () => {
+    const snapshot = buildRendererInput(
+      [
+        event({
+          kind: 'message',
+          actor: 'user',
+          payload: { text: 'Audit dev@example.com under D:\\_projects\\AgentVisualCrazy\\secret.txt' }
+        }),
+        event({
+          id: 'evt-2',
+          kind: 'tool_started',
+          payload: {
+            toolName: 'Read',
+            file_path: 'D:\\_projects\\AgentVisualCrazy\\secret.txt'
+          }
+        })
+      ],
+      {
+        source: { kind: 'transcript', label: 'live-transcript' }
+      }
+    );
+
+    expect(snapshot.record.title).toBe('Audit [redacted-email] under [redacted-path]');
+    expect(snapshot.state.title).toBe('Audit [redacted-email] under [redacted-path]');
+    expect(snapshot.state.fileAttention).toEqual([{ filePath: '[redacted-path]', touches: 1 }]);
+    expect(snapshot.events[0]?.payload).toEqual({
+      text: 'Audit [redacted-email] under [redacted-path]'
+    });
+  });
 });


### PR DESCRIPTION
## **User description**
## Summary

- sanitize renderer-facing events before title, record, and derived-state assembly
- keep renderer file attention and transcript-derived titles redacted by default
- keep inference startup local-only by avoiding credential loading until off-host inference is explicitly enabled

## Validation

- `npx vitest run tests/renderer/renderer-input-adapter.test.ts tests/inference/privacy-startup.test.ts`
- `npm test`
- pre-push `npm test`


___

## **CodeAnt-AI Description**
**Keep transcript titles and file details redacted in the UI, and avoid loading inference credentials in local-only mode**

### What Changed
- Transcript-derived titles, source labels, and file attention now stay redacted before they are shown or saved
- Rendered events and session details use the sanitized text so user-facing titles no longer expose emails or local file paths
- Inference startup now skips provider credential loading when off-host inference is turned off
- Added tests to cover redacted renderer titles and the local-only startup path

### Impact
`✅ Fewer transcript leaks in session headers`
`✅ Safer display of file paths and email addresses`
`✅ Local-only mode starts without external credential access`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
