### PR TITLE
feat(renderer): add quality-tiered WebGL particles

### DIFF
--- a/shadow-agent/src/renderer/canvas/CanvasRenderer.tsx
+++ b/shadow-agent/src/renderer/canvas/CanvasRenderer.tsx
@@ -15,6 +15,7 @@ import {
   createQualityController,
   getQualityProfile,
   sampleQualityController,
+  selectParticleRenderMode,
   type QualityChangeReason,
   type QualityControllerState,
   type QualityTier,
@@ -23,7 +24,6 @@ import {
 import {
   COLLIDE_RADIUS,
   STATE_COLORS,
-  type Particle,
   type RiskLevel,
   type SimulationEdge,
   type SimulationNode
@@ -38,6 +38,11 @@ import {
   drawShadowNode
 } from './draw-utils';
 import { tickCanvasPulses } from './canvas-pulse';
+import {
+  createWebglParticleRenderer,
+  type ParticleDrawMode,
+  type WebglParticleRenderer
+} from './webgl-particle-renderer';
 export { triggerCanvasPulse, clearCanvasPulses } from './canvas-pulse';
 export type { CanvasPulseKind } from './canvas-pulse';
 
@@ -119,12 +124,14 @@ export interface CanvasRendererProps {
 
 export default function CanvasRenderer({ agentNodes, riskLevel, latestInsight }: CanvasRendererProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const particleCanvasRef = useRef<HTMLCanvasElement>(null);
   const animationFrameRef = useRef<number>(0);
   const lastFrameRef = useRef<number | null>(null);
   const nodesRef = useRef<SimulationNode[]>([]);
   const edgesRef = useRef<SimulationEdge[]>([]);
   const edgesByIdRef = useRef<Map<string, SimulationEdge>>(new Map());
   const simulationRef = useRef<Simulation<SimulationNode, SimulationEdge> | null>(null);
+  const webglParticleRendererRef = useRef<WebglParticleRenderer | null>(null);
   const riskLevelRef = useRef<RiskLevel | undefined>(riskLevel);
   const latestInsightRef = useRef<ShadowInsight | undefined>(latestInsight);
   const qualityStateRef = useRef<QualityControllerState>(
@@ -144,10 +151,12 @@ export default function CanvasRenderer({ agentNodes, riskLevel, latestInsight }:
     tier: QualityTier;
     reason: QualityChangeReason;
     particleMode: 'worker' | 'inline';
+    particleDrawMode: ParticleDrawMode | 'disabled';
   }>({
     tier: qualityStateRef.current.tier,
     reason: qualityStateRef.current.lastChangeReason,
-    particleMode: particleEngineRef.current.mode
+    particleMode: particleEngineRef.current.mode,
+    particleDrawMode: 'canvas'
   });
 
   const collectMetrics = useCallback((particleCount: number): ResourceMetrics => {
@@ -183,7 +192,8 @@ export default function CanvasRenderer({ agentNodes, riskLevel, latestInsight }:
       setRuntimeHud({
         tier: nextState.tier,
         reason: nextState.lastChangeReason,
-        particleMode: particleEngineRef.current.mode
+        particleMode: particleEngineRef.current.mode,
+        particleDrawMode: webglParticleRendererRef.current?.mode ?? 'canvas'
       });
     }
   }, []);
@@ -236,7 +246,33 @@ export default function CanvasRenderer({ agentNodes, riskLevel, latestInsight }:
       }
     }
 
-    drawParticles(ctx, particleSnapshot, nodesById, edgesByIdRef.current, profile.tier);
+    const selectedParticleRenderMode = selectParticleRenderMode(profile.tier, webglParticleRendererRef.current !== null);
+    let particleDrawMode: ParticleDrawMode | 'disabled' = 'disabled';
+
+    if (selectedParticleRenderMode === 'webgl') {
+      const drewParticlesOnGpu = webglParticleRendererRef.current?.draw({
+        particles: particleSnapshot,
+        nodesById,
+        edgesById: edgesByIdRef.current,
+        qualityTier: profile.tier,
+        width: viewport.width,
+        height: viewport.height,
+        dpr: viewport.dpr
+      }) ?? false;
+
+      if (drewParticlesOnGpu) {
+        particleDrawMode = 'webgl';
+      } else {
+        drawParticles(ctx, particleSnapshot, nodesById, edgesByIdRef.current, profile.tier);
+        particleDrawMode = 'canvas';
+      }
+    } else if (selectedParticleRenderMode === 'canvas2d') {
+      webglParticleRendererRef.current?.clear();
+      drawParticles(ctx, particleSnapshot, nodesById, edgesByIdRef.current, profile.tier);
+      particleDrawMode = 'canvas';
+    } else {
+      webglParticleRendererRef.current?.clear();
+    }
 
     for (const node of nodesRef.current) {
       drawAgentNode(ctx, node, time, profile.tier);
@@ -261,6 +297,21 @@ export default function CanvasRenderer({ agentNodes, riskLevel, latestInsight }:
         );
       }
     }
+
+    setRuntimeHud((current) => {
+      const nextHud = {
+        tier: qualityStateRef.current.tier,
+        reason: qualityStateRef.current.lastChangeReason,
+        particleMode: particleEngine.mode,
+        particleDrawMode
+      };
+      return current.tier === nextHud.tier &&
+        current.reason === nextHud.reason &&
+        current.particleMode === nextHud.particleMode &&
+        current.particleDrawMode === nextHud.particleDrawMode
+        ? current
+        : nextHud;
+    });
 
     animationFrameRef.current = requestAnimationFrame(draw);
   }, [applyQualityState, collectMetrics]);
@@ -343,6 +394,13 @@ export default function CanvasRenderer({ agentNodes, riskLevel, latestInsight }:
     }
 
     syncCanvasToDisplaySize(canvas, qualityStateRef.current.profile);
+    webglParticleRendererRef.current = particleCanvasRef.current
+      ? createWebglParticleRenderer(particleCanvasRef.current)
+      : null;
+    setRuntimeHud((current) => ({
+      ...current,
+      particleDrawMode: webglParticleRendererRef.current?.mode ?? 'canvas'
+    }));
     animationFrameRef.current = requestAnimationFrame(draw);
 
     const resizeObserver = new ResizeObserver(() => {
@@ -364,13 +422,31 @@ export default function CanvasRenderer({ agentNodes, riskLevel, latestInsight }:
       cancelAnimationFrame(animationFrameRef.current);
       resizeObserver.disconnect();
       simulationRef.current?.stop();
+      webglParticleRendererRef.current?.destroy();
+      webglParticleRendererRef.current = null;
       particleEngineRef.current.destroy();
     };
   }, [draw]);
 
   return (
-    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
-      <canvas ref={canvasRef} style={{ width: '100%', height: '100%', display: 'block' }} />
+    <div style={{ position: 'relative', width: '100%', height: '100%', background: colors.void }}>
+      <canvas
+        ref={canvasRef}
+        style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', display: 'block', zIndex: 1 }}
+      />
+      <canvas
+        ref={particleCanvasRef}
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          inset: 0,
+          width: '100%',
+          height: '100%',
+          display: 'block',
+          pointerEvents: 'none',
+          zIndex: 2
+        }}
+      />
       <div
         style={{
           position: 'absolute',
@@ -385,10 +461,11 @@ export default function CanvasRenderer({ agentNodes, riskLevel, latestInsight }:
           font: '600 11px/1 "Segoe UI Variable Text", system-ui, sans-serif',
           letterSpacing: '0.04em',
           textTransform: 'uppercase',
-          backdropFilter: 'blur(12px)'
+          backdropFilter: 'blur(12px)',
+          zIndex: 3
         }}
       >
-        Auto {runtimeHud.tier} • {runtimeHud.particleMode}
+        Auto {runtimeHud.tier} • {runtimeHud.particleMode} • {runtimeHud.particleDrawMode}
       </div>
     </div>
   );

--- a/shadow-agent/src/renderer/canvas/quality.ts
+++ b/shadow-agent/src/renderer/canvas/quality.ts
@@ -3,6 +3,7 @@ export const QUALITY_TIER_ORDER = ['ultra', 'high', 'medium', 'low'] as const;
 export type QualityTier = (typeof QUALITY_TIER_ORDER)[number];
 export type QualityChangeReason = 'initial' | 'resource-budget' | 'frame-budget' | 'frame-recovery' | 'stable';
 export type ParticleExecutionMode = 'worker' | 'inline' | 'disabled';
+export type ParticleRenderMode = 'webgl' | 'canvas2d' | 'disabled';
 
 export interface ResourceMetrics {
   nodeCount: number;
@@ -26,6 +27,7 @@ export interface QualityProfile {
   showShadowNode: boolean;
   showPredictionTrail: boolean;
   particleMode: ParticleExecutionMode;
+  particleRenderMode: ParticleRenderMode;
   particlesPerEdge: number;
   maxParticles: number;
   particleSizeScale: number;
@@ -63,6 +65,7 @@ export const QUALITY_PROFILES: Record<QualityTier, QualityProfile> = {
     showShadowNode: true,
     showPredictionTrail: true,
     particleMode: 'worker',
+    particleRenderMode: 'webgl',
     particlesPerEdge: 10,
     maxParticles: 360,
     particleSizeScale: 1.15,
@@ -82,6 +85,7 @@ export const QUALITY_PROFILES: Record<QualityTier, QualityProfile> = {
     showShadowNode: true,
     showPredictionTrail: true,
     particleMode: 'worker',
+    particleRenderMode: 'webgl',
     particlesPerEdge: 6,
     maxParticles: 220,
     particleSizeScale: 1,
@@ -101,6 +105,7 @@ export const QUALITY_PROFILES: Record<QualityTier, QualityProfile> = {
     showShadowNode: true,
     showPredictionTrail: false,
     particleMode: 'worker',
+    particleRenderMode: 'canvas2d',
     particlesPerEdge: 3,
     maxParticles: 120,
     particleSizeScale: 0.86,
@@ -120,6 +125,7 @@ export const QUALITY_PROFILES: Record<QualityTier, QualityProfile> = {
     showShadowNode: false,
     showPredictionTrail: false,
     particleMode: 'disabled',
+    particleRenderMode: 'disabled',
     particlesPerEdge: 0,
     maxParticles: 0,
     particleSizeScale: 0,
@@ -131,6 +137,17 @@ export const QUALITY_PROFILES: Record<QualityTier, QualityProfile> = {
 
 export function getQualityProfile(tier: QualityTier): QualityProfile {
   return QUALITY_PROFILES[tier];
+}
+
+export function selectParticleRenderMode(tier: QualityTier, webglSupported: boolean): ParticleRenderMode {
+  const profile = getQualityProfile(tier);
+  if (profile.particleMode === 'disabled' || profile.particleRenderMode === 'disabled') {
+    return 'disabled';
+  }
+  if (profile.particleRenderMode === 'webgl' && webglSupported) {
+    return 'webgl';
+  }
+  return 'canvas2d';
 }
 
 function clampPressure(value: number): number {

--- a/shadow-agent/src/renderer/canvas/webgl-particle-renderer.ts
+++ b/shadow-agent/src/renderer/canvas/webgl-particle-renderer.ts
@@ -1,0 +1,259 @@
+import { getQualityProfile, type QualityTier } from './quality';
+import {
+  getQuadraticControlPoint,
+  getQuadraticPoint
+} from './draw-utils';
+import type { Particle, SimulationEdge, SimulationNode } from './types';
+
+const FLOATS_PER_PARTICLE = 7;
+
+const VERTEX_SHADER_SOURCE = `
+  attribute vec2 a_position;
+  attribute vec4 a_color;
+  attribute float a_size;
+  varying vec4 v_color;
+
+  void main() {
+    v_color = a_color;
+    gl_Position = vec4(a_position, 0.0, 1.0);
+    gl_PointSize = a_size;
+  }
+`;
+
+const FRAGMENT_SHADER_SOURCE = `
+  precision mediump float;
+  varying vec4 v_color;
+
+  void main() {
+    vec2 offset = gl_PointCoord - vec2(0.5);
+    float alpha = smoothstep(0.5, 0.0, length(offset));
+    gl_FragColor = vec4(v_color.rgb, v_color.a * alpha);
+  }
+`;
+
+export type ParticleDrawMode = 'webgl' | 'canvas';
+
+export interface ParticleVertexBufferInput {
+  particles: Particle[];
+  nodesById: Map<string, SimulationNode>;
+  edgesById: Map<string, SimulationEdge>;
+  qualityTier: QualityTier;
+  width: number;
+  height: number;
+  dpr: number;
+}
+
+export interface ParticleVertexBuffer {
+  data: Float32Array;
+  count: number;
+}
+
+export interface WebglParticleDrawInput extends ParticleVertexBufferInput {
+  clearOnly?: boolean;
+}
+
+export interface WebglParticleRenderer {
+  readonly mode: 'webgl';
+  resize(width: number, height: number, dpr: number): void;
+  draw(input: WebglParticleDrawInput): boolean;
+  clear(): void;
+  destroy(): void;
+}
+
+type ParticleGl = WebGLRenderingContext | WebGL2RenderingContext;
+
+function hexToRgb(color: string): [number, number, number] {
+  const normalized = color.replace('#', '');
+  const value = normalized.length === 3
+    ? normalized
+        .split('')
+        .map((part) => `${part}${part}`)
+        .join('')
+    : normalized;
+
+  return [
+    parseInt(value.slice(0, 2), 16) / 255,
+    parseInt(value.slice(2, 4), 16) / 255,
+    parseInt(value.slice(4, 6), 16) / 255
+  ];
+}
+
+export function buildParticleVertexBuffer(input: ParticleVertexBufferInput): ParticleVertexBuffer {
+  const profile = getQualityProfile(input.qualityTier);
+  if (profile.particleMode === 'disabled' || input.width <= 0 || input.height <= 0) {
+    return { data: new Float32Array(0), count: 0 };
+  }
+
+  const values: number[] = [];
+  for (const particle of input.particles) {
+    const edge = input.edgesById.get(particle.edgeId);
+    if (!edge) {
+      continue;
+    }
+
+    const source = input.nodesById.get(edge.source);
+    const target = input.nodesById.get(edge.target);
+    if (!source || !target) {
+      continue;
+    }
+
+    const controlPoint = getQuadraticControlPoint(source.x, source.y, target.x, target.y);
+    const head = getQuadraticPoint(
+      source.x,
+      source.y,
+      controlPoint.x,
+      controlPoint.y,
+      target.x,
+      target.y,
+      particle.progress
+    );
+    const [red, green, blue] = hexToRgb(particle.color);
+    const alpha = particle.opacity * profile.particleAlphaScale;
+    const radius = Math.max(1.25, particle.size * profile.particleSizeScale) * input.dpr;
+    const clipX = (head.x / input.width) * 2 - 1;
+    const clipY = 1 - (head.y / input.height) * 2;
+
+    values.push(clipX, clipY, red, green, blue, alpha, radius);
+  }
+
+  return {
+    data: new Float32Array(values),
+    count: values.length / FLOATS_PER_PARTICLE
+  };
+}
+
+function createShader(gl: ParticleGl, type: number, source: string): WebGLShader | null {
+  const shader = gl.createShader(type);
+  if (!shader) {
+    return null;
+  }
+
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    gl.deleteShader(shader);
+    return null;
+  }
+
+  return shader;
+}
+
+function createProgram(gl: ParticleGl): WebGLProgram | null {
+  const vertexShader = createShader(gl, gl.VERTEX_SHADER, VERTEX_SHADER_SOURCE);
+  const fragmentShader = createShader(gl, gl.FRAGMENT_SHADER, FRAGMENT_SHADER_SOURCE);
+  if (!vertexShader || !fragmentShader) {
+    if (vertexShader) gl.deleteShader(vertexShader);
+    if (fragmentShader) gl.deleteShader(fragmentShader);
+    return null;
+  }
+
+  const program = gl.createProgram();
+  if (!program) {
+    gl.deleteShader(vertexShader);
+    gl.deleteShader(fragmentShader);
+    return null;
+  }
+
+  gl.attachShader(program, vertexShader);
+  gl.attachShader(program, fragmentShader);
+  gl.linkProgram(program);
+  gl.deleteShader(vertexShader);
+  gl.deleteShader(fragmentShader);
+
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    gl.deleteProgram(program);
+    return null;
+  }
+
+  return program;
+}
+
+class GpuParticleRenderer implements WebglParticleRenderer {
+  readonly mode = 'webgl' as const;
+  private readonly canvas: HTMLCanvasElement;
+  private readonly gl: ParticleGl;
+  private readonly program: WebGLProgram;
+  private readonly buffer: WebGLBuffer;
+  private readonly positionLocation: number;
+  private readonly colorLocation: number;
+  private readonly sizeLocation: number;
+
+  constructor(canvas: HTMLCanvasElement, gl: ParticleGl, program: WebGLProgram, buffer: WebGLBuffer) {
+    this.canvas = canvas;
+    this.gl = gl;
+    this.program = program;
+    this.buffer = buffer;
+    this.positionLocation = gl.getAttribLocation(program, 'a_position');
+    this.colorLocation = gl.getAttribLocation(program, 'a_color');
+    this.sizeLocation = gl.getAttribLocation(program, 'a_size');
+
+    gl.useProgram(program);
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
+  }
+
+  resize(width: number, height: number, dpr: number): void {
+    const nextWidth = Math.max(1, Math.round(width * dpr));
+    const nextHeight = Math.max(1, Math.round(height * dpr));
+    if (this.canvas.width !== nextWidth || this.canvas.height !== nextHeight) {
+      this.canvas.width = nextWidth;
+      this.canvas.height = nextHeight;
+    }
+    this.gl.viewport(0, 0, nextWidth, nextHeight);
+  }
+
+  clear(): void {
+    this.gl.clearColor(0, 0, 0, 0);
+    this.gl.clear(this.gl.COLOR_BUFFER_BIT);
+  }
+
+  draw(input: WebglParticleDrawInput): boolean {
+    this.resize(input.width, input.height, input.dpr);
+    this.clear();
+    if (input.clearOnly) {
+      return true;
+    }
+
+    const vertexBuffer = buildParticleVertexBuffer(input);
+    if (vertexBuffer.count === 0) {
+      return true;
+    }
+
+    const stride = FLOATS_PER_PARTICLE * Float32Array.BYTES_PER_ELEMENT;
+    this.gl.useProgram(this.program);
+    this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.buffer);
+    this.gl.bufferData(this.gl.ARRAY_BUFFER, vertexBuffer.data, this.gl.DYNAMIC_DRAW);
+
+    this.gl.enableVertexAttribArray(this.positionLocation);
+    this.gl.vertexAttribPointer(this.positionLocation, 2, this.gl.FLOAT, false, stride, 0);
+    this.gl.enableVertexAttribArray(this.colorLocation);
+    this.gl.vertexAttribPointer(this.colorLocation, 4, this.gl.FLOAT, false, stride, 2 * Float32Array.BYTES_PER_ELEMENT);
+    this.gl.enableVertexAttribArray(this.sizeLocation);
+    this.gl.vertexAttribPointer(this.sizeLocation, 1, this.gl.FLOAT, false, stride, 6 * Float32Array.BYTES_PER_ELEMENT);
+    this.gl.drawArrays(this.gl.POINTS, 0, vertexBuffer.count);
+    return true;
+  }
+
+  destroy(): void {
+    this.gl.deleteBuffer(this.buffer);
+    this.gl.deleteProgram(this.program);
+  }
+}
+
+export function createWebglParticleRenderer(canvas: HTMLCanvasElement): WebglParticleRenderer | null {
+  const gl = canvas.getContext('webgl2', { alpha: true, antialias: false })
+    ?? canvas.getContext('webgl', { alpha: true, antialias: false });
+  if (!gl) {
+    return null;
+  }
+
+  const program = createProgram(gl);
+  const buffer = gl.createBuffer();
+  if (!program || !buffer) {
+    if (program) gl.deleteProgram(program);
+    if (buffer) gl.deleteBuffer(buffer);
+    return null;
+  }
+
+  return new GpuParticleRenderer(canvas, gl, program, buffer);
+}

--- a/shadow-agent/tests/renderer/canvas-quality.test.ts
+++ b/shadow-agent/tests/renderer/canvas-quality.test.ts
@@ -3,6 +3,7 @@ import {
   createQualityController,
   estimateResourcePressure,
   sampleQualityController,
+  selectParticleRenderMode,
   tierFromResourcePressure,
   type ResourceMetrics
 } from '../../src/renderer/canvas/quality';
@@ -64,5 +65,13 @@ describe('canvas quality controller', () => {
 
     expect(state.resourceBudgetTier).toBe('medium');
     expect(state.tier).toBe('medium');
+  });
+
+  it('selects GPU particle rendering only for high-detail tiers with WebGL support', () => {
+    expect(selectParticleRenderMode('ultra', true)).toBe('webgl');
+    expect(selectParticleRenderMode('high', true)).toBe('webgl');
+    expect(selectParticleRenderMode('medium', true)).toBe('canvas2d');
+    expect(selectParticleRenderMode('low', true)).toBe('disabled');
+    expect(selectParticleRenderMode('high', false)).toBe('canvas2d');
   });
 });

--- a/shadow-agent/tests/renderer/webgl-particle-renderer.test.ts
+++ b/shadow-agent/tests/renderer/webgl-particle-renderer.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildParticleVertexBuffer,
+  createWebglParticleRenderer
+} from '../../src/renderer/canvas/webgl-particle-renderer';
+import type { SimulationEdge, SimulationNode, Particle } from '../../src/renderer/canvas/types';
+
+const nodesById = new Map<string, SimulationNode>([
+  ['source', { id: 'source', label: 'Source', state: 'thinking', toolCount: 1, x: 100, y: 120, vx: 0, vy: 0 }],
+  ['target', { id: 'target', label: 'Target', state: 'complete', toolCount: 2, x: 300, y: 220, vx: 0, vy: 0 }]
+]);
+
+const edgesById = new Map<string, SimulationEdge>([
+  ['source-target', { id: 'source-target', source: 'source', target: 'target', state: 'thinking' }]
+]);
+
+const particles: Particle[] = [
+  {
+    id: 'p1',
+    edgeId: 'source-target',
+    progress: 0.5,
+    speed: 0.2,
+    trailLength: 30,
+    color: '#66ccff',
+    opacity: 0.8,
+    size: 4
+  },
+  {
+    id: 'missing-edge',
+    edgeId: 'missing',
+    progress: 0.5,
+    speed: 0.2,
+    trailLength: 30,
+    color: '#ff5566',
+    opacity: 1,
+    size: 6
+  }
+];
+
+describe('webgl particle renderer', () => {
+  it('builds a compact point-sprite vertex buffer for visible particles', () => {
+    const buffer = buildParticleVertexBuffer({
+      particles,
+      nodesById,
+      edgesById,
+      qualityTier: 'high',
+      width: 400,
+      height: 300,
+      dpr: 2
+    });
+
+    expect(buffer.count).toBe(1);
+    expect(buffer.data).toHaveLength(7);
+    expect(buffer.data[0]).toBeCloseTo(-0.05, 4);
+    expect(buffer.data[1]).toBeCloseTo(-0.2667, 4);
+    expect(buffer.data[2]).toBeCloseTo(0.4, 4);
+    expect(buffer.data[3]).toBeCloseTo(0.8, 4);
+    expect(buffer.data[4]).toBe(1);
+    expect(buffer.data[5]).toBeCloseTo(0.72, 4);
+    expect(buffer.data[6]).toBe(8);
+  });
+
+  it('returns an empty buffer when the selected tier disables particles', () => {
+    const buffer = buildParticleVertexBuffer({
+      particles,
+      nodesById,
+      edgesById,
+      qualityTier: 'low',
+      width: 400,
+      height: 300,
+      dpr: 1
+    });
+
+    expect(buffer.count).toBe(0);
+    expect(buffer.data).toHaveLength(0);
+  });
+
+  it('does not create a renderer when WebGL is unavailable', () => {
+    const canvas = {
+      getContext: () => null
+    } as unknown as HTMLCanvasElement;
+
+    expect(createWebglParticleRenderer(canvas)).toBeNull();
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary
- add quality-tier metadata for particle render mode selection
- add a WebGL point-sprite particle renderer with Canvas2D fallback
- route CanvasRenderer particles through runtime quality selection: WebGL for ultra/high, Canvas2D for medium/fallback, disabled for low

## Verification
- npm test --prefix shadow-agent
- npm run build --prefix shadow-agent
- local dev server smoke: http://127.0.0.1:5174/ returned HTTP 200

Note: Browser plugin automation was unavailable in this session because the required node_repl js tool was not exposed, so visual browser inspection could not be completed through the in-app browser.


___

## **CodeAnt-AI Description**
**Use WebGL for particles on high-detail views, with fallback on lower-capability devices**

### What Changed
- Particle effects now use WebGL on Ultra and High tiers when supported
- Medium tier keeps particles on the 2D canvas, and Low tier leaves particles off
- If WebGL is unavailable, particle drawing falls back to the 2D canvas instead of stopping
- The on-screen quality status now shows which particle drawing path is active

### Impact
`✅ Faster particle rendering on high-detail views`
`✅ Fewer visual dropouts on devices without WebGL`
`✅ Clearer quality status during live rendering`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
