### PR TITLE
feat(capture): allow transport source attribution

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,6 +70,8 @@ budget.
 Event capture is now transport-pluggable. The default path still watches Claude Code JSONL
 files via a filesystem tailer, but the runtime can also ingest streaming HTTP, WebSocket,
 and raw socket feeds through the same parser → normalizer → queue → IPC pipeline.
+Each transport can carry an explicit `EventSource` via `SHADOW_CAPTURE_SOURCE` or the
+programmatic transport options, so transport choice and harness attribution stay separate.
 
 The file-tail path remains the simplest zero-config option for Claude transcripts, and it
 now adds checksum-based rotation detection so replaced transcript files replay cleanly even

--- a/docs/domain-events.md
+++ b/docs/domain-events.md
@@ -99,6 +99,12 @@ come from, and the live runtime now supports multiple capture transports:
 Each transport feeds the same incremental parser and normalizer pipeline so the downstream
 event buffer, IPC bridge, renderer, and inference consumers stay unchanged.
 
+Transport options include an optional `source` field, and the Electron startup path maps
+`SHADOW_CAPTURE_SOURCE` into that field. Defaults preserve the current Claude behavior
+(`claude-transcript` for file-tail and `claude-hook` for network transports), while future
+harness drivers can stamp values such as `codex-transcript`, `cursor-hook`, or
+`opencode-event-stream` without forking the byte-delivery adapters.
+
 ## File Map
 
 ```

--- a/shadow-agent/src/capture/capture-transport.ts
+++ b/shadow-agent/src/capture/capture-transport.ts
@@ -38,6 +38,7 @@ export interface FileTailCaptureTransportOptions {
   overridePath?: string;
   discoveryIntervalMs?: number;
   fingerprintBytes?: number;
+  source?: EventSource;
 }
 
 export interface HttpStreamCaptureTransportOptions {
@@ -47,6 +48,7 @@ export interface HttpStreamCaptureTransportOptions {
   reconnectDelayMs?: number;
   sessionId?: string;
   sessionLabel?: string;
+  source?: EventSource;
 }
 
 export interface WebSocketCaptureTransportOptions {
@@ -56,6 +58,7 @@ export interface WebSocketCaptureTransportOptions {
   reconnectDelayMs?: number;
   sessionId?: string;
   sessionLabel?: string;
+  source?: EventSource;
 }
 
 export interface SocketCaptureTransportOptions {
@@ -65,6 +68,7 @@ export interface SocketCaptureTransportOptions {
   reconnectDelayMs?: number;
   sessionId?: string;
   sessionLabel?: string;
+  source?: EventSource;
 }
 
 export type CaptureTransportOptions =

--- a/shadow-agent/src/capture/capture-transports.ts
+++ b/shadow-agent/src/capture/capture-transports.ts
@@ -17,6 +17,11 @@ function parseReconnectDelayMs(raw: string | undefined): number | undefined {
   return parsed;
 }
 
+function parseSource(raw: string | undefined): string | undefined {
+  const source = raw?.trim();
+  return source || undefined;
+}
+
 function requiredEnv(value: string | undefined, variableName: string): string {
   if (value && value.trim()) {
     return value.trim();
@@ -41,7 +46,8 @@ export function resolveCaptureTransportOptionsFromEnv(
     case 'file-tail':
       return {
         kind: 'file-tail',
-        overridePath: env.SHADOW_CAPTURE_FILE?.trim() || undefined
+        overridePath: env.SHADOW_CAPTURE_FILE?.trim() || undefined,
+        source: parseSource(env.SHADOW_CAPTURE_SOURCE)
       };
     case 'http':
     case 'http-stream':
@@ -53,7 +59,8 @@ export function resolveCaptureTransportOptionsFromEnv(
         ),
         reconnectDelayMs: parseReconnectDelayMs(env.SHADOW_CAPTURE_RECONNECT_MS),
         sessionId: env.SHADOW_CAPTURE_SESSION_ID?.trim() || undefined,
-        sessionLabel: env.SHADOW_CAPTURE_SESSION_LABEL?.trim() || undefined
+        sessionLabel: env.SHADOW_CAPTURE_SESSION_LABEL?.trim() || undefined,
+        source: parseSource(env.SHADOW_CAPTURE_SOURCE)
       } satisfies HttpStreamCaptureTransportOptions;
     case 'ws':
     case 'websocket':
@@ -65,7 +72,8 @@ export function resolveCaptureTransportOptionsFromEnv(
         ),
         reconnectDelayMs: parseReconnectDelayMs(env.SHADOW_CAPTURE_RECONNECT_MS),
         sessionId: env.SHADOW_CAPTURE_SESSION_ID?.trim() || undefined,
-        sessionLabel: env.SHADOW_CAPTURE_SESSION_LABEL?.trim() || undefined
+        sessionLabel: env.SHADOW_CAPTURE_SESSION_LABEL?.trim() || undefined,
+        source: parseSource(env.SHADOW_CAPTURE_SOURCE)
       } satisfies WebSocketCaptureTransportOptions;
     case 'socket':
       return {
@@ -74,7 +82,8 @@ export function resolveCaptureTransportOptionsFromEnv(
         port: parsePort(env.SHADOW_CAPTURE_SOCKET_PORT),
         reconnectDelayMs: parseReconnectDelayMs(env.SHADOW_CAPTURE_RECONNECT_MS),
         sessionId: env.SHADOW_CAPTURE_SESSION_ID?.trim() || undefined,
-        sessionLabel: env.SHADOW_CAPTURE_SESSION_LABEL?.trim() || undefined
+        sessionLabel: env.SHADOW_CAPTURE_SESSION_LABEL?.trim() || undefined,
+        source: parseSource(env.SHADOW_CAPTURE_SOURCE)
       } satisfies SocketCaptureTransportOptions;
     default:
       throw new Error(`Unsupported SHADOW_CAPTURE_TRANSPORT: ${kind}`);

--- a/shadow-agent/src/capture/http-stream-transport.ts
+++ b/shadow-agent/src/capture/http-stream-transport.ts
@@ -15,7 +15,7 @@ function buildSession(options: HttpStreamCaptureTransportOptions): CaptureSessio
   return {
     sessionId: options.sessionId ?? `http-stream-${url.host}`,
     label: options.sessionLabel ?? `Live HTTP: ${url.host}`,
-    source: 'claude-hook',
+    source: options.source ?? 'claude-hook',
     path: options.url,
     transportId: 'http-stream'
   };

--- a/shadow-agent/src/capture/socket-transport.ts
+++ b/shadow-agent/src/capture/socket-transport.ts
@@ -16,7 +16,7 @@ function buildSession(options: SocketCaptureTransportOptions): CaptureSession {
   return {
     sessionId: options.sessionId ?? `socket-${options.host}:${options.port}`,
     label: options.sessionLabel ?? `Live Socket: ${options.host}:${options.port}`,
-    source: 'claude-hook',
+    source: options.source ?? 'claude-hook',
     path: `tcp://${options.host}:${options.port}`,
     transportId: 'socket'
   };

--- a/shadow-agent/src/capture/transcript-watcher.ts
+++ b/shadow-agent/src/capture/transcript-watcher.ts
@@ -61,11 +61,14 @@ export function computeWatchDelay(
   return baseDelayMs;
 }
 
-function buildSession(discovered: DiscoveredSession): CaptureSession {
+function buildSession(
+  discovered: DiscoveredSession,
+  overrideSource?: FileTailCaptureTransportOptions['source']
+): CaptureSession {
   return {
     sessionId: discovered.sessionId,
     label: `Live: ${discovered.sessionId.slice(0, 12)}`,
-    source: 'claude-transcript',
+    source: overrideSource ?? discovered.source,
     path: discovered.filePath,
     transportId: 'file-tail'
   };
@@ -275,7 +278,7 @@ export function createFileTailCaptureTransport(
       };
 
       const activateSession = async (discovered: DiscoveredSession) => {
-        const nextSession = buildSession(discovered);
+        const nextSession = buildSession(discovered, options.source);
         const isSameFile = activeSession?.path === nextSession.path;
         if (isSameFile) {
           return;

--- a/shadow-agent/src/capture/websocket-transport.ts
+++ b/shadow-agent/src/capture/websocket-transport.ts
@@ -15,7 +15,7 @@ function buildSession(options: WebSocketCaptureTransportOptions): CaptureSession
   return {
     sessionId: options.sessionId ?? `websocket-${url.host}`,
     label: options.sessionLabel ?? `Live WebSocket: ${url.host}`,
-    source: 'claude-hook',
+    source: options.source ?? 'claude-hook',
     path: options.url,
     transportId: 'websocket'
   };

--- a/shadow-agent/tests/capture/capture-transports.test.ts
+++ b/shadow-agent/tests/capture/capture-transports.test.ts
@@ -6,10 +6,12 @@ import path from 'node:path';
 import { tmpdir } from 'node:os';
 import type {
   CaptureSession,
+  CaptureTransportOptions,
   CaptureTransportContext,
   CaptureTransportResetReason,
   CaptureTransportSubscription
 } from '../../src/capture/capture-transport';
+import { createCaptureTransport, resolveCaptureTransportOptionsFromEnv } from '../../src/capture/capture-transports';
 import { createHttpStreamCaptureTransport } from '../../src/capture/http-stream-transport';
 import { createSocketCaptureTransport } from '../../src/capture/socket-transport';
 import { createFileTailCaptureTransport } from '../../src/capture/transcript-watcher';
@@ -165,6 +167,24 @@ describe('capture transports', () => {
     await waitFor(() => resets.includes('rotation') && chunks.join('').includes(rotatedLine));
   });
 
+  it('file-tail transport stamps a caller-supplied source on discovered sessions', async () => {
+    const dir = await makeTempDir('shadow-file-tail-source-');
+    const filePath = path.join(dir, 'session-a.jsonl');
+    await writeFile(filePath, '{"message":{"role":"assistant","content":"hello"}}\n', 'utf8');
+
+    const { context, sessions } = createContext();
+    const subscription = await createFileTailCaptureTransport({
+      kind: 'file-tail',
+      overridePath: filePath,
+      source: 'codex-transcript',
+      discoveryIntervalMs: 5_000
+    }).start(context);
+    subscriptions.push(subscription);
+
+    await waitFor(() => sessions.length === 1);
+    expect(sessions[0]?.source).toBe('codex-transcript');
+  });
+
   it('http-stream transport reconnects and emits streamed chunks', async () => {
     let requestCount = 0;
     const server = http.createServer((_, response) => {
@@ -190,6 +210,26 @@ describe('capture transports', () => {
 
     await waitFor(() => sessions.length === 1 && chunks.join('').includes('{"step":1}\n'));
     await waitFor(() => resets.includes('reconnect') && chunks.join('').includes('{"step":2}\n'));
+  });
+
+  it('http-stream transport stamps a caller-supplied source', async () => {
+    const server = http.createServer((_, response) => {
+      response.writeHead(200, { 'Content-Type': 'application/x-ndjson' });
+      response.end('{"step":1}\n');
+    });
+    const port = await listenHttp(server);
+
+    const { context, sessions } = createContext();
+    const subscription = await createHttpStreamCaptureTransport({
+      kind: 'http-stream',
+      url: `http://127.0.0.1:${port}/stream`,
+      source: 'opencode-event-stream',
+      sessionId: 'http-custom-source'
+    }).start(context);
+    subscriptions.push(subscription);
+
+    await waitFor(() => sessions.length === 1);
+    expect(sessions[0]?.source).toBe('opencode-event-stream');
   });
 
   it('websocket transport normalizes framed messages and reconnects after close', async () => {
@@ -255,6 +295,48 @@ describe('capture transports', () => {
     await waitFor(() => resets.includes('reconnect'));
   });
 
+  it('websocket transport stamps a caller-supplied source', async () => {
+    class MockWebSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static instances: MockWebSocket[] = [];
+
+      readyState = MockWebSocket.CONNECTING;
+      onopen: ((event: Event) => void) | null = null;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      onclose: ((event: CloseEvent) => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+
+      constructor(public readonly url: string) {
+        MockWebSocket.instances.push(this);
+      }
+
+      emitOpen() {
+        this.readyState = MockWebSocket.OPEN;
+        this.onopen?.({} as Event);
+      }
+
+      close() {
+        this.onclose?.({} as CloseEvent);
+      }
+    }
+
+    globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+
+    const { context, sessions } = createContext();
+    const subscription = await createWebSocketCaptureTransport({
+      kind: 'websocket',
+      url: 'ws://localhost:4098/shadow',
+      source: 'mcp-json-rpc',
+      sessionId: 'ws-custom-source'
+    }).start(context);
+    subscriptions.push(subscription);
+
+    MockWebSocket.instances[0]?.emitOpen();
+    await waitFor(() => sessions.length === 1);
+    expect(sessions[0]?.source).toBe('mcp-json-rpc');
+  });
+
   it('socket transport reconnects after disconnects and keeps streaming chunks', async () => {
     let connectionCount = 0;
     const server = net.createServer((socket) => {
@@ -276,5 +358,43 @@ describe('capture transports', () => {
 
     await waitFor(() => sessions.length === 1 && chunks.join('').includes('{"connection":1}\n'));
     await waitFor(() => resets.includes('reconnect') && chunks.join('').includes('{"connection":2}\n'));
+  });
+
+  it('socket transport stamps a caller-supplied source', async () => {
+    const server = net.createServer((socket) => {
+      socket.write('{"connection":1}\n');
+      socket.end();
+    });
+    const port = await listenSocket(server);
+
+    const { context, sessions } = createContext();
+    const subscription = await createSocketCaptureTransport({
+      kind: 'socket',
+      host: '127.0.0.1',
+      port,
+      source: 'cursor-hook',
+      sessionId: 'tcp-custom-source'
+    }).start(context);
+    subscriptions.push(subscription);
+
+    await waitFor(() => sessions.length === 1);
+    expect(sessions[0]?.source).toBe('cursor-hook');
+  });
+
+  it('resolves custom capture source from env for pluggable transport options', () => {
+    const options = resolveCaptureTransportOptionsFromEnv({
+      SHADOW_CAPTURE_TRANSPORT: 'socket',
+      SHADOW_CAPTURE_SOCKET_HOST: '127.0.0.1',
+      SHADOW_CAPTURE_SOCKET_PORT: '4876',
+      SHADOW_CAPTURE_SOURCE: 'cursor-hook'
+    } as NodeJS.ProcessEnv);
+
+    expect(options).toMatchObject<CaptureTransportOptions>({
+      kind: 'socket',
+      host: '127.0.0.1',
+      port: 4876,
+      source: 'cursor-hook'
+    });
+    expect(createCaptureTransport(options).kind).toBe('socket');
   });
 });


### PR DESCRIPTION
## **User description**
## Summary
- Adds optional source attribution to all capture transport options.
- Threads `SHADOW_CAPTURE_SOURCE` through env resolution so file-tail, HTTP stream, WebSocket, and TCP socket transports can stamp non-Claude EventSource values.
- Documents the source/transport separation and covers custom source behavior in capture transport tests.

## Validation
- `npm test --prefix shadow-agent` (410 tests passed)
- `npm run build --prefix shadow-agent`
- `git diff --check`
- Pre-push hook reran `shadow-agent` tests successfully


___

## **CodeAnt-AI Description**
**Let capture transports record a custom source**

### What Changed
- Capture sessions can now keep a caller-provided source instead of always using the built-in Claude source
- File tail, HTTP stream, WebSocket, and socket captures all accept the source from environment settings or direct transport options
- If no source is provided, existing defaults stay the same for Claude-based captures
- Tests now cover custom source values for each transport and env-based setup

### Impact
`✅ Clearer event attribution`
`✅ Easier use with non-Claude capture tools`
`✅ Fewer mismatched source labels in captured sessions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
