### PR TITLE
feat: persist bounded event queue checkpoints

### DIFF
--- a/docs/domain-events.md
+++ b/docs/domain-events.md
@@ -107,7 +107,7 @@ src/capture/
   transcript-watcher.ts    — FileSystemWatcher on JSONL file
   incremental-parser.ts    — Chunk → parsed JSON objects
   normalizer.ts            — Raw transcript entry → CanonicalEvent
-  event-buffer.ts          — Ring buffer with subscriptions
+  event-buffer.ts          — Bounded event queue with spill, metrics, and checkpoints
   ipc-bridge.ts            — Main↔renderer IPC
   session-manager.ts       — Orchestrator: discover → watch → parse → normalize → buffer
 ```

--- a/docs/plans/plan-event-capture.md
+++ b/docs/plans/plan-event-capture.md
@@ -26,7 +26,7 @@ All new files live under `shadow-agent/src/capture/`:
 | `src/capture/transcript-watcher.ts` | FileSystemWatcher on a single JSONL file, emits new lines |
 | `src/capture/incremental-parser.ts` | Parse new JSONL lines into raw objects, handle partial lines |
 | `src/capture/normalizer.ts` | Transform raw Claude Code transcript entries → `CanonicalEvent` |
-| `src/capture/event-buffer.ts` | In-memory ring buffer of recent events, supports subscriptions |
+| `src/capture/event-buffer.ts` | Bounded event queue with hot memory window, spill-to-disk, metrics, backpressure, subscriptions, and consumer checkpoints |
 | `src/capture/ipc-bridge.ts` | Bridge between main-process event buffer and renderer via IPC |
 | `src/capture/session-manager.ts` | Orchestrator: discover → watch → parse → normalize → buffer → IPC |
 
@@ -110,16 +110,21 @@ Each normalized event gets:
 
 ## 6. Event Buffer
 
-`event-buffer.ts` is an in-memory ring buffer holding the last N events (default: 2000).
+`event-buffer.ts` is a bounded queue with a hot in-memory window (default: 2000)
+and spill-to-disk persistence for older events.
 
 Features:
-- `push(event)` — add new event, evict oldest if at capacity
-- `getRecent(n)` — return last N events
-- `getAll()` — return all events in order
-- `subscribe(callback)` — register a listener called on every new event
-- `getSince(eventId)` — return all events after a given ID (for catch-up)
+- `push(events)` — add events, spill older entries to disk, and report enqueue/backpressure metrics
+- `getRecent(n)` — return the last N events across memory and spill storage
+- `getAll()` — return all retained events in order
+- `subscribe(callback)` — register a listener called on every new event batch with queue metrics
+- `getSince(eventId)` — return all retained events after a given ID for catch-up
+- `registerConsumer(consumerId)` / `readPending()` / `commitCheckpoint()` — let renderer and inference consumers drain independently
+- `getMetrics()` / `getBackpressure()` — expose queue depth, consumer lag, pending writes, and throttle state
 
-The buffer is the central data structure that both the renderer and the inference engine consume from. It lives in the Electron main process.
+The buffer is the central data structure that both the renderer and the inference
+engine consume from. It lives in the Electron main process, and capture
+transports consult its backpressure state before delivering chunks.
 
 ---
 

--- a/docs/plans/plan-testing-observability.md
+++ b/docs/plans/plan-testing-observability.md
@@ -157,7 +157,7 @@ rotation, duplicate events, session switching.
 Required automated coverage:
 - `incremental-parser.ts` unit tests for partial lines and malformed JSON
 - `normalizer.ts` contract tests against known Claude transcript fragments
-- `event-buffer.ts` unit tests for ring behavior, ordering, and subscriptions
+- `event-buffer.ts` unit tests for bounded queue behavior, spill ordering, metrics, backpressure, checkpoints, and subscriptions
 - `session-discovery.ts` tests using temp directories and synthetic file mtimes
 - `transcript-watcher.ts` integration tests with a temp JSONL file that is appended to in
   chunks

--- a/shadow-agent/src/capture/event-buffer.ts
+++ b/shadow-agent/src/capture/event-buffer.ts
@@ -203,6 +203,7 @@ export function createEventBuffer(capacityOrOptions: number | EventBufferOptions
   let pendingWrites = 0;
   let operationChain: Promise<void> = Promise.resolve();
   let lastBackpressureLevel: EventQueueBackpressureLevel = 'normal';
+  let hydratedFromDisk = false;
 
   const sessionDir = () => path.join(persistenceRoot, encodeSessionId(sessionId));
   const spillPath = () => path.join(sessionDir(), SPILL_FILE);
@@ -287,10 +288,33 @@ export function createEventBuffer(capacityOrOptions: number | EventBufferOptions
     await writeCheckpointFile(checkpointPath(), checkpoints);
   };
 
+  const hydrateFromDisk = async () => {
+    if (hydratedFromDisk) {
+      return;
+    }
+
+    const spilled = await readSpillFile(spillPath());
+    if (spilled.length > 0) {
+      updateOffsets(spilled);
+      nextOffset = Math.max(nextOffset, (newestOffset ?? -1) + 1);
+    }
+
+    if (checkpoints.size === 0) {
+      const persisted = await readCheckpointFile(checkpointPath());
+      for (const [id, checkpoint] of persisted.entries()) {
+        checkpoints.set(id, checkpoint);
+      }
+    }
+
+    hydratedFromDisk = true;
+  };
+
   const ensureCheckpoint = async (
     consumerId: string,
     options?: { startAt?: 'latest' | 'earliest' }
   ): Promise<EventQueueCheckpoint> => {
+    await hydrateFromDisk();
+
     if (checkpoints.has(consumerId)) {
       return checkpoints.get(consumerId)!;
     }
@@ -299,18 +323,6 @@ export function createEventBuffer(capacityOrOptions: number | EventBufferOptions
       startAt: options?.startAt ?? consumerDefaults.get(consumerId)?.startAt ?? 'latest'
     } as const;
     consumerDefaults.set(consumerId, defaults);
-
-    // Lazy-load persisted checkpoints if this session already has them.
-    if (checkpoints.size === 0) {
-      const persisted = await readCheckpointFile(checkpointPath());
-      for (const [id, checkpoint] of persisted.entries()) {
-        checkpoints.set(id, checkpoint);
-      }
-      const restored = checkpoints.get(consumerId);
-      if (restored) {
-        return restored;
-      }
-    }
 
     const initialOffset =
       defaults.startAt === 'earliest'
@@ -328,7 +340,9 @@ export function createEventBuffer(capacityOrOptions: number | EventBufferOptions
   };
 
   const loadAllEnvelopes = async (): Promise<EventEnvelope[]> => {
-    const spilled = spilledDepth > 0 ? await readSpillFile(spillPath()) : [];
+    await hydrateFromDisk();
+    const spilled = await readSpillFile(spillPath());
+    updateOffsets(spilled);
     return [...spilled, ...memory];
   };
 
@@ -351,7 +365,6 @@ export function createEventBuffer(capacityOrOptions: number | EventBufferOptions
   return {
     async setSession(nextSessionId: string) {
       await enqueueMutation(async () => {
-        const previousDir = sessionDir();
         sessionId = nextSessionId;
         memory.length = 0;
         nextOffset = 0;
@@ -359,6 +372,7 @@ export function createEventBuffer(capacityOrOptions: number | EventBufferOptions
         oldestOffset = null;
         newestOffset = null;
         lastBackpressureLevel = 'normal';
+        hydratedFromDisk = false;
 
         const resetCheckpoints = new Map<string, EventQueueCheckpoint>();
         for (const consumerId of consumerDefaults.keys()) {
@@ -369,13 +383,16 @@ export function createEventBuffer(capacityOrOptions: number | EventBufferOptions
           });
         }
         checkpoints.clear();
-        for (const [consumerId, checkpoint] of resetCheckpoints.entries()) {
-          checkpoints.set(consumerId, checkpoint);
-        }
 
-        await rm(previousDir, { recursive: true, force: true });
-        await rm(sessionDir(), { recursive: true, force: true });
-        await persistCheckpoints();
+        await hydrateFromDisk();
+        for (const [consumerId, checkpoint] of resetCheckpoints.entries()) {
+          if (!checkpoints.has(consumerId)) {
+            checkpoints.set(consumerId, checkpoint);
+          }
+        }
+        if (resetCheckpoints.size > 0) {
+          await persistCheckpoints();
+        }
         logger.info('capture', 'buffer.session_set', { sessionId: nextSessionId });
       });
     },
@@ -393,6 +410,8 @@ export function createEventBuffer(capacityOrOptions: number | EventBufferOptions
       }
 
       return enqueueMutation(async () => {
+        await hydrateFromDisk();
+
         const acceptedEnvelopes = events.map((event) => ({
           offset: nextOffset++,
           event
@@ -400,7 +419,7 @@ export function createEventBuffer(capacityOrOptions: number | EventBufferOptions
         memory.push(...acceptedEnvelopes);
 
         const overflow = Math.max(0, memory.length - memoryCapacity);
-        let spilled = overflow > 0 ? await readSpillFile(spillPath()) : [];
+        let spilled = spilledDepth > 0 ? await readSpillFile(spillPath()) : [];
         let spilledCount = 0;
         let droppedCount = 0;
 

--- a/shadow-agent/src/capture/http-stream-transport.ts
+++ b/shadow-agent/src/capture/http-stream-transport.ts
@@ -6,6 +6,7 @@ import type {
   CaptureTransportSubscription,
   HttpStreamCaptureTransportOptions
 } from './capture-transport';
+import { waitForBackpressureRelief } from './transcript-watcher';
 
 const logger = createLogger({ minLevel: 'info' });
 const DEFAULT_RECONNECT_DELAY_MS = 1_000;
@@ -88,11 +89,13 @@ export function createHttpStreamCaptureTransport(
               if (done) {
                 const trailing = decoder.decode();
                 if (trailing) {
+                  await waitForBackpressureRelief(context.getBackpressure());
                   await context.onChunk({ session, chunk: trailing });
                 }
                 break;
               }
               if (value && value.byteLength > 0) {
+                await waitForBackpressureRelief(context.getBackpressure());
                 await context.onChunk({
                   session,
                   chunk: decoder.decode(value, { stream: true })

--- a/shadow-agent/src/capture/ipc-bridge.ts
+++ b/shadow-agent/src/capture/ipc-bridge.ts
@@ -91,7 +91,7 @@ export function createIpcBridge(opts: IpcBridgeOptions): IpcBridge {
       ipcMain.removeHandler('shadow:events-since');
       ipcMain.handle('shadow:events-since', async (_event, eventId: string) => {
         logger.debug('ipc', 'events_since_requested', { eventId });
-        return await buffer.getSince(eventId);
+        return prepareEventsForStorage(await buffer.getSince(eventId), getPrivacy());
       });
 
       return () => {

--- a/shadow-agent/src/capture/socket-transport.ts
+++ b/shadow-agent/src/capture/socket-transport.ts
@@ -7,7 +7,7 @@ import type {
   CaptureTransportSubscription,
   SocketCaptureTransportOptions
 } from './capture-transport';
-import { computeWatchDelay } from './transcript-watcher';
+import { computeWatchDelay, waitForBackpressureRelief } from './transcript-watcher';
 
 const logger = createLogger({ minLevel: 'info' });
 const DEFAULT_RECONNECT_DELAY_MS = 1_000;
@@ -92,6 +92,7 @@ export function createSocketCaptureTransport(
                   nextSocket.resume();
                 }
               }, computeWatchDelay(50, backpressure));
+              await waitForBackpressureRelief(backpressure, 50);
             }
             await context.onChunk({ session, chunk });
           })();

--- a/shadow-agent/src/capture/transcript-watcher.ts
+++ b/shadow-agent/src/capture/transcript-watcher.ts
@@ -61,6 +61,22 @@ export function computeWatchDelay(
   return baseDelayMs;
 }
 
+export async function waitForBackpressureRelief(
+  backpressure: EventQueueBackpressureState | undefined,
+  baseDelayMs = 0
+): Promise<void> {
+  if (!backpressure?.shouldThrottle) {
+    return;
+  }
+
+  const delayMs = computeWatchDelay(baseDelayMs, backpressure);
+  if (delayMs <= 0) {
+    return;
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
 function buildSession(discovered: DiscoveredSession): CaptureSession {
   return {
     sessionId: discovered.sessionId,

--- a/shadow-agent/src/capture/websocket-transport.ts
+++ b/shadow-agent/src/capture/websocket-transport.ts
@@ -6,6 +6,7 @@ import type {
   CaptureTransportSubscription,
   WebSocketCaptureTransportOptions
 } from './capture-transport';
+import { waitForBackpressureRelief } from './transcript-watcher';
 
 const logger = createLogger({ minLevel: 'info' });
 const DEFAULT_RECONNECT_DELAY_MS = 1_000;
@@ -104,6 +105,7 @@ export function createWebSocketCaptureTransport(
           void (async () => {
             const chunk = await readMessageData(event.data);
             if (chunk) {
+              await waitForBackpressureRelief(context.getBackpressure());
               await context.onChunk({ session, chunk });
             }
           })();

--- a/shadow-agent/tests/capture/capture-transports.test.ts
+++ b/shadow-agent/tests/capture/capture-transports.test.ts
@@ -192,6 +192,30 @@ describe('capture transports', () => {
     await waitFor(() => resets.includes('reconnect') && chunks.join('').includes('{"step":2}\n'));
   });
 
+  it('http-stream transport checks queue backpressure before delivering chunks', async () => {
+    const server = http.createServer((_, response) => {
+      response.writeHead(200, { 'Content-Type': 'application/x-ndjson' });
+      response.end('{"step":1}\n');
+    });
+    const port = await listenHttp(server);
+
+    const { context, chunks } = createContext();
+    const getBackpressure = vi.fn(context.getBackpressure);
+    context.getBackpressure = getBackpressure;
+
+    const subscription = await createHttpStreamCaptureTransport({
+      kind: 'http-stream',
+      url: `http://127.0.0.1:${port}/stream`,
+      reconnectDelayMs: 25,
+      sessionId: 'http-backpressure-test'
+    }).start(context);
+    subscriptions.push(subscription);
+
+    await waitFor(() => chunks.join('').includes('{"step":1}\n'));
+
+    expect(getBackpressure).toHaveBeenCalled();
+  });
+
   it('websocket transport normalizes framed messages and reconnects after close', async () => {
     class MockWebSocket {
       static CONNECTING = 0;
@@ -253,6 +277,76 @@ describe('capture transports', () => {
     MockWebSocket.instances[1]?.emitOpen();
 
     await waitFor(() => resets.includes('reconnect'));
+  });
+
+  it('websocket transport delays message delivery while queue backpressure is critical', async () => {
+    vi.useFakeTimers();
+
+    class MockWebSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static instances: MockWebSocket[] = [];
+
+      readyState = MockWebSocket.CONNECTING;
+      onopen: ((event: Event) => void) | null = null;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onclose: ((event: CloseEvent) => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+
+      constructor(
+        public readonly url: string,
+        public readonly protocols?: string | string[]
+      ) {
+        MockWebSocket.instances.push(this);
+      }
+
+      emitOpen() {
+        this.readyState = MockWebSocket.OPEN;
+        this.onopen?.({} as Event);
+      }
+
+      emitMessage(data: unknown) {
+        this.onmessage?.({ data } as MessageEvent);
+      }
+
+      close() {
+        this.onclose?.({} as CloseEvent);
+      }
+    }
+
+    globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+
+    const { context, chunks } = createContext();
+    context.getBackpressure = () => ({
+      level: 'critical',
+      shouldThrottle: true,
+      totalRatio: 1,
+      pendingWrites: 4
+    });
+
+    const subscription = await createWebSocketCaptureTransport({
+      kind: 'websocket',
+      url: 'ws://localhost:4098/shadow',
+      reconnectDelayMs: 25,
+      sessionId: 'ws-backpressure-test'
+    }).start(context);
+    subscriptions.push(subscription);
+
+    try {
+      MockWebSocket.instances[0]?.emitOpen();
+      MockWebSocket.instances[0]?.emitMessage('{"frame":1}');
+      await Promise.resolve();
+
+      expect(chunks).toEqual([]);
+
+      await vi.advanceTimersByTimeAsync(499);
+      expect(chunks).toEqual([]);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(chunks).toEqual(['{"frame":1}\n']);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('socket transport reconnects after disconnects and keeps streaming chunks', async () => {

--- a/shadow-agent/tests/capture/capture.test.ts
+++ b/shadow-agent/tests/capture/capture.test.ts
@@ -477,6 +477,62 @@ describe('createEventBuffer', () => {
     expect(buf.getMetrics().consumers[0]?.lag).toBe(3);
   });
 
+  it('hydrates spilled events when a queue is recreated for the same session', async () => {
+    const root = makeTempRoot();
+    const first = createEventBuffer({
+      memoryCapacity: 1,
+      totalCapacity: 5,
+      persistenceRoot: root,
+      sessionId: 'persisted-session'
+    });
+    await first.push([makeEvent('a'), makeEvent('b')]);
+
+    const restored = createEventBuffer({
+      memoryCapacity: 1,
+      totalCapacity: 5,
+      persistenceRoot: root,
+      sessionId: 'persisted-session'
+    });
+
+    expect((await restored.getAll()).map((event) => event.id)).toEqual(['a']);
+    expect(restored.getMetrics()).toMatchObject({
+      memoryDepth: 0,
+      spilledDepth: 1,
+      totalDepth: 1,
+      oldestOffset: 0,
+      newestOffset: 0
+    });
+  });
+
+  it('restores persisted consumer checkpoints when a queue is recreated', async () => {
+    const root = makeTempRoot();
+    const first = createEventBuffer({
+      memoryCapacity: 1,
+      totalCapacity: 5,
+      persistenceRoot: root,
+      sessionId: 'checkpoint-session'
+    });
+    await first.push([makeEvent('a'), makeEvent('b')]);
+    await first.registerConsumer('inference', { startAt: 'earliest' });
+    await first.commitCheckpoint('inference', 'a');
+
+    const restored = createEventBuffer({
+      memoryCapacity: 1,
+      totalCapacity: 5,
+      persistenceRoot: root,
+      sessionId: 'checkpoint-session'
+    });
+    await restored.registerConsumer('inference', { startAt: 'earliest' });
+
+    expect((await restored.readPending('inference')).events).toHaveLength(0);
+    expect(restored.getMetrics().consumers[0]).toMatchObject({
+      consumerId: 'inference',
+      lastOffset: 0,
+      lastEventId: 'a',
+      lag: 0
+    });
+  });
+
   it('reports high backpressure as the queue fills', async () => {
     const buf = createEventBuffer({
       memoryCapacity: 2,
@@ -606,8 +662,14 @@ describe('createIpcBridge', () => {
     expect(result).toBe(expected);
   });
 
-  it('shadow:events-since handler delegates to buffer.getSince and returns its result', async () => {
-    const events = [makeCanonicalEvent('a'), makeCanonicalEvent('b')];
+  it('shadow:events-since handler delegates to buffer.getSince and returns sanitized events', async () => {
+    const events = [
+      {
+        ...makeCanonicalEvent('a'),
+        payload: { text: 'Contact dev@example.com using sk-abcdefghijklmnop' }
+      },
+      makeCanonicalEvent('b')
+    ];
     const buffer = makeMockBuffer({
       getSince: vi.fn().mockResolvedValue(events),
     });
@@ -619,7 +681,13 @@ describe('createIpcBridge', () => {
     const result = await handler({} /* _event */, 'evt-a');
 
     expect(buffer.getSince).toHaveBeenCalledWith('evt-a');
-    expect(result).toEqual(events);
+    expect(result).toEqual([
+      {
+        ...events[0],
+        payload: { text: 'Contact [redacted-email] using [redacted-token]' }
+      },
+      events[1]
+    ]);
   });
 
   it('cleanup removes both IPC handlers from ipcMain', () => {


### PR DESCRIPTION
## **User description**
## Summary
- hydrate spilled queue events and checkpoint metadata from disk when a bounded event queue is recreated
- preserve session spill/checkpoint storage across setSession while keeping consumer defaults intact
- propagate queue backpressure into streaming capture adapters and document the queue/checkpoint behavior
- sanitize pull-based IPC event catch-up responses to match pushed batches

## Tests
- npm test

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


___

## **CodeAnt-AI Description**
**Keep event queues and consumer progress after a session is recreated, and slow down live capture when the queue is full**

### What Changed
- Recreated queues now restore spilled events and saved consumer checkpoints for the same session instead of starting over
- When a session is switched, saved progress is kept for known consumers so they can continue from the right point
- HTTP, socket, and WebSocket capture sources now pause briefly when queue pressure is high, reducing dropped or bursty event delivery
- Pull-based event catch-up responses are now sanitized before being returned, hiding sensitive text such as emails and tokens

### Impact
`✅ Fewer lost events after session restarts`
`✅ Less reprocessing for queued consumers`
`✅ Fewer capture bursts during queue pressure`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
