### PR TITLE
refactor: decouple renderer live host from Electron

### DIFF
--- a/shadow-agent/README.md
+++ b/shadow-agent/README.md
@@ -51,6 +51,35 @@ runs that hook installer — run it once at the repo root.
 
 `npm run build:web` emits the reusable renderer bundle in `dist-web/`.
 
+## Renderer Library Contract
+
+The reusable renderer is the default product surface. It accepts a plain browser host contract and
+does not read Electron preload globals:
+
+```ts
+import {
+  renderShadowAgent,
+  registerShadowAgentElement,
+  type ShadowAgentHost
+} from './dist-web/shadow-agent-renderer.js';
+
+const host: ShadowAgentHost = {
+  loadInitialSnapshot: async () => snapshot,
+  loadLiveSnapshot: async () => liveSnapshotOrNull,
+  subscribeLiveEvents: (callback) => {
+    const unsubscribe = eventBus.subscribe(callback);
+    return unsubscribe;
+  }
+};
+
+renderShadowAgent(document.querySelector('#root')!, host);
+registerShadowAgentElement();
+```
+
+Electron lives in `src/electron/` as an optional host shell. Its renderer entry creates an
+Electron-backed `ShadowAgentHost` from the preload bridge, while web embeds can provide their own
+host object or assign one to the custom element's `host` property.
+
 After `npm run build`, launch the Electron shell with:
 
 ```bash

--- a/shadow-agent/src/electron/renderer-host.ts
+++ b/shadow-agent/src/electron/renderer-host.ts
@@ -1,5 +1,5 @@
 import type { ShadowAgentBridge } from '../shared/schema';
-import { createBridgeHost, type ShadowAgentHost } from '../renderer/host';
+import type { ShadowAgentHost } from '../renderer/host';
 
 export function getShadowAgentBridge(target: Window = window): ShadowAgentBridge {
   if (!target.shadowAgent) {
@@ -10,5 +10,16 @@ export function getShadowAgentBridge(target: Window = window): ShadowAgentBridge
 }
 
 export function createElectronHost(bridge: ShadowAgentBridge = getShadowAgentBridge()): ShadowAgentHost {
-  return createBridgeHost(bridge);
+  return {
+    loadInitialSnapshot: () => bridge.bootstrap(),
+    loadLiveSnapshot: () => bridge.getLiveSnapshot(),
+    subscribeLiveEvents: (callback) => bridge.onLiveEvents(callback),
+    openReplayFile: () => bridge.openReplayFile(),
+    getPrivacyPolicy: () => bridge.getPrivacyPolicy(),
+    updatePrivacySettings: (updates) => bridge.updatePrivacySettings(updates),
+    exportReplayJsonl: (events, suggestedFileName, options) =>
+      options === undefined
+        ? bridge.exportReplayJsonl(events, suggestedFileName)
+        : bridge.exportReplayJsonl(events, suggestedFileName, options)
+  };
 }

--- a/shadow-agent/src/renderer/App.tsx
+++ b/shadow-agent/src/renderer/App.tsx
@@ -4,7 +4,6 @@ import type {
   CanonicalEvent,
   DerivedState,
   PrivacyPolicy,
-  ShadowAgentBridge,
   SnapshotPayload,
   TimelineItem,
   TranscriptPrivacySettings
@@ -16,19 +15,6 @@ import { getRendererSurfaceAdapter } from './renderer-surface-adapter';
 import { formatClock, safeFileName, toLabel } from './view-model';
 
 const LIVE_REFRESH_DEBOUNCE_MS = 300;
-
-function getLiveBridge(): Pick<ShadowAgentBridge, 'onLiveEvents' | 'getLiveSnapshot'> | null {
-  if (typeof window === 'undefined' || !window.shadowAgent) {
-    return null;
-  }
-
-  const { onLiveEvents, getLiveSnapshot } = window.shadowAgent;
-  if (typeof onLiveEvents !== 'function' || typeof getLiveSnapshot !== 'function') {
-    return null;
-  }
-
-  return { onLiveEvents, getLiveSnapshot };
-}
 
 function Panel({
   title,
@@ -210,11 +196,9 @@ export default function App({ host }: ShadowAgentAppProps) {
   }, [snapshot]);
 
   const loadPreferredSnapshot = async (): Promise<SnapshotPayload> => {
-    const liveBridge = getLiveBridge();
-
-    if (liveBridge) {
+    if (host.loadLiveSnapshot) {
       try {
-        const liveSnapshot = await liveBridge.getLiveSnapshot();
+        const liveSnapshot = await host.loadLiveSnapshot();
         if (liveSnapshot) {
           return liveSnapshot;
         }
@@ -261,8 +245,7 @@ export default function App({ host }: ShadowAgentAppProps) {
   }, [host]);
 
   useEffect(() => {
-    const liveBridge = getLiveBridge();
-    if (!liveBridge) {
+    if (!host.subscribeLiveEvents || !host.loadLiveSnapshot) {
       return;
     }
 
@@ -271,7 +254,7 @@ export default function App({ host }: ShadowAgentAppProps) {
 
     const refreshLiveSnapshot = async () => {
       try {
-        const liveSnapshot = await liveBridge.getLiveSnapshot();
+        const liveSnapshot = await host.loadLiveSnapshot?.();
         if (!active || !liveSnapshot || currentSourceKindRef.current === 'replay') {
           return;
         }
@@ -282,7 +265,7 @@ export default function App({ host }: ShadowAgentAppProps) {
       }
     };
 
-    const unsubscribe = liveBridge.onLiveEvents((events: CanonicalEvent[]) => {
+    const unsubscribe = host.subscribeLiveEvents((events: CanonicalEvent[]) => {
       if (events.length === 0) {
         return;
       }
@@ -305,7 +288,7 @@ export default function App({ host }: ShadowAgentAppProps) {
         clearTimeout(debounceTimer);
       }
     };
-  }, []);
+  }, [host]);
 
   // Pulse on snapshot loads (replay, fixture, or initial boot).
   useEffect(() => {

--- a/shadow-agent/src/renderer/host.ts
+++ b/shadow-agent/src/renderer/host.ts
@@ -2,13 +2,17 @@ import type {
   CanonicalEvent,
   ExportResult,
   PrivacyPolicy,
-  ShadowAgentBridge,
   SnapshotPayload,
   TranscriptPrivacySettings
 } from '../shared/schema';
 
+export type LiveEventSubscriber = (events: CanonicalEvent[]) => void;
+export type UnsubscribeLiveEvents = () => void;
+
 export interface ShadowAgentHost {
   loadInitialSnapshot(): Promise<SnapshotPayload>;
+  loadLiveSnapshot?: () => Promise<SnapshotPayload | null>;
+  subscribeLiveEvents?: (callback: LiveEventSubscriber) => UnsubscribeLiveEvents;
   openReplayFile?: () => Promise<SnapshotPayload | null>;
   getPrivacyPolicy?: () => Promise<PrivacyPolicy>;
   updatePrivacySettings?: (updates: Partial<TranscriptPrivacySettings>) => Promise<PrivacyPolicy>;
@@ -20,6 +24,8 @@ export interface ShadowAgentHost {
 }
 
 export interface ShadowAgentHostCapabilities {
+  canStreamLiveEvents: boolean;
+  canLoadLiveSnapshot: boolean;
   canOpenReplayFile: boolean;
   canManagePrivacy: boolean;
   canExportReplayJsonl: boolean;
@@ -27,6 +33,8 @@ export interface ShadowAgentHostCapabilities {
 
 export function getHostCapabilities(host: ShadowAgentHost): ShadowAgentHostCapabilities {
   return {
+    canStreamLiveEvents: typeof host.subscribeLiveEvents === 'function',
+    canLoadLiveSnapshot: typeof host.loadLiveSnapshot === 'function',
     canOpenReplayFile: typeof host.openReplayFile === 'function',
     canManagePrivacy:
       typeof host.getPrivacyPolicy === 'function' &&
@@ -38,15 +46,5 @@ export function getHostCapabilities(host: ShadowAgentHost): ShadowAgentHostCapab
 export function createStaticHost(snapshot: SnapshotPayload): ShadowAgentHost {
   return {
     loadInitialSnapshot: async () => snapshot
-  };
-}
-
-export function createBridgeHost(bridge: ShadowAgentBridge): ShadowAgentHost {
-  return {
-    loadInitialSnapshot: () => bridge.bootstrap(),
-    openReplayFile: bridge.openReplayFile,
-    getPrivacyPolicy: bridge.getPrivacyPolicy,
-    updatePrivacySettings: bridge.updatePrivacySettings,
-    exportReplayJsonl: bridge.exportReplayJsonl
   };
 }

--- a/shadow-agent/src/renderer/index.ts
+++ b/shadow-agent/src/renderer/index.ts
@@ -2,5 +2,12 @@ import './styles.css';
 
 export { default as ShadowAgentApp } from './App';
 export { registerShadowAgentElement, ShadowAgentViewerElement } from './custom-element';
-export { createBridgeHost, createStaticHost, getHostCapabilities, type ShadowAgentHost } from './host';
+export {
+  createStaticHost,
+  getHostCapabilities,
+  type LiveEventSubscriber,
+  type ShadowAgentHost,
+  type ShadowAgentHostCapabilities,
+  type UnsubscribeLiveEvents
+} from './host';
 export { renderShadowAgent } from './render';

--- a/shadow-agent/tests/electron/renderer-host.test.ts
+++ b/shadow-agent/tests/electron/renderer-host.test.ts
@@ -41,11 +41,12 @@ describe('electron renderer host', () => {
   });
 
   it('adapts the preload bridge into the platform-agnostic renderer host', async () => {
+    const unsubscribe = vi.fn();
     const bridge: ShadowAgentBridge = {
       bootstrap: vi.fn(async () => {
         throw new Error('not used');
       }),
-      onLiveEvents: vi.fn(() => vi.fn()),
+      onLiveEvents: vi.fn(() => unsubscribe),
       getLiveSnapshot: vi.fn(async () => null),
       openReplayFile: vi.fn(async () => null),
       getPrivacyPolicy: vi.fn(async () => makePrivacyPolicy()),
@@ -56,9 +57,14 @@ describe('electron renderer host', () => {
     const host = createElectronHost(bridge);
 
     expect(host.loadInitialSnapshot).not.toBe(bridge.bootstrap);
+    await host.loadLiveSnapshot?.();
+    const unsubscribeFromHost = host.subscribeLiveEvents?.(vi.fn());
     await host.openReplayFile?.();
     await host.exportReplayJsonl?.([], 'session.jsonl');
 
+    expect(bridge.getLiveSnapshot).toHaveBeenCalledTimes(1);
+    expect(bridge.onLiveEvents).toHaveBeenCalledTimes(1);
+    expect(unsubscribeFromHost).toBe(unsubscribe);
     expect(bridge.openReplayFile).toHaveBeenCalledTimes(1);
     expect(bridge.exportReplayJsonl).toHaveBeenCalledWith([], 'session.jsonl');
   });

--- a/shadow-agent/tests/renderer/app.integration.test.tsx
+++ b/shadow-agent/tests/renderer/app.integration.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
 
-import { render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createStaticHost, type ShadowAgentHost } from '../../src/renderer/host';
-import type { SnapshotPayload } from '../../src/shared/schema';
+import type { ShadowAgentBridge, SnapshotPayload } from '../../src/shared/schema';
 import App from '../../src/renderer/App';
 
 // Mock canvas/spring-heavy subcomponents to isolate App wiring tests
@@ -52,6 +52,11 @@ function makeSnapshot(overrides: Partial<SnapshotPayload> = {}): SnapshotPayload
 }
 
 describe('App integration', () => {
+  afterEach(() => {
+    cleanup();
+    Reflect.deleteProperty(window, 'shadowAgent');
+  });
+
   it('shows loading state on initial render', () => {
     const host: ShadowAgentHost = {
       loadInitialSnapshot: () => new Promise(() => {})
@@ -128,5 +133,67 @@ describe('App integration', () => {
     expect(screen.getByText('No timeline events yet.')).toBeInTheDocument();
     expect(screen.getByText('No transcript content is available yet.')).toBeInTheDocument();
     expect(screen.getByText('No file attention has been inferred yet.')).toBeInTheDocument();
+  });
+
+  it('prefers live snapshots supplied by the injected host', async () => {
+    const fixtureSnapshot = makeSnapshot({
+      record: { ...makeSnapshot().record, title: 'Fixture Snapshot' }
+    });
+    const liveSnapshot = makeSnapshot({
+      source: { kind: 'transcript', label: 'live-host' },
+      record: { ...makeSnapshot().record, title: 'Live Host Snapshot' },
+      state: {
+        ...makeSnapshot().state,
+        currentObjective: 'Live host objective'
+      }
+    });
+    const host: ShadowAgentHost = {
+      loadInitialSnapshot: vi.fn(async () => fixtureSnapshot),
+      loadLiveSnapshot: vi.fn(async () => liveSnapshot)
+    };
+
+    render(<App host={host} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Live Host Snapshot')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('LIVE')).toBeInTheDocument();
+    expect(screen.getByText('Live host objective')).toBeInTheDocument();
+    expect(host.loadInitialSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('does not read an ambient Electron bridge when a web host is supplied', async () => {
+    const hostSnapshot = makeSnapshot({
+      record: { ...makeSnapshot().record, title: 'Injected Web Host' }
+    });
+    const ambientSnapshot = makeSnapshot({
+      source: { kind: 'transcript', label: 'ambient-electron' },
+      record: { ...makeSnapshot().record, title: 'Ambient Electron Bridge' }
+    });
+    const bridge: ShadowAgentBridge = {
+      bootstrap: vi.fn(async () => ambientSnapshot),
+      onLiveEvents: vi.fn(() => vi.fn()),
+      getLiveSnapshot: vi.fn(async () => ambientSnapshot),
+      openReplayFile: vi.fn(async () => null),
+      getPrivacyPolicy: vi.fn(async () => ambientSnapshot.privacy),
+      updatePrivacySettings: vi.fn(async () => ambientSnapshot.privacy),
+      exportReplayJsonl: vi.fn(async () => ({ canceled: true }))
+    };
+
+    Object.defineProperty(window, 'shadowAgent', {
+      configurable: true,
+      value: bridge
+    });
+
+    render(<App host={createStaticHost(hostSnapshot)} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Injected Web Host')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Ambient Electron Bridge')).not.toBeInTheDocument();
+    expect(bridge.getLiveSnapshot).not.toHaveBeenCalled();
+    expect(bridge.onLiveEvents).not.toHaveBeenCalled();
   });
 });

--- a/shadow-agent/tests/renderer/host.test.ts
+++ b/shadow-agent/tests/renderer/host.test.ts
@@ -43,6 +43,27 @@ describe('renderer host helpers', () => {
 
     await expect(host.loadInitialSnapshot()).resolves.toBe(snapshot);
     expect(getHostCapabilities(host)).toEqual({
+      canStreamLiveEvents: false,
+      canLoadLiveSnapshot: false,
+      canOpenReplayFile: false,
+      canManagePrivacy: false,
+      canExportReplayJsonl: false
+    });
+  });
+
+  it('reports live capture hooks without requiring Electron file operations', async () => {
+    const snapshot = makeSnapshot();
+    const unsubscribe = () => {};
+    const host = {
+      loadInitialSnapshot: async () => snapshot,
+      loadLiveSnapshot: async () => snapshot,
+      subscribeLiveEvents: () => unsubscribe
+    };
+
+    await expect(host.loadLiveSnapshot()).resolves.toBe(snapshot);
+    expect(getHostCapabilities(host)).toEqual({
+      canStreamLiveEvents: true,
+      canLoadLiveSnapshot: true,
       canOpenReplayFile: false,
       canManagePrivacy: false,
       canExportReplayJsonl: false


### PR DESCRIPTION
## **User description**
## Summary

- Move live snapshot loading and live event subscriptions into the platform-agnostic `ShadowAgentHost` contract.
- Stop the renderer app from reading the ambient Electron preload bridge directly.
- Keep Electron as an adapter shell that maps the preload bridge into the renderer host contract.
- Document the web renderer/custom element host API in `shadow-agent/README.md`.

## Validation

- `npm exec vitest run tests/renderer/host.test.ts tests/renderer/app.integration.test.tsx tests/electron/renderer-host.test.ts`
- `npm test`
- `npm run build`
- `git push` pre-push hook reran `npm test --prefix shadow-agent`


___

## **CodeAnt-AI Description**
**Make the renderer work as a browser-first host library and use live updates without Electron**

### What Changed
- The renderer now loads live snapshots and subscribes to live events through the host object it is given, instead of reaching for Electron-specific globals.
- Web embeds can provide their own host with live capture support, and the app will use that live data when available.
- When a plain web host is supplied, the app no longer reads from an ambient Electron bridge in the page.
- The renderer package now documents the browser host contract so it can be embedded outside Electron.

### Impact
`✅ Web embeds without Electron`
`✅ Live updates in browser hosts`
`✅ Fewer accidental Electron-only dependencies`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
