### PR TITLE
[codex] Add renderer vendor adapter boundaries

### DIFF
--- a/shadow-agent/src/inference/direct-api.ts
+++ b/shadow-agent/src/inference/direct-api.ts
@@ -73,6 +73,10 @@ export async function createDirectApiClient(
   return {
     id: 'anthropic-direct-api',
     provider: 'anthropic' as const,
+    unitTests: {
+      testFile: 'tests/inference/direct-api.test.ts',
+      covers: ['provider identity', 'request forwarding', 'response normalization']
+    },
 
     async infer(request: InferenceRequest): Promise<InferenceResult> {
       const start = now();

--- a/shadow-agent/src/inference/inference-client.ts
+++ b/shadow-agent/src/inference/inference-client.ts
@@ -3,6 +3,7 @@ import type {
   EventQueueCheckpoint,
   EventQueueMetrics
 } from '../shared/schema';
+import type { AdapterContract } from '../shared/adapter-contracts';
 
 export interface InferenceRequest {
   systemPrompt: string;
@@ -21,8 +22,7 @@ export type Provider = 'opencode' | 'anthropic' | 'fake';
  * Concrete inference adapters must ship with focused unit tests that exercise
  * provider identity, request forwarding, and response normalization.
  */
-export interface InferenceAdapter {
-  readonly id: string;
+export interface InferenceAdapter extends AdapterContract {
   readonly provider: Provider;
   infer(request: InferenceRequest): Promise<InferenceResult>;
 }

--- a/shadow-agent/src/inference/opencode-client.ts
+++ b/shadow-agent/src/inference/opencode-client.ts
@@ -145,6 +145,10 @@ export async function createOpencodeClient(
   return {
     id: 'opencode-harness',
     provider: 'opencode' as const,
+    unitTests: {
+      testFile: 'tests/inference/opencode-client.test.ts',
+      covers: ['provider identity', 'request forwarding', 'response normalization']
+    },
 
     async infer(request: InferenceRequest): Promise<InferenceResult> {
       const start = now();

--- a/shadow-agent/src/renderer/canvas/CanvasRenderer.tsx
+++ b/shadow-agent/src/renderer/canvas/CanvasRenderer.tsx
@@ -1,14 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import {
-  forceCenter,
-  forceCollide,
-  forceLink,
-  forceManyBody,
-  forceSimulation,
-  type Simulation
-} from 'd3-force';
 import type { AgentNode, ShadowInsight } from '../../shared/schema';
 import { colors } from '../theme/colors';
+import { getGraphPhysicsAdapter, type GraphPhysicsSimulation } from './force-simulation-adapter';
 import { createParticleEngine } from './particle-engine';
 import type { ParticleSceneEdge } from './particle-engine-core';
 import {
@@ -124,7 +117,8 @@ export default function CanvasRenderer({ agentNodes, riskLevel, latestInsight }:
   const nodesRef = useRef<SimulationNode[]>([]);
   const edgesRef = useRef<SimulationEdge[]>([]);
   const edgesByIdRef = useRef<Map<string, SimulationEdge>>(new Map());
-  const simulationRef = useRef<Simulation<SimulationNode, SimulationEdge> | null>(null);
+  const simulationRef = useRef<GraphPhysicsSimulation | null>(null);
+  const graphPhysicsAdapterRef = useRef(getGraphPhysicsAdapter());
   const riskLevelRef = useRef<RiskLevel | undefined>(riskLevel);
   const latestInsightRef = useRef<ShadowInsight | undefined>(latestInsight);
   const qualityStateRef = useRef<QualityControllerState>(
@@ -316,24 +310,22 @@ export default function CanvasRenderer({ agentNodes, riskLevel, latestInsight }:
     const height = canvas?.clientHeight ?? 720;
 
     if (!simulationRef.current) {
-      simulationRef.current = forceSimulation<SimulationNode>(nextNodes)
-        .force('charge', forceManyBody().strength(-300))
-        .force('link', forceLink<SimulationNode, SimulationEdge>(nextEdges).id((node) => node.id).distance(150))
-        .force('center', forceCenter(width / 2, height / 2))
-        .force('collide', forceCollide(COLLIDE_RADIUS))
-        .alphaDecay(0.02)
-        .on('tick', () => {
+      simulationRef.current = graphPhysicsAdapterRef.current.createSimulation({
+        nodes: nextNodes,
+        edges: nextEdges,
+        width,
+        height,
+        collideRadius: COLLIDE_RADIUS,
+        onTick: () => {
           nodesRef.current = [...nextNodes];
-        });
+        }
+      });
       return;
     }
 
-    simulationRef.current.nodes(nextNodes);
-    const linkForce = simulationRef.current.force('link');
-    if (linkForce) {
-      (linkForce as ReturnType<typeof forceLink<SimulationNode, SimulationEdge>>).links(nextEdges);
-    }
-    simulationRef.current.alpha(0.35).restart();
+    simulationRef.current.updateNodes(nextNodes);
+    simulationRef.current.updateLinks(nextEdges);
+    simulationRef.current.restart(0.35);
   }, [agentNodes]);
 
   useEffect(() => {
@@ -351,11 +343,7 @@ export default function CanvasRenderer({ agentNodes, riskLevel, latestInsight }:
       if (!simulation) {
         return;
       }
-      const centerForce = simulation.force('center');
-      if (centerForce) {
-        (centerForce as ReturnType<typeof forceCenter>).x(viewport.width / 2);
-        (centerForce as ReturnType<typeof forceCenter>).y(viewport.height / 2);
-      }
+      simulation.updateCenter(viewport.width / 2, viewport.height / 2);
     });
 
     resizeObserver.observe(canvas);

--- a/shadow-agent/src/renderer/canvas/force-simulation-adapter.ts
+++ b/shadow-agent/src/renderer/canvas/force-simulation-adapter.ts
@@ -1,0 +1,86 @@
+import {
+  forceCenter,
+  forceCollide,
+  forceLink,
+  forceManyBody,
+  forceSimulation,
+  type Simulation
+} from 'd3-force';
+import type { SimulationEdge, SimulationNode } from './types';
+
+type D3LinkForce = ReturnType<typeof forceLink<SimulationNode, SimulationEdge>>;
+type D3CenterForce = ReturnType<typeof forceCenter<SimulationNode>>;
+
+export interface GraphPhysicsSimulation {
+  updateNodes(nodes: SimulationNode[]): void;
+  updateLinks(edges: SimulationEdge[]): void;
+  updateCenter(x: number, y: number): void;
+  restart(alpha: number): void;
+  stop(): void;
+}
+
+export interface GraphPhysicsSimulationOptions {
+  nodes: SimulationNode[];
+  edges: SimulationEdge[];
+  width: number;
+  height: number;
+  collideRadius: number;
+  onTick: () => void;
+}
+
+export interface GraphPhysicsAdapter {
+  readonly id: string;
+  createSimulation(options: GraphPhysicsSimulationOptions): GraphPhysicsSimulation;
+}
+
+class D3GraphPhysicsSimulation implements GraphPhysicsSimulation {
+  private readonly simulation: Simulation<SimulationNode, SimulationEdge>;
+  private readonly linkForce: D3LinkForce;
+  private readonly centerForce: D3CenterForce;
+
+  constructor(options: GraphPhysicsSimulationOptions) {
+    this.linkForce = forceLink<SimulationNode, SimulationEdge>(options.edges)
+      .id((node) => node.id)
+      .distance(150);
+    this.centerForce = forceCenter<SimulationNode>(options.width / 2, options.height / 2);
+    this.simulation = forceSimulation<SimulationNode>(options.nodes)
+      .force('charge', forceManyBody<SimulationNode>().strength(-300))
+      .force('link', this.linkForce)
+      .force('center', this.centerForce)
+      .force('collide', forceCollide<SimulationNode>(options.collideRadius))
+      .alphaDecay(0.02)
+      .on('tick', options.onTick);
+  }
+
+  updateNodes(nodes: SimulationNode[]): void {
+    this.simulation.nodes(nodes);
+  }
+
+  updateLinks(edges: SimulationEdge[]): void {
+    this.linkForce.links(edges);
+  }
+
+  updateCenter(x: number, y: number): void {
+    this.centerForce.x(x);
+    this.centerForce.y(y);
+  }
+
+  restart(alpha: number): void {
+    this.simulation.alpha(alpha).restart();
+  }
+
+  stop(): void {
+    this.simulation.stop();
+  }
+}
+
+const d3GraphPhysicsAdapter: GraphPhysicsAdapter = {
+  id: 'd3-force-graph-physics',
+  createSimulation(options) {
+    return new D3GraphPhysicsSimulation(options);
+  }
+};
+
+export function getGraphPhysicsAdapter(): GraphPhysicsAdapter {
+  return d3GraphPhysicsAdapter;
+}

--- a/shadow-agent/src/renderer/components/GlassCard.tsx
+++ b/shadow-agent/src/renderer/components/GlassCard.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react';
-import { cva, type VariantProps } from 'class-variance-authority';
+import { createClassVariants, type VariantProps } from '../style-variant-adapter';
 import { TIMING } from '../theme/timing';
 
 /**
  * GlassCard — glass-morphism card with backdrop blur and mount animation.
  */
-const glassCVA = cva('glass-card', {
+const glassCVA = createClassVariants('glass-card', {
   variants: {
     size: {
       sm: 'glass-card--sm',

--- a/shadow-agent/src/renderer/components/ShadowPanel.tsx
+++ b/shadow-agent/src/renderer/components/ShadowPanel.tsx
@@ -1,5 +1,5 @@
-import { animated, useSpring } from '@react-spring/web';
 import type { ShadowInsight } from '../../shared/schema';
+import { AnimatedAside, useMotionSpring } from '../motion-adapter';
 
 export interface ShadowPanelProps {
   phase: string;
@@ -34,11 +34,9 @@ function ConfidenceRing({ confidence }: { confidence: number }) {
   );
 }
 
-const AnimatedAside = animated.aside as React.ElementType;
-
 export default function ShadowPanel({ phase, objective, riskSignals, nextMoves, insights }: ShadowPanelProps) {
   // Slide in from right
-  const slideStyle = useSpring({
+  const slideStyle = useMotionSpring({
     from: { opacity: 0, transform: 'translateX(32px)' },
     to: { opacity: 1, transform: 'translateX(0)' },
     config: { tension: 220, friction: 28 },

--- a/shadow-agent/src/renderer/components/TimelineScrubber.tsx
+++ b/shadow-agent/src/renderer/components/TimelineScrubber.tsx
@@ -1,8 +1,6 @@
 import { useRef, useCallback } from 'react';
 import type { TimelineItem } from '../../shared/schema';
-import { animated, useSpring } from '@react-spring/web';
-
-const AnimatedDiv = animated.div as React.ElementType;
+import { AnimatedDiv, useMotionSpring } from '../motion-adapter';
 
 export interface TimelineScrubberProps {
   timeline: TimelineItem[];
@@ -39,7 +37,7 @@ function EventMarker({ event: timelineEvent }: { event: TimelineItem }) {
 export default function TimelineScrubber({ timeline }: TimelineScrubberProps) {
   const trackRef = useRef<HTMLDivElement>(null);
 
-  const [{ playhead }, playheadApi] = useSpring(() => ({
+  const [{ playhead }, playheadApi] = useMotionSpring(() => ({
     playhead: 0,
     config: { tension: 200, friction: 40 },
   }));

--- a/shadow-agent/src/renderer/motion-adapter.tsx
+++ b/shadow-agent/src/renderer/motion-adapter.tsx
@@ -1,0 +1,24 @@
+import { animated, useSpring } from '@react-spring/web';
+import type { ElementType } from 'react';
+
+export interface MotionAdapter {
+  readonly id: string;
+  readonly AnimatedAside: ElementType;
+  readonly AnimatedDiv: ElementType;
+  readonly useSpring: typeof useSpring;
+}
+
+const reactSpringMotionAdapter: MotionAdapter = {
+  id: 'react-spring-motion',
+  AnimatedAside: animated.aside as ElementType,
+  AnimatedDiv: animated.div as ElementType,
+  useSpring
+};
+
+export function getMotionAdapter(): MotionAdapter {
+  return reactSpringMotionAdapter;
+}
+
+export const AnimatedAside = reactSpringMotionAdapter.AnimatedAside;
+export const AnimatedDiv = reactSpringMotionAdapter.AnimatedDiv;
+export const useMotionSpring = reactSpringMotionAdapter.useSpring;

--- a/shadow-agent/src/renderer/style-variant-adapter.ts
+++ b/shadow-agent/src/renderer/style-variant-adapter.ts
@@ -1,0 +1,18 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export interface StyleVariantAdapter {
+  readonly id: string;
+  readonly createClassVariants: typeof cva;
+}
+
+const classVarianceAuthorityAdapter: StyleVariantAdapter = {
+  id: 'class-variance-authority',
+  createClassVariants: cva
+};
+
+export function getStyleVariantAdapter(): StyleVariantAdapter {
+  return classVarianceAuthorityAdapter;
+}
+
+export const createClassVariants = classVarianceAuthorityAdapter.createClassVariants;
+export type { VariantProps };

--- a/shadow-agent/src/shared/adapter-contracts.ts
+++ b/shadow-agent/src/shared/adapter-contracts.ts
@@ -1,0 +1,19 @@
+/**
+ * Every concrete adapter must name the focused unit test file that covers its
+ * boundary. This keeps adapter authors from satisfying the structural contract
+ * without also landing regression coverage for the implementation.
+ */
+export interface AdapterUnitTestRequirement {
+  readonly testFile: string;
+  readonly covers: readonly string[];
+}
+
+/**
+ * Shared adapter boundary fields for capture, inference, and renderer-input
+ * adapters. Domain-specific contracts extend this interface with their own
+ * input/output methods.
+ */
+export interface AdapterContract {
+  readonly id: string;
+  readonly unitTests: AdapterUnitTestRequirement;
+}

--- a/shadow-agent/src/shared/capture-adapter.ts
+++ b/shadow-agent/src/shared/capture-adapter.ts
@@ -1,4 +1,5 @@
 import type { CanonicalEvent, EventSource } from './schema';
+import type { AdapterContract } from './adapter-contracts';
 
 /**
  * Concrete capture adapters must ship with focused unit tests that exercise
@@ -6,8 +7,7 @@ import type { CanonicalEvent, EventSource } from './schema';
  * with a sibling `*.test.ts` that proves the adapter boundary, not just the
  * parsing helpers behind it.
  */
-export interface CaptureAdapter<TInput = string> {
-  readonly id: string;
+export interface CaptureAdapter<TInput = string> extends AdapterContract {
   readonly source: EventSource;
   parse(input: TInput): CanonicalEvent[];
 }

--- a/shadow-agent/src/shared/renderer-input-adapter.ts
+++ b/shadow-agent/src/shared/renderer-input-adapter.ts
@@ -5,6 +5,7 @@ import {
   resolvePrivacyPolicy
 } from './privacy';
 import { buildSessionRecord } from './replay-store';
+import type { AdapterContract } from './adapter-contracts';
 import type {
   CanonicalEvent,
   LoadedSource,
@@ -22,8 +23,7 @@ export interface RendererInputBuildOptions {
  * Concrete renderer-input adapters must ship with focused unit tests that
  * exercise title resolution, privacy defaults, and derived-state assembly.
  */
-export interface RendererInputAdapter<TInput = CanonicalEvent[]> {
-  readonly id: string;
+export interface RendererInputAdapter<TInput = CanonicalEvent[]> extends AdapterContract {
   build(input: TInput, options: RendererInputBuildOptions): RendererInput;
 }
 
@@ -57,6 +57,10 @@ export function inferRendererInputTitle(
 
 export const canonicalEventRendererInputAdapter: RendererInputAdapter<CanonicalEvent[]> = {
   id: 'canonical-event-renderer-input',
+  unitTests: {
+    testFile: 'tests/renderer/renderer-input-adapter.test.ts',
+    covers: ['title resolution', 'privacy defaults', 'derived-state assembly']
+  },
   build(events, options) {
     const title = inferRendererInputTitle(events, options.fallbackTitle ?? options.source.label);
     const record = buildSessionRecord(events, title);

--- a/shadow-agent/src/shared/transcript-adapter.ts
+++ b/shadow-agent/src/shared/transcript-adapter.ts
@@ -148,6 +148,10 @@ function parseTranscript(raw: string): CanonicalEvent[] {
 export const claudeTranscriptCaptureAdapter: CaptureAdapter<string> = {
   id: 'claude-transcript-jsonl',
   source: 'claude-transcript',
+  unitTests: {
+    testFile: 'tests/transcript-adapter.test.ts',
+    covers: ['source metadata', 'normalization behavior', 'malformed input handling']
+  },
   parse: parseTranscript
 };
 

--- a/shadow-agent/tests/helpers/fake-inference-client.ts
+++ b/shadow-agent/tests/helpers/fake-inference-client.ts
@@ -5,6 +5,10 @@ type ResponseFactory = (request: InferenceRequest) => InferenceResult | Promise<
 export class FakeInferenceClient implements InferenceClient {
   readonly id = 'fake-inference-client';
   readonly provider = 'fake' as const;
+  readonly unitTests = {
+    testFile: 'tests/inference/inference-contract.test.ts',
+    covers: ['provider identity', 'request forwarding', 'response normalization']
+  };
   private queue: ResponseFactory[] = [];
   readonly calls: InferenceRequest[] = [];
 

--- a/shadow-agent/tests/inference/direct-api.test.ts
+++ b/shadow-agent/tests/inference/direct-api.test.ts
@@ -59,6 +59,10 @@ describe('createDirectApiClient', () => {
     expect(client).not.toBeNull();
     expect(client?.id).toBe('anthropic-direct-api');
     expect(client?.provider).toBe('anthropic');
+    expect(client?.unitTests).toEqual({
+      testFile: 'tests/inference/direct-api.test.ts',
+      covers: ['provider identity', 'request forwarding', 'response normalization']
+    });
 
     const result = await client!.infer({
       systemPrompt: 'system prompt',

--- a/shadow-agent/tests/inference/inference-client-factory.test.ts
+++ b/shadow-agent/tests/inference/inference-client-factory.test.ts
@@ -2,6 +2,19 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as directApi from '../../src/inference/direct-api';
 import * as opencodeClient from '../../src/inference/opencode-client';
 import { createInferenceClient } from '../../src/inference/inference-client-factory';
+import type { InferenceClient, Provider } from '../../src/inference/inference-client';
+
+function inferenceAdapter(id: string, provider: Provider): InferenceClient {
+  return {
+    id,
+    provider,
+    unitTests: {
+      testFile: 'tests/inference/inference-client-factory.test.ts',
+      covers: ['provider selection']
+    },
+    infer: vi.fn()
+  };
+}
 
 describe('createInferenceClient', () => {
   afterEach(() => {
@@ -11,13 +24,9 @@ describe('createInferenceClient', () => {
 
   it('prefers the direct Anthropic client when SHADOW_INFERENCE_PROVIDER=anthropic', async () => {
     process.env.SHADOW_INFERENCE_PROVIDER = 'anthropic';
-    const direct = { id: 'anthropic-direct-api', provider: 'anthropic' as const, infer: vi.fn() };
+    const direct = inferenceAdapter('anthropic-direct-api', 'anthropic');
     vi.spyOn(directApi, 'createDirectApiClient').mockResolvedValue(direct);
-    vi.spyOn(opencodeClient, 'createOpencodeClient').mockResolvedValue({
-      id: 'opencode-harness',
-      provider: 'opencode',
-      infer: vi.fn()
-    });
+    vi.spyOn(opencodeClient, 'createOpencodeClient').mockResolvedValue(inferenceAdapter('opencode-harness', 'opencode'));
 
     const client = await createInferenceClient();
 
@@ -26,13 +35,9 @@ describe('createInferenceClient', () => {
   });
 
   it('uses OpenCode when available and no provider override is set', async () => {
-    const opencode = { id: 'opencode-harness', provider: 'opencode' as const, infer: vi.fn() };
+    const opencode = inferenceAdapter('opencode-harness', 'opencode');
     vi.spyOn(opencodeClient, 'createOpencodeClient').mockResolvedValue(opencode);
-    vi.spyOn(directApi, 'createDirectApiClient').mockResolvedValue({
-      id: 'anthropic-direct-api',
-      provider: 'anthropic',
-      infer: vi.fn()
-    });
+    vi.spyOn(directApi, 'createDirectApiClient').mockResolvedValue(inferenceAdapter('anthropic-direct-api', 'anthropic'));
 
     const client = await createInferenceClient();
 
@@ -41,7 +46,7 @@ describe('createInferenceClient', () => {
   });
 
   it('falls back to Anthropic when OpenCode is unavailable', async () => {
-    const direct = { id: 'anthropic-direct-api', provider: 'anthropic' as const, infer: vi.fn() };
+    const direct = inferenceAdapter('anthropic-direct-api', 'anthropic');
     vi.spyOn(opencodeClient, 'createOpencodeClient').mockResolvedValue(null);
     vi.spyOn(directApi, 'createDirectApiClient').mockResolvedValue(direct);
 

--- a/shadow-agent/tests/inference/inference-contract.test.ts
+++ b/shadow-agent/tests/inference/inference-contract.test.ts
@@ -65,6 +65,15 @@ function makeEvent(overrides: Partial<CanonicalEvent> = {}): CanonicalEvent {
 // ---------------------------------------------------------------------------
 
 describe('FakeInferenceClient', () => {
+  it('declares the unit tests that cover the fake inference adapter contract', () => {
+    const client = new FakeInferenceClient();
+
+    expect(client.unitTests).toEqual({
+      testFile: 'tests/inference/inference-contract.test.ts',
+      covers: ['provider identity', 'request forwarding', 'response normalization']
+    });
+  });
+
   it('returns queued results in order', async () => {
     const client = new FakeInferenceClient();
     client.enqueue({ text: 'response A', model: 'fake/1', latencyMs: 1 });

--- a/shadow-agent/tests/inference/opencode-client.test.ts
+++ b/shadow-agent/tests/inference/opencode-client.test.ts
@@ -66,7 +66,12 @@ describe('createOpencodeClient', () => {
     });
 
     expect(client).not.toBeNull();
+    expect(client?.id).toBe('opencode-harness');
     expect(client?.provider).toBe('opencode');
+    expect(client?.unitTests).toEqual({
+      testFile: 'tests/inference/opencode-client.test.ts',
+      covers: ['provider identity', 'request forwarding', 'response normalization']
+    });
 
     const result = await client!.infer({
       systemPrompt: 'shadow system',

--- a/shadow-agent/tests/renderer/renderer-input-adapter.test.ts
+++ b/shadow-agent/tests/renderer/renderer-input-adapter.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { buildRendererInput, inferRendererInputTitle } from '../../src/shared/renderer-input-adapter';
+import {
+  buildRendererInput,
+  canonicalEventRendererInputAdapter,
+  inferRendererInputTitle
+} from '../../src/shared/renderer-input-adapter';
 import type { CanonicalEvent } from '../../src/shared/schema';
 
 function event(overrides: Partial<CanonicalEvent> = {}): CanonicalEvent {
@@ -16,6 +20,13 @@ function event(overrides: Partial<CanonicalEvent> = {}): CanonicalEvent {
 }
 
 describe('canonicalEventRendererInputAdapter', () => {
+  it('declares the unit tests that cover the renderer input contract', () => {
+    expect(canonicalEventRendererInputAdapter.unitTests).toEqual({
+      testFile: 'tests/renderer/renderer-input-adapter.test.ts',
+      covers: ['title resolution', 'privacy defaults', 'derived-state assembly']
+    });
+  });
+
   it('prefers session labels and user objectives when inferring the renderer title', () => {
     expect(
       inferRendererInputTitle(

--- a/shadow-agent/tests/renderer/vendor-adapters.test.ts
+++ b/shadow-agent/tests/renderer/vendor-adapters.test.ts
@@ -1,0 +1,86 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  getGraphPhysicsAdapter,
+  type GraphPhysicsSimulation
+} from '../../src/renderer/canvas/force-simulation-adapter';
+import { getMotionAdapter } from '../../src/renderer/motion-adapter';
+import { getStyleVariantAdapter } from '../../src/renderer/style-variant-adapter';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const rendererSrcDir = join(testDir, '..', '..', 'src', 'renderer');
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const path = join(dir, entry);
+    const stats = statSync(path);
+    if (stats.isDirectory()) {
+      return sourceFiles(path);
+    }
+    return /\.(ts|tsx)$/.test(entry) ? [path] : [];
+  });
+}
+
+describe('renderer vendor adapters', () => {
+  it('exposes graph physics through the internal adapter contract', () => {
+    const adapter = getGraphPhysicsAdapter();
+    const simulation: GraphPhysicsSimulation = adapter.createSimulation({
+      nodes: [],
+      edges: [],
+      width: 640,
+      height: 480,
+      collideRadius: 44,
+      onTick: () => undefined
+    });
+
+    expect(adapter.id).toBe('d3-force-graph-physics');
+    expect(typeof simulation.updateNodes).toBe('function');
+    expect(typeof simulation.updateLinks).toBe('function');
+    expect(typeof simulation.updateCenter).toBe('function');
+    expect(typeof simulation.restart).toBe('function');
+    expect(typeof simulation.stop).toBe('function');
+
+    simulation.stop();
+  });
+
+  it('exposes motion and style variant vendors through internal adapters', () => {
+    const motion = getMotionAdapter();
+    const variants = getStyleVariantAdapter();
+
+    expect(motion.id).toBe('react-spring-motion');
+    expect(['function', 'object']).toContain(typeof motion.AnimatedAside);
+    expect(['function', 'object']).toContain(typeof motion.AnimatedDiv);
+    expect(typeof motion.useSpring).toBe('function');
+
+    expect(variants.id).toBe('class-variance-authority');
+    expect(typeof variants.createClassVariants).toBe('function');
+  });
+
+  it('keeps swappable vendor imports centralized in adapter modules', () => {
+    const allowed = new Set([
+      'canvas/force-simulation-adapter.ts',
+      'motion-adapter.tsx',
+      'style-variant-adapter.ts'
+    ]);
+    const forbiddenImports = [
+      "from 'd3-force'",
+      "from '@react-spring/web'",
+      "from 'class-variance-authority'"
+    ];
+
+    const violations = sourceFiles(rendererSrcDir).flatMap((file) => {
+      const relativePath = relative(rendererSrcDir, file).split(/[\\/]/).join('/');
+      if (allowed.has(relativePath)) {
+        return [];
+      }
+      const contents = readFileSync(file, 'utf8');
+      return forbiddenImports
+        .filter((vendorImport) => contents.includes(vendorImport))
+        .map((vendorImport) => `${relativePath}: ${vendorImport}`);
+    });
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/shadow-agent/tests/transcript-adapter.test.ts
+++ b/shadow-agent/tests/transcript-adapter.test.ts
@@ -19,6 +19,10 @@ describe('parseClaudeTranscriptJsonl', () => {
     expect(adapter).toBe(claudeTranscriptCaptureAdapter);
     expect(adapter.id).toBe('claude-transcript-jsonl');
     expect(adapter.source).toBe('claude-transcript');
+    expect(adapter.unitTests).toEqual({
+      testFile: 'tests/transcript-adapter.test.ts',
+      covers: ['source metadata', 'normalization behavior', 'malformed input handling']
+    });
     expect(adapter.parse(raw)).toEqual(parseClaudeTranscriptJsonl(raw));
   });
 


### PR DESCRIPTION
## What changed

- Added shared adapter contract metadata for concrete capture, inference, and renderer-input adapters.
- Added renderer vendor adapters for `d3-force`, `@react-spring/web`, and `class-variance-authority`.
- Migrated `CanvasRenderer`, `ShadowPanel`, `TimelineScrubber`, and `GlassCard` to depend on internal adapter surfaces instead of importing those vendors directly.
- Added renderer adapter boundary tests that verify the adapter exports and fail if vendor imports leak back into renderer call sites.

## Why

Adapter implementations now have explicit ownership and test metadata, and renderer vendor dependencies are centralized behind thin first-party interfaces so upstream packages can be swapped or upgraded without touching product call sites.

## Validation

- `npm test -- tests/renderer/vendor-adapters.test.ts` passed: 1 file, 3 tests.
- `npm test` passed: 43 files, 410 tests.
- `npm run build` passed for web, renderer, and Electron bundles.
- Pre-push `npm test` passed again before updating the remote branch.