### PR TITLE
docs: remove stale shadow-agent path references

### DIFF
--- a/.claude/rules/prompts.md
+++ b/.claude/rules/prompts.md
@@ -1,7 +1,7 @@
 ---
 paths:
   - "prompts/**"
-  - "shadow-agent/src/inference/prompts.ts"
+  - "src/inference/prompts.ts"
 ---
 
 # Rules for the Shadow System Prompt
@@ -11,7 +11,7 @@ configuration in shadow-agent. Treat it accordingly.
 
 ## Where it lives
 
-There is **one file**: `shadow-agent/src/inference/prompts.ts`. The prompt
+There is **one file**: `src/inference/prompts.ts`. The prompt
 itself is the `SHADOW_SYSTEM_PROMPT` template literal. The rationale,
 philosophy, per-section justification, evaluation plan, iteration log, and
 "why this lives in one file" meta-decision all live in the file-level doc

--- a/docs/domain-inference.md
+++ b/docs/domain-inference.md
@@ -17,7 +17,7 @@ stream and produces structured interpretations (phase, risk, predictions, confid
 Full research spec: `docs/research/shadow-inference-architecture.md`
 Sidecar source patterns: `docs/research/visual-patterns-sidecar.md`
 Implementation plan: `docs/plans/plan-inference-engine.md`
-Prompt source: `shadow-agent/src/inference/prompts.ts` (single source of truth — rationale + runtime template literal in one file)
+Prompt source: `src/inference/prompts.ts` (single source of truth — rationale + runtime template literal in one file)
 
 ## OpenCode Harness
 
@@ -65,7 +65,7 @@ phase classification, risk signals with severity and confidence, predicted next 
 factual observations, and file attention. Key constraints: read-only, terse, specific,
 honest confidence scores (not everything warrants 0.9+), JSON-only output.
 
-The prompt lives in `shadow-agent/src/inference/prompts.ts` as a single source
+The prompt lives in `src/inference/prompts.ts` as a single source
 of truth: the runtime template literal `SHADOW_SYSTEM_PROMPT` and the rationale
 doc comment (philosophy, per-section justification, evaluation plan, iteration
 log, "why one file") are co-located. No generation step. See

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,20 +4,15 @@ Welcome to **shadow-agent**. This guide will help you get the project running lo
 
 ## Setup
 
-The main project lives in the `shadow-agent` directory.
-
 ```bash
-cd shadow-agent
 npm install
 ```
 
 ## Test
 
-We use [Vitest](https://vitest.dev/) for unit and integration testing. Tests run
-from inside the `shadow-agent/` directory.
+We use [Vitest](https://vitest.dev/) for unit and integration testing.
 
 ```bash
-cd shadow-agent
 npm test               # run all tests
 npm run test:coverage  # run with coverage report
 npx vitest tests/derive.test.ts   # run a single file
@@ -39,7 +34,7 @@ by running `vitest run` and confirming the output contains only reporter summary
 
 CI runs the test suite and the build on every PR via the `CI`
 workflow (`.github/workflows/ci.yml`). The repo uses a pre-push Git
-hook in `.githooks/pre-push` that runs `npm test --prefix shadow-agent`
+hook in `.githooks/pre-push` that runs `npm test`
 once before pushing; `npm install` from the repo root configures
 `core.hooksPath` automatically. Run `npm test` yourself before pushing
 — the pre-push hook will also run it, but catching failures earlier
@@ -50,7 +45,6 @@ is cheaper than re-pushing.
 Build the web, renderer, and Electron bundles, then launch the desktop app:
 
 ```bash
-cd shadow-agent
 npm run build
 npm start
 ```
@@ -91,17 +85,17 @@ variables override the saved file for that run.
 
 ## Project Structure
 
-- `shadow-agent/src/electron/`: Main process code, including IPC handling, session management, and file loading.
-- `shadow-agent/src/renderer/`: React shell plus Canvas2D + D3-Force graph (`src/renderer/canvas/`), glass panels, and timeline UI.
-- `shadow-agent/src/shared/`: Code shared between the main and renderer processes (types, utilities, logging, privacy, transcript parsing, replay store).
-- `shadow-agent/src/inference/`: Shadow inference engine — OpenCode-first client with Anthropic fallback, auth, context packaging, prompt building, and trigger logic.
-- `shadow-agent/src/capture/`: Pluggable capture transports (file tail, HTTP stream, WebSocket, socket).
-- `shadow-agent/src/mcp/`: MCP server exposing shadow tools to other agents.
+- `src/electron/`: Main process code, including IPC handling, session management, and file loading.
+- `src/renderer/`: React shell plus Canvas2D + D3-Force graph (`src/renderer/canvas/`), glass panels, and timeline UI.
+- `src/shared/`: Code shared between the main and renderer processes (types, utilities, logging, privacy, transcript parsing, replay store).
+- `src/inference/`: Shadow inference engine — OpenCode-first client with Anthropic fallback, auth, context packaging, prompt building, and trigger logic.
+- `src/capture/`: Pluggable capture transports (file tail, HTTP stream, WebSocket, socket).
+- `src/mcp/`: MCP server exposing shadow tools to other agents.
 - `docs/`: Technical documentation, architecture decisions, and project plans.
 
 ## Prompt Workflow
 
-The shadow system prompt lives in `shadow-agent/src/inference/prompts.ts`
+The shadow system prompt lives in `src/inference/prompts.ts`
 as a single source of truth. The doc comment at the top contains the
 rationale, philosophy, per-section justification, evaluation plan, and
 iteration log. The template literal at the bottom is the prompt the

--- a/docs/plans/plan-inference-engine.md
+++ b/docs/plans/plan-inference-engine.md
@@ -22,7 +22,7 @@ All patterns are ported from `third_party/sidecar/` as described in `docs/resear
 
 ## 1. Dependencies to Add
 
-Install in `shadow-agent/` as needed:
+Install in the repo root as needed:
 
 ```
 @opencode-ai/sdk@^1.1.36        # Planned OpenCode server + client SDK
@@ -34,7 +34,7 @@ Install in `shadow-agent/` as needed:
 
 ## 2. File Map
 
-All new files live under `shadow-agent/src/inference/` and `shadow-agent/src/mcp/`:
+All new files live under `src/inference/` and `src/mcp/`:
 
 | File | Purpose |
 |------|---------|

--- a/docs/plans/plan-testing-observability.md
+++ b/docs/plans/plan-testing-observability.md
@@ -66,7 +66,7 @@ Several planned subsystems are naturally nondeterministic unless we create seams
 We should standardize the following test helpers:
 
 ```text
-shadow-agent/tests/
+tests/
   fixtures/
     transcripts/
     replays/
@@ -295,7 +295,7 @@ escape or when they only happen in live sessions.
 
 ### Logger Shape
 
-Create a shared structured logger, for example in `shadow-agent/src/shared/logger.ts`.
+Create a shared structured logger, for example in `src/shared/logger.ts`.
 
 Every log entry should carry:
 - timestamp
@@ -546,4 +546,3 @@ the real `StructuredLogger` instances.
 - `tests/instrumentation-sampling.test.ts` — simplified: imports `createTestLogger()`, passes
   it to `FileReplayStore`/`session-io`, asserts `logger.getRecent()`.
 - All other tests — unchanged (they don't interact with the logger).
-

--- a/docs/tooling-philosophy.md
+++ b/docs/tooling-philosophy.md
@@ -71,7 +71,7 @@ Examples of problems that may not exist yet:
 When unsure: write down the trigger that would create the problem, ship without
 the infrastructure, and re-evaluate when the trigger fires. See the "When to
 upgrade" sections that appear in artifact comments (e.g., the doc comment in
-`shadow-agent/src/inference/prompts.ts`).
+`src/inference/prompts.ts`).
 
 ## Principle 4: Anchor decisions on the north star
 


### PR DESCRIPTION
## **User description**
## Summary
- remove stale `shadow-agent/` repo-internal path prefixes from live docs and prompt rules
- update getting-started commands to run from the flattened repo root
- keep intentional `~/.shadow-agent/` storage references unchanged per roadmap

## Testing
- npm test
- npm run build

Closes #104


___

## **CodeAnt-AI Description**
**Remove stale `shadow-agent/` path references from docs**

### What Changed
- Updated setup, testing, build, and project-structure instructions to use the repo root and `src/...` paths instead of `shadow-agent/...`
- Replaced old prompt and plan references with the current file locations
- Kept the intentional `~/.shadow-agent/` storage references unchanged

### Impact
`✅ Clearer setup instructions`
`✅ Fewer broken doc paths`
`✅ Easier onboarding from the repo root`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Documentation Path Updates - Monorepo Flatten Cleanup

Removes stale `shadow-agent/` path prefixes from live documentation and development guidelines following the repository restructure. This addresses ~117 path references that remained after the monorepo flatten operation.

### Changes by File

| File | Changes | Effort |
|------|---------|--------|
| `.claude/rules/prompts.md` | Updated paths section from `shadow-agent/src/inference/prompts.ts` → `src/inference/prompts.ts` | Medium |
| `docs/domain-inference.md` | Updated prompt "single source of truth" reference to new path location | Low |
| `docs/getting-started.md` | Removed `cd shadow-agent` requirement; updated all setup/build/test commands to run from repo root | Medium |
| `docs/plans/plan-inference-engine.md` | Updated file map and installation guidance to reference root-level `src/inference/` and `src/mcp/` | Low |
| `docs/plans/plan-testing-observability.md` | Updated fixture location references from `shadow-agent/tests/` → `tests/` and logger path from `shadow-agent/...` → `src/shared/logger.ts` | Low |
| `docs/tooling-philosophy.md` | Updated example file path in guidance section | Low |

### Key Updates

- **Installation & Execution**: Simplified getting-started instructions to run `npm install` and `npm test` from repository root instead of requiring navigation to `shadow-agent/` subdirectory
- **File References**: Consistently updated path prefixes across documentation to match flattened repository structure
- **Preserved**: References to `~/.shadow-agent/` storage directory remain unchanged per roadmap requirements
- **Testing**: Changes validated with `npm test` and `npm run build`

Closes `#104`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->