### PR TITLE
[codex] Thread inference loggers through DI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 * text=auto
 
 # Source code — always LF in the repository
+.gitattributes text eol=lf
 *.ts text eol=lf
 *.tsx text eol=lf
 *.js text eol=lf
@@ -20,6 +21,7 @@
 *.snap text eol=lf
 
 # Scripts
+.githooks/* text eol=lf
 *.sh text eol=lf
 *.ps1 text eol=lf
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -6,12 +6,12 @@ npm test
 
 # Live tests: REAL read pipeline + REAL model inference (DeepSeek via Doppler)
 # against a real ~/.claude session. Intentionally NOT in CI (no real session or
-# secrets there) — pre-push, on a developer machine, is the right place. They
-# SKIP (not fail) when no real session / no inference key exists, so a fresh
-# checkout still pushes cleanly. With Doppler present, DEEPSEEK_API_KEY is
-# injected and the inference test runs for real.
+# secrets there) — pre-push, on a developer machine, is the right place. When
+# Doppler is installed, the Doppler-backed live suite is a hard gate so real
+# inference failures cannot be masked by a skip-capable fallback run. Machines
+# without Doppler still run the skip-capable suite for read-pipeline coverage.
 if command -v doppler >/dev/null 2>&1; then
-  doppler run -p ai-models -c dev -- npm run test:live || npm run test:live
+  doppler run -p ai-models -c dev -- npm run test:live
 else
   npm run test:live
 fi

--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -4,9 +4,12 @@
 
 This audit reflects the state of `main` **after** PR #100 (`test/audit-followup-rewrites`), which addressed the prior audit's worst offenders.
 
-**Follow-up in this PR:** the logger redesign is now implemented for the capture/persistence/session-io paths, instrumentation tests assert against injected in-memory loggers, and the highest-noise renderer helper/pulse suites were consolidated. The current regular suite is **48 files / 381 tests**, plus **1 live file / 3 live tests**.
+**Follow-up in this PR:** the logger redesign is now implemented for the capture/persistence/session-io paths and the inference auth/provider/engine path. Instrumentation and inference tests assert against injected in-memory loggers, and the highest-noise renderer helper/pulse suites were consolidated. The current regular suite is **46 files / 372 tests**, plus **2 live files / 4 live tests**.
 
-## Post-PR #100 Headline
+## Post-PR #100 Headline (Historical Baseline)
+
+These figures are the audited post-PR #100 baseline. The current follow-up branch count is
+listed above.
 
 - **49 files · 430 test cases (427 regular + 3 live).**
 - **REAL 387 (90%) · WEAK 43 (10%) · FICTION 0 (0%).**
@@ -31,7 +34,6 @@ This audit reflects the state of `main` **after** PR #100 (`test/audit-followup-
 | File | Grade | Issue |
 |------|-------|-------|
 | `tests/electron/start-main-process.test.ts` | C/WEAK | Everything mocked. No real Electron IPC exercised. Tests wiring contracts, not behavior. |
-| `tests/electron/start-main-process-privacy.test.ts` | C/WEAK | All modules mocked. Single test checks argument flow, not behavioral outcome. |
 | `tests/electron/renderer-host.test.ts` | C/WEAK | Bridge entirely hand-mocked. 14 lines of production code under test. |
 | `tests/renderer/renderer-surface-adapter.test.ts` | D/REAL | 1 test with identity checks. Would catch deletions but not behavioral regressions. |
 | `tests/renderer/host.test.ts` | D/REAL | 1 test for static host. Missing `createBridgeHost` or populated capabilities. |
@@ -44,10 +46,10 @@ The original audit found that `tests/instrumentation-sampling.test.ts` had to sp
 
 1. a `Logger` interface implemented by `StructuredLogger`;
 2. `createTestLogger()`, which disables console output and captures debug-through-error events in memory;
-3. logger injection for `FileReplayStore`, `session-io`, `SessionManager`, and `EventBuffer`;
-4. behavior assertions in `tests/instrumentation-sampling.test.ts` against `logger.getRecent()` instead of environment mutation or console spies.
+3. logger injection for `FileReplayStore`, `session-io`, `SessionManager`, `EventBuffer`, inference auth, inference providers, the provider factory, the trigger, parser, and engine;
+4. behavior assertions in `tests/instrumentation-sampling.test.ts` and focused inference/provider/auth tests against `logger.getRecent()` instead of environment mutation or console spies.
 
-Remaining guidance: new instrumentation should accept a `Logger` or receive one from a parent subsystem, and tests should prefer `createTestLogger()` plus `getRecent()` for structured assertions. See `docs/plans/plan-testing-observability.md` for the design rationale and the capture layer for usage examples.
+Remaining guidance: new instrumentation should accept a `Logger` or receive one from a parent subsystem, and tests should prefer `createTestLogger()` plus `getRecent()` for structured assertions. Peripheral entry surfaces that still create their own logger should only be migrated when their surrounding behavior changes. See `docs/plans/plan-testing-observability.md` for the design rationale and the capture/inference layers for usage examples.
 
 ## Previous Audit Comparison
 

--- a/docs/plans/plan-testing-observability.md
+++ b/docs/plans/plan-testing-observability.md
@@ -414,7 +414,7 @@ Additional gate for capture-heavy PRs:
 ## Immediate Next Tasks
 
 1. Expand the current happy-path tests into edge and corruption cases.
-2. Introduce the shared logger before capture and inference work lands.
+2. Keep new capture and inference instrumentation on the injected `Logger` pattern.
 3. Extract the Electron and renderer seams needed for clean tests.
 4. Create a reusable replay/transcript fixture corpus under `tests/fixtures/`.
 5. Add one temp-file watcher integration test before implementing the full session manager.
@@ -426,124 +426,55 @@ of the implementation path.
 
 ## Logging Architecture Redesign
 
-### Current state (post-PR #100)
+### Implemented state
 
-The `StructuredLogger` in `src/shared/logger.ts` is a concrete class with no interface.
-Modules create loggers at import time:
+`src/shared/logger.ts` now exposes a `Logger` interface, `StructuredLogger` implements it,
+and `createTestLogger()` provides a quiet in-memory logger for assertions. Tests no longer
+need `vi.hoisted` environment mutation or console spies to verify structured log output.
 
-```typescript
-// src/persistence/file-replay-store.ts (module scope)
-const logger = createLogger({ /* ... */ });
+The injectable logger pattern is in place for the high-value diagnostic paths:
 
-// src/electron/session-io.ts (module scope)
-const logger = createLogger();
-```
+- persistence: `FileReplayStore`
+- Electron/session IO: `createSnapshot`, `loadSnapshotFromFile`, `buildFixtureSnapshot`,
+  `saveReplayFile`
+- capture state: `SessionManager`, `EventBuffer`
+- inference: credential loading, direct Anthropic, OpenAI-compatible, OpenCode, provider
+  selection, trigger, response parser, and `createInferenceEngine`
 
-Tests cannot reach these module-scope singleton instances. To verify log output,
-`tests/instrumentation-sampling.test.ts` uses a convoluted workaround:
+Default behavior is unchanged: when no logger is supplied, these modules create the same
+real structured logger locally. Tests pass `createTestLogger()` and assert through
+`logger.getRecent()` so the observed event stream is the test surface.
 
-```typescript
-// Pin the level before any imports run (lock is at import time)
-const ORIGINAL_LOG_LEVEL = vi.hoisted(() => {
-  const prev = process.env['SHADOW_LOG_LEVEL'];
-  process.env['SHADOW_LOG_LEVEL'] = 'debug';
-  return prev;
-});
+### Remaining follow-up
 
-// Spy on console.log — the only observable side effect
-function captureStructuredConsole() {
-  return vi.spyOn(console, 'log').mockImplementation(() => undefined);
-}
-```
+Some peripheral entry surfaces still create their own logger because they are currently
+tested as startup or transport boundaries rather than shared instrumentation units:
 
-This is fragile, order-dependent, and couples tests to `console.log` format strings.
+- Electron app startup in `src/electron/start-main-process.ts`
+- capture transports and low-level parser/discovery helpers
+- MCP server startup
 
-### Design problems
+Do not churn those surfaces just to eliminate every local `createLogger()` call. Migrate them
+when a behavioral change needs a shared parent logger, a diagnostics export, or focused log
+assertions.
 
-1. **No `Logger` interface.** Only a concrete class. Every module imports `StructuredLogger`
-   directly with full knowledge of its constructor signature.
-2. **Import-time side effects.** `createLogger()` reads `SHADOW_LOG_LEVEL` from
-   `process.env` and locks the level at module load. Changing the level dynamically or
-   per-test requires `vi.hoisted` + env mutation before import.
-3. **Three output sinks, one testable.** The logger writes to a memory ring buffer
-   (`getRecent()`), `console.log`, and optionally a file. The memory ring is the ideal test
-   surface, but tests can't reach the module-scope instances.
-4. **No test double.** There is no `createTestLogger()` or `InMemoryLogger`. The
-   `FakeEventBuffer` / `FakeCheckpointBuffer` pattern used in
-   `tests/inference/shadow-inference-engine.test.ts` shows the team understands this pattern —
-   the logger just never got the same treatment.
+### Usage pattern
 
-### Proposed architecture
-
-**Step 1: Extract a `Logger` interface.**
+Production entry points either create a real logger or accept one from a parent subsystem:
 
 ```typescript
-// src/shared/logger.ts
-export interface Logger {
-  debug(domain: LogDomain, event: string, context?: Record<string, unknown>): void;
-  info(domain: LogDomain, event: string, context?: Record<string, unknown>): void;
-  warn(domain: LogDomain, event: string, context?: Record<string, unknown>): void;
-  error(domain: LogDomain, event: string, context?: Record<string, unknown>): void;
-  getRecent(limit?: number): LogEntry[];
-}
+const logger = createLogger({ minLevel: 'info' });
+const engine = createInferenceEngine({ buffer, getState, onInsights, logger });
 ```
 
-`StructuredLogger` implements `Logger`. No behavioral change.
-
-**Step 2: Add a `TestLogger` for test code.**
+Tests use the in-memory logger:
 
 ```typescript
-// src/shared/logger.ts (or tests/helpers/test-logger.ts)
-export function createTestLogger(): StructuredLogger {
-  return new StructuredLogger({
-    includeConsole: false,   // don't spam CI
-    memoryCapacity: 500,
-  });
-}
+const logger = createTestLogger();
+const store = new FileReplayStore(tmpDir, { logger });
+
+expect(logger.getRecent()).toContainEqual(expect.objectContaining({
+  domain: 'persistence',
+  event: 'persistence.replay.saved',
+}));
 ```
-
-Tests import `createTestLogger()`, pass it to the system under test, and assert via
-`logger.getRecent()`. No `vi.hoisted`, no `console.log` spy, no env mutation.
-
-**Step 3: Accept `Logger` via constructor parameter (opt-in DI).**
-
-Modules that create loggers at import time add an optional parameter:
-
-```typescript
-// src/persistence/file-replay-store.ts
-export class FileReplayStore {
-  constructor(
-    rootDir: string,
-    private readonly logger: Logger = createLogger()
-  ) {}
-}
-```
-
-Default parameter preserves backward compatibility. Tests pass `createTestLogger()`.
-
-**Step 4: Remove module-scope singleton loggers.**
-
-Once all consumers accept `Logger` via constructor, remove the module-scope `createLogger()`
-calls. The handful of top-level entry points (main process, preload, renderer) create
-the real `StructuredLogger` instances.
-
-### Migration path (least-disruptive order)
-
-| Order | Step | Breakage risk | Files touched |
-|-------|------|---------------|---------------|
-| 1 | Extract `interface Logger` | None — `StructuredLogger` already matches the shape | 1 file |
-| 2 | Add `createTestLogger()` | None — new function | 1 file |
-| 3 | Add optional `logger` param to `FileReplayStore` | None — defaults to current behavior | 1 file |
-| 4 | Add optional `logger` param to `session-io` functions | None | 1 file |
-| 5 | Rewrite `instrumentation-sampling.test.ts` to use `createTestLogger()` | None — test rewrite only | 1 file |
-| 6 | Remove `captureStructuredConsole()` and `vi.hoisted` from tests | None | 1 file |
-| 7 | Thread `Logger` through remaining modules | None — all optional params | ~5 files |
-| 8 | Remove module-scope `createLogger()` calls, pass from entry points | Minimal | ~5 files |
-
-### Impact on existing tests
-
-- `tests/logger.test.ts` — unchanged (tests `StructuredLogger` directly, which is correct).
-- `tests/instrumentation-sampling.test.ts` — simplified: imports `createTestLogger()`, passes
-  it to `FileReplayStore`/`session-io`, asserts `logger.getRecent()`.
-- All other tests — unchanged (they don't interact with the logger).
-

--- a/docs/plans/roadmap.md
+++ b/docs/plans/roadmap.md
@@ -4,13 +4,13 @@ The canonical forward plan. Read [`../north-star.md`](../north-star.md) for *wha
 *why*; this is *what's next, in order*. Older `plan-*.md` files in this folder are historical
 context from the pre-reset era — this document supersedes them.
 
-## Baseline (where we actually are, 2026-05-30)
+## Baseline (where we actually are, 2026-06-02)
 
 After the great-cleanup reset, this is one flat Electron app — no monorepo, no `third_party/`,
 no dead scaffolding. Verified facts, not aspirations:
 
 - **Builds** from the repo root (`npm run build`, exit 0) and **launches** (`npm start`).
-- **47 test files / 427 tests pass** (`npm test` = `tsc --noEmit` + vitest).
+- **46 regular test files / 372 tests pass** (`npm test` = `tsc --noEmit` + vitest).
 - **It renders.** The built app mounts the dashboard and live-tails a real Claude Code
   session (the `file://` asset-path + index-path bugs that left it blank are fixed).
 - **Watch** works against Claude Code JSONL. **Interpret** is wired (local-only default).
@@ -64,11 +64,11 @@ Visual fidelity is priority #1 (per the north star).
   AgentVisualCrazy product name. This is a behavior-affecting refactor (credential paths, env
   vars) — deliberate, not casual. Deferred until someone decides it's worth the churn.
 - **CI green check.** Confirm the flattened `.github/workflows/ci.yml` passes on the first push.
-- **Logger interface + DI redesign.** `StructuredLogger` has no interface and module-scope
-  singletons force tests to spy on `console.log` with `vi.hoisted` hacks. Extract `interface
-  Logger`, thread it via constructor parameters, add `createTestLogger()` for in-memory
-  assertion. See `docs/plans/plan-testing-observability.md#logging-architecture-redesign`.
-- **Remaining weak test cleanup.** After PR #100 eliminated all FICTION tests, 4 D-grade and
-  3 WEAK files remain (see `docs/audits/README.md`). Strengthen: IPC bridge (2 tests for 145
-  lines), host.ts (1 test), renderer-surface-adapter (1 test), record-2d-context (tests the
-  helper, not production code).
+- **Logger DI follow-through.** `Logger`, `createTestLogger()`, and injected structured
+  loggers are now in place for persistence/session IO, event buffering/session management,
+  and the inference auth/provider/engine path. Remaining singleton cleanup is limited to
+  peripheral entry surfaces such as app startup, capture transports, and MCP; handle those
+  when the surrounding behavior changes.
+- **Remaining weak test cleanup.** After PR #100 eliminated all FICTION tests, keep
+  strengthening the weak surfaces tracked in `docs/audits/README.md`: IPC bridge, renderer
+  host/surface, static host, Electron startup wiring, and recorder-backed renderer coverage.

--- a/src/inference/auth.ts
+++ b/src/inference/auth.ts
@@ -13,10 +13,9 @@
 import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { createLogger } from '../shared/logger';
+import { createLogger, type Logger } from '../shared/logger';
 import { parseDotenv } from '../shared/dotenv';
 
-const logger = createLogger({ minLevel: 'info' });
 const SECURE_STORE_DIR_MODE = 0o700;
 const SECURE_STORE_FILE_MODE = 0o600;
 
@@ -48,6 +47,7 @@ export interface CredentialLoaderOptions {
   env?: NodeJS.ProcessEnv;
   homeDir?: string;
   safeStorage?: SafeStorageLike | null;
+  logger?: Logger;
 }
 
 function setIfMissing(env: NodeJS.ProcessEnv, key: string, value: string): boolean {
@@ -112,7 +112,8 @@ async function ensureSecurePath(pathToWrite: string, mode: number): Promise<void
 async function readSecureStore(
   env: NodeJS.ProcessEnv,
   secureStorePath: string,
-  safeStorage: SafeStorageLike | null
+  safeStorage: SafeStorageLike | null,
+  logger: Logger
 ): Promise<Record<string, string>> {
   if (!safeStorage || !safeStorage.isEncryptionAvailable()) {
     logger.info('inference', 'auth.secure_store_unavailable', { path: secureStorePath });
@@ -177,7 +178,8 @@ async function writeSecureStore(
 
 async function loadDotenvFile(
   env: NodeJS.ProcessEnv,
-  envPath: string
+  envPath: string,
+  logger: Logger
 ): Promise<Record<string, string>> {
   try {
     const contents = await readFile(envPath, 'utf8');
@@ -204,7 +206,8 @@ async function loadDotenvFile(
 
 async function loadOpencodeAuth(
   env: NodeJS.ProcessEnv,
-  authPath: string
+  authPath: string,
+  logger: Logger
 ): Promise<Record<string, string>> {
   try {
     const raw = await readFile(authPath, 'utf8');
@@ -236,14 +239,15 @@ async function loadOpencodeAuth(
  * Reports which provider keys are now available (without logging values).
  */
 export async function loadCredentials(options: CredentialLoaderOptions = {}): Promise<void> {
+  const logger = options.logger ?? createLogger({ minLevel: 'info' });
   const env = options.env ?? process.env;
   const homeDirPath = options.homeDir ?? homedir();
   const secureStorePath = getSecureStorePath(homeDirPath);
   const safeStorage = await getSafeStorage(options);
-  const secureStoreCredentials = await readSecureStore(env, secureStorePath, safeStorage);
+  const secureStoreCredentials = await readSecureStore(env, secureStorePath, safeStorage, logger);
 
-  const dotenvCredentials = await loadDotenvFile(env, getLegacyDotenvPath(homeDirPath));
-  const opencodeCredentials = await loadOpencodeAuth(env, getOpencodeAuthPath(homeDirPath));
+  const dotenvCredentials = await loadDotenvFile(env, getLegacyDotenvPath(homeDirPath), logger);
+  const opencodeCredentials = await loadOpencodeAuth(env, getOpencodeAuthPath(homeDirPath), logger);
   const migratedCredentials = filterSupportedCredentials({
     ...dotenvCredentials,
     ...opencodeCredentials,

--- a/src/inference/direct-api.ts
+++ b/src/inference/direct-api.ts
@@ -7,9 +7,7 @@
  * Implements InferenceClient so it's a drop-in alternative to the OpenCode client.
  */
 import type { InferenceClient, InferenceRequest, InferenceResult } from './inference-client';
-import { createLogger } from '../shared/logger';
-
-const logger = createLogger({ minLevel: 'info' });
+import { createLogger, type Logger } from '../shared/logger';
 
 const MODEL = 'claude-sonnet-4-5';
 const MAX_TOKENS = 1024;
@@ -40,6 +38,7 @@ export interface DirectApiClientDependencies {
   model?: string;
   loadSdk?: () => Promise<{ default: AnthropicSdkConstructor }>;
   now?: () => number;
+  logger?: Logger;
 }
 
 async function loadAnthropicSdk(): Promise<{ default: AnthropicSdkConstructor }> {
@@ -53,6 +52,7 @@ async function loadAnthropicSdk(): Promise<{ default: AnthropicSdkConstructor }>
 export async function createDirectApiClient(
   deps: DirectApiClientDependencies = {}
 ): Promise<InferenceClient | null> {
+  const logger = deps.logger ?? createLogger({ minLevel: 'info' });
   const apiKey = deps.apiKey ?? process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
     logger.warn('inference', 'direct_api.no_key');

--- a/src/inference/inference-client-factory.ts
+++ b/src/inference/inference-client-factory.ts
@@ -8,27 +8,35 @@ import type { InferenceClient } from './inference-client';
 import { createDirectApiClient } from './direct-api';
 import { createOpencodeClient } from './opencode-client';
 import { createOpenAiCompatibleClient } from './openai-compatible-client';
+import type { Logger } from '../shared/logger';
 
-export async function createInferenceClient(): Promise<InferenceClient | null> {
+export interface InferenceClientFactoryDependencies {
+  logger?: Logger;
+}
+
+export async function createInferenceClient(
+  deps: InferenceClientFactoryDependencies = {}
+): Promise<InferenceClient | null> {
   const preference = process.env.SHADOW_INFERENCE_PROVIDER?.trim().toLowerCase();
+  const providerDeps = deps.logger ? { logger: deps.logger } : undefined;
 
   if (preference === 'anthropic' || preference === 'direct') {
-    return createDirectApiClient();
+    return createDirectApiClient(providerDeps);
   }
 
   if (preference === 'openai' || preference === 'openai-compatible') {
-    return createOpenAiCompatibleClient();
+    return createOpenAiCompatibleClient(providerDeps);
   }
 
   if (preference === 'opencode') {
-    const opencode = await createOpencodeClient();
-    return opencode ?? createDirectApiClient();
+    const opencode = await createOpencodeClient(providerDeps);
+    return opencode ?? createDirectApiClient(providerDeps);
   }
 
-  const opencode = await createOpencodeClient();
+  const opencode = await createOpencodeClient(providerDeps);
   if (opencode) {
     return opencode;
   }
 
-  return createDirectApiClient();
+  return createDirectApiClient(providerDeps);
 }

--- a/src/inference/openai-compatible-client.ts
+++ b/src/inference/openai-compatible-client.ts
@@ -16,9 +16,7 @@
  * and a missing base URL / fetch returns null so the engine degrades gracefully.
  */
 import type { InferenceClient, InferenceRequest, InferenceResult } from './inference-client';
-import { createLogger } from '../shared/logger';
-
-const logger = createLogger({ minLevel: 'info' });
+import { createLogger, type Logger } from '../shared/logger';
 
 const DEFAULT_MODEL = 'gpt-4o-mini';
 const DEFAULT_TIMEOUT_MS = 60_000;
@@ -35,11 +33,13 @@ export interface OpenAiCompatibleClientDependencies {
   timeoutMs?: number;
   fetchImpl?: typeof fetch;
   now?: () => number;
+  logger?: Logger;
 }
 
 export function createOpenAiCompatibleClient(
   deps: OpenAiCompatibleClientDependencies = {}
 ): InferenceClient | null {
+  const logger = deps.logger ?? createLogger({ minLevel: 'info' });
   const baseUrl = deps.baseUrl ?? process.env.OPENAI_BASE_URL ?? process.env.SHADOW_INFERENCE_BASE_URL;
   if (!baseUrl) {
     logger.warn('inference', 'openai_compatible.no_base_url');

--- a/src/inference/opencode-client.ts
+++ b/src/inference/opencode-client.ts
@@ -5,9 +5,7 @@
  * sidecar's 4096), creates a session, sends prompts, and polls for completion.
  */
 import type { InferenceClient, InferenceRequest, InferenceResult } from './inference-client';
-import { createLogger } from '../shared/logger';
-
-const logger = createLogger({ minLevel: 'info' });
+import { createLogger, type Logger } from '../shared/logger';
 
 const DEFAULT_PORT = 4097;
 const POLL_INTERVAL_MS = 1_000;
@@ -21,6 +19,7 @@ export interface OpencodeClientDependencies {
   now?: () => number;
   pollIntervalMs?: number;
   pollTimeoutMs?: number;
+  logger?: Logger;
 }
 
 interface OpencodeSdkModule {
@@ -106,6 +105,7 @@ async function pollForAssistantText(
 export async function createOpencodeClient(
   deps: OpencodeClientDependencies = {}
 ): Promise<InferenceClient | null> {
+  const logger = deps.logger ?? createLogger({ minLevel: 'info' });
   const now = deps.now ?? Date.now;
   const pollIntervalMs = deps.pollIntervalMs ?? POLL_INTERVAL_MS;
   const pollTimeoutMs = deps.pollTimeoutMs ?? POLL_TIMEOUT_MS;

--- a/src/inference/response-parser.ts
+++ b/src/inference/response-parser.ts
@@ -10,9 +10,7 @@
  *   observations[i] → {kind: 'summary'}
  */
 import type { ShadowInsight, InsightKind } from '../shared/schema';
-import { createLogger } from '../shared/logger';
-
-const logger = createLogger({ minLevel: 'info' });
+import { createLogger, type Logger } from '../shared/logger';
 
 interface ModelResponse {
   phase?: string;
@@ -132,7 +130,10 @@ function makeInsight(
   };
 }
 
-export function parseModelResponse(text: string): ShadowInsight[] {
+export function parseModelResponse(
+  text: string,
+  logger: Logger = createLogger({ minLevel: 'info' })
+): ShadowInsight[] {
   const parsed = parseModelObject(text);
 
   if (!parsed) {

--- a/src/inference/shadow-inference-engine.ts
+++ b/src/inference/shadow-inference-engine.ts
@@ -10,7 +10,7 @@ import type {
   DerivedState,
   ShadowInsight
 } from '../shared/schema';
-import { createLogger } from '../shared/logger';
+import { createLogger, type Logger } from '../shared/logger';
 import { buildContextPacket } from './context-packager';
 import { buildInferenceRequest } from './prompt-builder';
 import { parseModelResponse } from './response-parser';
@@ -20,7 +20,6 @@ import { loadCredentials } from './auth';
 import type { InferenceClient } from './inference-client';
 import type { EventBufferLike } from './inference-client';
 
-const logger = createLogger({ minLevel: 'info' });
 const INFERENCE_CONSUMER_ID = 'inference-trigger';
 
 export type InsightCallback = (insights: ShadowInsight[]) => void;
@@ -31,6 +30,7 @@ export interface InferenceEngineOptions {
   onInsights: InsightCallback;
   triggerConfig?: Partial<TriggerConfig>;
   client?: InferenceClient;
+  logger?: Logger;
 }
 
 export interface InferenceEngine {
@@ -52,6 +52,7 @@ function isCheckpointedEventBuffer(buffer: EventBufferLike): buffer is Checkpoin
 
 export function createInferenceEngine(opts: InferenceEngineOptions): InferenceEngine {
   const { buffer, getState, onInsights } = opts;
+  const logger = opts.logger ?? createLogger({ minLevel: 'info' });
   let client: InferenceClient | null = null;
   let inflight = false;
   let pendingTrigger = false;
@@ -76,7 +77,7 @@ export function createInferenceEngine(opts: InferenceEngineOptions): InferenceEn
 
       logger.info('inference', 'engine.run_start', { eventCount: events.length });
       const inferenceResponse = await client.infer(request);
-      const insights = parseModelResponse(inferenceResponse.text);
+      const insights = parseModelResponse(inferenceResponse.text, logger);
 
       logger.info('inference', 'engine.run_done', {
         latencyMs: inferenceResponse.latencyMs,
@@ -97,7 +98,7 @@ export function createInferenceEngine(opts: InferenceEngineOptions): InferenceEn
     }
   };
 
-  const trigger = createInferenceTrigger(() => void runInference(), opts.triggerConfig);
+  const trigger = createInferenceTrigger(() => void runInference(), opts.triggerConfig, logger);
 
   const drainPendingEvents = async () => {
     if (!checkpointBuffer) {
@@ -138,9 +139,9 @@ export function createInferenceEngine(opts: InferenceEngineOptions): InferenceEn
 
   return {
     async start() {
-      await loadCredentials();
+      await loadCredentials({ logger });
 
-      client = opts.client ?? await createInferenceClient();
+      client = opts.client ?? await createInferenceClient({ logger });
 
       if (!client) {
         logger.warn('inference', 'engine.no_client', {

--- a/src/inference/trigger.ts
+++ b/src/inference/trigger.ts
@@ -9,9 +9,7 @@
  *   - Specific event kinds: tool_failed, agent_completed always trigger immediately
  */
 import type { CanonicalEvent, EventKind } from '../shared/schema';
-import { createLogger } from '../shared/logger';
-
-const logger = createLogger({ minLevel: 'info' });
+import { createLogger, type Logger } from '../shared/logger';
 
 const IMMEDIATE_KINDS = new Set<EventKind>(['tool_failed', 'agent_completed']);
 
@@ -37,7 +35,8 @@ export interface InferenceTrigger {
 
 export function createInferenceTrigger(
   onTrigger: TriggerCallback,
-  config: Partial<TriggerConfig> = {}
+  config: Partial<TriggerConfig> = {},
+  logger: Logger = createLogger({ minLevel: 'info' })
 ): InferenceTrigger {
   const cfg = { ...DEFAULT_CONFIG, ...config };
   let eventsSinceLastInference = 0;

--- a/tests/inference-auth.test.ts
+++ b/tests/inference-auth.test.ts
@@ -6,6 +6,7 @@ import {
   SECURE_CREDENTIAL_STORE_FILE,
   loadCredentials,
 } from '../src/inference/auth';
+import { createTestLogger } from '../src/shared/logger';
 
 const tempRoots: string[] = [];
 
@@ -77,6 +78,34 @@ describe('loadCredentials', () => {
     expect(env.ANTHROPIC_API_KEY).toBe('sk-secure-anthropic');
     expect(env.OPENAI_API_KEY).toBe('sk-secure-openai');
     expect(env.UNUSED_SECRET).toBeUndefined();
+  });
+
+  it('writes credential readiness diagnostics to an injected logger', async () => {
+    const homeDir = await createTempHomeDir('logger');
+    const env: NodeJS.ProcessEnv = {};
+    const logger = createTestLogger();
+    const options = {
+      env,
+      homeDir,
+      safeStorage: null,
+      logger,
+    };
+
+    await loadCredentials(options);
+
+    expect(logger.getRecent()).toContainEqual(expect.objectContaining({
+      domain: 'inference',
+      event: 'auth.secure_store_unavailable',
+      level: 'info',
+    }));
+    expect(logger.getRecent()).toContainEqual(expect.objectContaining({
+      domain: 'inference',
+      event: 'auth.credentials_ready',
+      level: 'info',
+      context: expect.objectContaining({
+        providers: [],
+      }),
+    }));
   });
 
   it('does not override process env values with secure-store credentials', async () => {

--- a/tests/inference/direct-api.test.ts
+++ b/tests/inference/direct-api.test.ts
@@ -1,10 +1,25 @@
 import { describe, expect, it } from 'vitest';
 import { createDirectApiClient } from '../../src/inference/direct-api';
+import { createTestLogger } from '../../src/shared/logger';
 
 describe('createDirectApiClient', () => {
   it('returns null when no API key is available', async () => {
     const client = await createDirectApiClient({ apiKey: '' });
     expect(client).toBeNull();
+  });
+
+  it('writes no-key diagnostics to an injected logger', async () => {
+    const logger = createTestLogger();
+    const deps = { apiKey: '', logger };
+
+    const client = await createDirectApiClient(deps);
+
+    expect(client).toBeNull();
+    expect(logger.getRecent()).toContainEqual(expect.objectContaining({
+      domain: 'inference',
+      event: 'direct_api.no_key',
+      level: 'warn',
+    }));
   });
 
   it('returns null when the Anthropic SDK is unavailable', async () => {

--- a/tests/inference/inference-client-factory.test.ts
+++ b/tests/inference/inference-client-factory.test.ts
@@ -3,6 +3,7 @@ import * as directApi from '../../src/inference/direct-api';
 import * as opencodeClient from '../../src/inference/opencode-client';
 import * as openaiClient from '../../src/inference/openai-compatible-client';
 import { createInferenceClient } from '../../src/inference/inference-client-factory';
+import { createTestLogger } from '../../src/shared/logger';
 
 describe('createInferenceClient', () => {
   afterEach(() => {
@@ -24,6 +25,18 @@ describe('createInferenceClient', () => {
 
     expect(client).toBe(direct);
     expect(opencodeClient.createOpencodeClient).not.toHaveBeenCalled();
+  });
+
+  it('passes an injected logger to the selected provider factory', async () => {
+    process.env.SHADOW_INFERENCE_PROVIDER = 'anthropic';
+    const logger = createTestLogger();
+    const direct = { id: 'anthropic-direct-api', provider: 'anthropic' as const, infer: vi.fn() };
+    vi.spyOn(directApi, 'createDirectApiClient').mockResolvedValue(direct);
+
+    const client = await createInferenceClient({ logger });
+
+    expect(client).toBe(direct);
+    expect(directApi.createDirectApiClient).toHaveBeenCalledWith(expect.objectContaining({ logger }));
   });
 
   it('uses OpenCode when available and no provider override is set', async () => {

--- a/tests/inference/openai-compatible-client.test.ts
+++ b/tests/inference/openai-compatible-client.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createOpenAiCompatibleClient } from '../../src/inference/openai-compatible-client';
+import { createTestLogger } from '../../src/shared/logger';
 
 function jsonResponse(body: unknown, status = 200): Response {
   return {
@@ -21,6 +22,20 @@ describe('createOpenAiCompatibleClient', () => {
   it('returns null when no base URL is configured', () => {
     const client = createOpenAiCompatibleClient({ fetchImpl: vi.fn() as unknown as typeof fetch });
     expect(client).toBeNull();
+  });
+
+  it('writes missing-base-url diagnostics to an injected logger', () => {
+    const logger = createTestLogger();
+    const deps = { fetchImpl: vi.fn() as unknown as typeof fetch, logger };
+
+    const client = createOpenAiCompatibleClient(deps);
+
+    expect(client).toBeNull();
+    expect(logger.getRecent()).toContainEqual(expect.objectContaining({
+      domain: 'inference',
+      event: 'openai_compatible.no_base_url',
+      level: 'warn',
+    }));
   });
 
   it('reports openai provider identity', () => {

--- a/tests/inference/opencode-client.test.ts
+++ b/tests/inference/opencode-client.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { createOpencodeClient } from '../../src/inference/opencode-client';
+import { createTestLogger } from '../../src/shared/logger';
 
 describe('createOpencodeClient', () => {
   it('returns null when the OpenCode SDK cannot be loaded', async () => {
@@ -10,6 +11,25 @@ describe('createOpencodeClient', () => {
     });
 
     expect(client).toBeNull();
+  });
+
+  it('writes SDK-load diagnostics to an injected logger', async () => {
+    const logger = createTestLogger();
+    const deps = {
+      logger,
+      loadSdk: async () => {
+        throw new Error('missing sdk');
+      }
+    };
+
+    const client = await createOpencodeClient(deps);
+
+    expect(client).toBeNull();
+    expect(logger.getRecent()).toContainEqual(expect.objectContaining({
+      domain: 'inference',
+      event: 'opencode.sdk_not_available',
+      level: 'warn',
+    }));
   });
 
   it('returns null when the OpenCode server fails to start', async () => {

--- a/tests/inference/shadow-inference-engine.test.ts
+++ b/tests/inference/shadow-inference-engine.test.ts
@@ -7,6 +7,7 @@ import type { CanonicalEvent, DerivedState, EventQueueCheckpoint } from '../../s
 import type { ShadowInsight } from '../../src/shared/schema';
 import type { EventBufferLike } from '../../src/inference/inference-client';
 import { FakeInferenceClient } from '../helpers/fake-inference-client';
+import { createTestLogger } from '../../src/shared/logger';
 
 const FIXTURES = join(fileURLToPath(new URL('.', import.meta.url)), '../fixtures/replays');
 
@@ -169,6 +170,45 @@ describe('createInferenceEngine — orchestrator integration', () => {
     expect(insights.some((i) => i.kind === 'phase')).toBe(true);
     expect(insights.some((i) => i.kind === 'next_move')).toBe(true);
     engine.stop();
+  });
+
+  it('routes engine, trigger, and parser logs through an injected logger', async () => {
+    const logger = createTestLogger();
+    const onInsights = vi.fn();
+    const buffer = new FakeEventBuffer();
+    client.enqueue({
+      text: 'not json at all',
+      model: 'fake/1',
+      latencyMs: 5,
+    });
+
+    const engineOptions = {
+      buffer,
+      getState: async () => derivedState({ activePhase: 'debugging' }),
+      onInsights,
+      client,
+      logger,
+    };
+    const engine = createInferenceEngine(engineOptions);
+
+    await engine.start();
+    buffer.push(makeEvent('e1', 'tool_failed'));
+
+    await vi.waitFor(() => {
+      expect(client.calls.length).toBe(1);
+    });
+    engine.stop();
+
+    expect(onInsights).not.toHaveBeenCalled();
+    const eventNames = logger.getRecent(100).map((entry) => entry.event);
+    expect(eventNames).toEqual(expect.arrayContaining([
+      'engine.started',
+      'trigger.fired',
+      'engine.run_start',
+      'response_parser.json_parse_failed',
+      'engine.run_done',
+      'engine.stopped',
+    ]));
   });
 
   it('propagates inference errors gracefully and allows subsequent runs', async () => {


### PR DESCRIPTION
## Summary
- Thread injected `Logger` dependencies through inference credential loading, provider factories, trigger/parser, and `createInferenceEngine`.
- Add focused regression coverage proving provider/auth/engine logs reach `createTestLogger()` via `logger.getRecent()`.
- Update roadmap, audit, and observability docs so logger DI is described as implemented for capture and inference paths.
- Make Doppler-backed live tests a hard pre-push gate when Doppler is installed, and normalize hook files to LF.

## Why
Logger DI makes structured diagnostics directly assertable without import-order environment mutation or console spies. The remaining singleton cleanup is intentionally deferred to peripheral entry surfaces until those surfaces need shared diagnostics, a diagnostics export, or focused log assertions. The pre-push hook now treats Doppler-backed live inference as a real gate so a failed live model call cannot be hidden by a skip-capable fallback run.

## Validation
- `git diff --check`
- `npm test` (46 files, 372 tests)
- `npm run build`
- `npm run test:live:infer` (2 live files, 4 tests passed; DeepSeek returned model insights)
- Pre-push hook after hard-gate fix: `npm test`; Doppler-backed `npm run test:live` (2 live files, 4 tests passed; DeepSeek returned model insights)
- PR checks: CI `test`, GitGuardian, Kilo Code Review, and CodeRabbit passed before the hook follow-up; CI is expected to rerun on the new commit.

## Notes
- Stacked PR base is `feat/logger-di-and-doc-cleanup` because this branch was intentionally created from that branch and the base branch was local-only before publication.
- `doppler.yaml` commits only project/config names (`ai-models` / `dev`), not secret values.