### PR TITLE
feat: codex rollout harness driver

### DIFF
--- a/src/capture/drivers/codex/capabilities.ts
+++ b/src/capture/drivers/codex/capabilities.ts
@@ -1,0 +1,37 @@
+import type { HarnessCapabilities } from '../harness-driver';
+
+/**
+ * Risk heuristic IDs map 1:1 to checks in `shared/derive.ts:collectRiskSignals`.
+ * See claude-code/capabilities.ts for the general rationale.
+ *
+ * Codex-specific notes:
+ * - `repeated_searches` is new for Codex (the GHCR-403 stuck signature: n>=3
+ *   near-identical web_search queries in a window). It is implemented
+ *   capability-driven in derive.ts, not as Codex-only branching, so any other
+ *   driver can opt in by declaring the same ID.
+ * - `toolNameMap` normalizes Codex's tool vocabulary onto the same generic
+ *   names derive.ts's phase detection and shell_churn/exploration_volume
+ *   checks already key off of (Claude Code's `Edit`/`Bash`/etc equivalents):
+ *   `apply_patch` -> `edit` so patch application is recognized as
+ *   implementation work, and `exec` -> `bash` so shell_churn can see Codex's
+ *   shell tool. Without this map those two checks would be permanently dead
+ *   for Codex sessions despite being declared.
+ */
+export const codexCapabilities: HarnessCapabilities = {
+  // Codex's `wait` tool call surfaces coordinator/subagent polling, but v1
+  // does not reconstruct subagent topology from it (see plan-codex-replay.md
+  // non-goals). Keep this false until that upgrade lands.
+  emitsSubagentEvents: false,
+  fileAttention: 'tool-args',
+  toolNameMap: (name) => {
+    if (name === 'apply_patch') return 'edit';
+    if (name === 'exec') return 'bash';
+    return name;
+  },
+  riskHeuristics: [
+    'tool_failures',
+    'shell_churn',
+    'exploration_volume',
+    'repeated_searches',
+  ],
+};

--- a/src/capture/drivers/codex/discovery.ts
+++ b/src/capture/drivers/codex/discovery.ts
@@ -1,0 +1,98 @@
+/**
+ * Codex session discovery: locates the active rollout JSONL file under
+ * `~/.codex/sessions/` (Codex CLI nests these `YYYY/MM/DD/rollout-*.jsonl`,
+ * but we walk recursively rather than assuming that exact shape so future
+ * layout changes don't silently break discovery).
+ *
+ * Mirrors claude-code/discovery.ts's structure; see that file's header for
+ * the general discovery-strategy rationale.
+ */
+import { readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import type {
+  DiscoveryStrategy,
+  DriverDiscoveredSession,
+} from '../harness-driver';
+import { createLogger } from '../../../shared/logger';
+
+const logger = createLogger({ minLevel: 'info' });
+
+const SOURCE = 'codex-rollout' as const;
+
+/**
+ * UUID suffix at the end of a Codex rollout filename, e.g.
+ * `rollout-2026-07-23T12-16-30-019f8ee7-e51f-7ed1-b650-b7fb11ffecda.jsonl`
+ * -> `019f8ee7-e51f-7ed1-b650-b7fb11ffecda`.
+ */
+const UUID_SUFFIX_RE = /([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$/;
+
+function getCodexSessionsDir(): string {
+  return process.env.CODEX_SESSIONS_DIR || path.join(os.homedir(), '.codex', 'sessions');
+}
+
+/** sessionId = the UUID suffix of the filename; fallback: full basename. */
+function extractSessionId(filePath: string): string {
+  const base = path.basename(filePath, path.extname(filePath));
+  const match = base.match(UUID_SUFFIX_RE);
+  return match ? match[1]! : base;
+}
+
+async function findRolloutFiles(
+  dir: string
+): Promise<Array<{ filePath: string; mtime: number }>> {
+  const results: Array<{ filePath: string; mtime: number }> = [];
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return results;
+  }
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry);
+    try {
+      const info = await stat(fullPath);
+      if (info.isDirectory()) {
+        const nested = await findRolloutFiles(fullPath);
+        results.push(...nested);
+      } else if (entry.startsWith('rollout-') && entry.endsWith('.jsonl')) {
+        results.push({ filePath: fullPath, mtime: info.mtimeMs });
+      }
+    } catch {
+      // Skip unreadable paths
+    }
+  }
+  return results;
+}
+
+export interface CodexDiscoveryOptions {
+  /** Override the discovery root. Defaults to `CODEX_SESSIONS_DIR` env var, then `~/.codex/sessions/`. */
+  sessionsDir?: string;
+}
+
+export function createCodexDiscovery(
+  options: CodexDiscoveryOptions = {}
+): DiscoveryStrategy {
+  return {
+    async discoverSessions(): Promise<DriverDiscoveredSession[]> {
+      const sessionsDir = options.sessionsDir ?? getCodexSessionsDir();
+      logger.debug('capture', 'codex_discovery.scan_start', { sessionsDir });
+
+      const files = await findRolloutFiles(sessionsDir);
+      if (files.length === 0) {
+        logger.debug('capture', 'codex_discovery.no_sessions_found', { sessionsDir });
+        return [];
+      }
+
+      return files.map(({ filePath, mtime }) => ({
+        filePath,
+        sessionId: extractSessionId(filePath),
+        lastModified: mtime,
+        source: SOURCE,
+      }));
+    },
+  };
+}
+
+export const codexDiscovery = createCodexDiscovery();

--- a/src/capture/drivers/codex/index.ts
+++ b/src/capture/drivers/codex/index.ts
@@ -1,0 +1,12 @@
+import type { HarnessDriver } from '../harness-driver';
+import { codexCapabilities } from './capabilities';
+import { normalizeEntry } from './normalizer';
+import { codexDiscovery } from './discovery';
+
+export const codexDriver: HarnessDriver = {
+  id: 'codex',
+  sources: ['codex-rollout'],
+  capabilities: codexCapabilities,
+  normalizeEntry,
+  discovery: codexDiscovery,
+};

--- a/src/capture/drivers/codex/normalizer.ts
+++ b/src/capture/drivers/codex/normalizer.ts
@@ -1,0 +1,510 @@
+/**
+ * Normalizes raw Codex rollout entries (`~/.codex/sessions/**\/rollout-*.jsonl`)
+ * into CanonicalEvents. See docs/plans/plan-codex-replay.md section D1 for the
+ * full mapping table this file implements; the table is reproduced inline
+ * above each branch below so this file stays readable without the doc open.
+ *
+ * Every event produced here carries harnessId: 'codex' and driverVersion:
+ * '0.1.0' (bumped when the mapping below changes shape).
+ *
+ * Determinism: event IDs are derived from `sessionId + entry index + intra-
+ * entry index`, not randomUUID(), so replaying the same file twice produces
+ * an identical ID sequence (required for deterministic replay, D3). The
+ * entry-index counter is per-session state that resets whenever a
+ * `session_meta` line is seen — every rollout file opens with exactly one,
+ * so starting (or restarting) a session naturally re-synchronizes the
+ * counter without needing an explicit "end of stream" hook that the
+ * single-entry `normalizeEntry(entry, sessionId, source)` signature has no
+ * room for.
+ */
+import type { CanonicalEvent, EventKind, EventSource } from '../../../shared/schema';
+import type { ParsedEntry } from '../../incremental-parser';
+import { createLogger } from '../../../shared/logger';
+
+const logger = createLogger({ minLevel: 'info' });
+
+const HARNESS_ID = 'codex' as const;
+const DRIVER_VERSION = '0.1.0' as const;
+const DEFAULT_SOURCE: EventSource = 'codex-rollout';
+
+/** Emit roughly 1 in this many `token_count` lines as `context_snapshot`. */
+const TOKEN_COUNT_SAMPLE_RATE = 10;
+
+// ---------------------------------------------------------------------------
+// Per-session state
+//
+// normalizeEntry is called once per parsed line by session-manager (and by
+// tests, directly). There is no session-lifecycle hook, so state that must
+// span calls (deterministic ID counters, the token_count sampler, the
+// user-message dedupe watermark) lives here, keyed by sessionId, and is
+// reset whenever a `session_meta` entry (always the first line of a rollout
+// file) is observed for that session.
+// ---------------------------------------------------------------------------
+
+const entryIndexBySession = new Map<string, number>();
+const tokenCountIndexBySession = new Map<string, number>();
+const lastUserMessageBySession = new Map<string, string | null>();
+
+function resetSessionState(sessionId: string): void {
+  entryIndexBySession.set(sessionId, 0);
+  tokenCountIndexBySession.set(sessionId, 0);
+  lastUserMessageBySession.set(sessionId, null);
+}
+
+function nextEntryIndex(sessionId: string): number {
+  const idx = entryIndexBySession.get(sessionId) ?? 0;
+  entryIndexBySession.set(sessionId, idx + 1);
+  return idx;
+}
+
+function buildId(sessionId: string, entryIndex: number, subIndex: number): string {
+  return `codex:${sessionId}:${entryIndex}:${subIndex}`;
+}
+
+// ---------------------------------------------------------------------------
+// Small shape helpers
+// ---------------------------------------------------------------------------
+
+function extractTimestamp(entry: ParsedEntry): string {
+  const ts = entry.timestamp;
+  if (typeof ts === 'string') return ts;
+  return new Date().toISOString();
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+}
+
+/** Concatenates the `.text` of every block in a Codex content array. */
+function extractContentText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((block) => {
+      const rec = asRecord(block);
+      return typeof rec.text === 'string' ? rec.text : '';
+    })
+    .filter((text) => text.length > 0)
+    .join('\n');
+}
+
+/** Flattens a Codex tool-output payload (string | block array | object) to text. */
+function outputToText(output: unknown): string {
+  if (typeof output === 'string') return output;
+  if (Array.isArray(output)) {
+    return output
+      .map((block) => {
+        const rec = asRecord(block);
+        return typeof rec.text === 'string' ? rec.text : '';
+      })
+      .filter((text) => text.length > 0)
+      .join('\n');
+  }
+  if (output && typeof output === 'object') {
+    try {
+      return JSON.stringify(output);
+    } catch {
+      return '';
+    }
+  }
+  return '';
+}
+
+/**
+ * Codex's `exec`-backed tool outputs (custom_tool_call_output,
+ * function_call_output) wrap results in a "Script completed"/"Script failed"
+ * envelope, usually followed by an "Exit code: N" line. Both signals are
+ * checked (OR'd) because some failures (e.g. a JS SyntaxError inside the
+ * sandboxed script) never print an exit code at all — verified against the
+ * PR-1 fixture: every case where the exit-code regex matched a nonzero code
+ * also had the "Script failed" first line, but not vice versa.
+ */
+function isScriptOutputError(output: unknown): boolean {
+  if (output && typeof output === 'object' && !Array.isArray(output)) {
+    const rec = output as Record<string, unknown>;
+    if (rec.success === false) return true;
+  }
+  const firstBlockText = Array.isArray(output)
+    ? (asRecord(output[0]).text as string | undefined) ?? ''
+    : typeof output === 'string'
+      ? output
+      : '';
+  if (/^Script failed/.test(firstBlockText)) return true;
+  const fullText = outputToText(output);
+  return /Exit code:\s*[1-9]\d*/.test(fullText);
+}
+
+function messageEvent(
+  sessionId: string,
+  source: EventSource,
+  timestamp: string,
+  entryIndex: number,
+  actor: string,
+  payload: Record<string, unknown>
+): CanonicalEvent {
+  return {
+    id: buildId(sessionId, entryIndex, 0),
+    sessionId,
+    source,
+    timestamp,
+    actor,
+    kind: 'message',
+    payload,
+    harnessId: HARNESS_ID,
+    driverVersion: DRIVER_VERSION,
+  };
+}
+
+function makeEvent(
+  sessionId: string,
+  source: EventSource,
+  timestamp: string,
+  entryIndex: number,
+  actor: string,
+  kind: EventKind,
+  payload: Record<string, unknown>
+): CanonicalEvent {
+  return {
+    id: buildId(sessionId, entryIndex, 0),
+    sessionId,
+    source,
+    timestamp,
+    actor,
+    kind,
+    payload,
+    harnessId: HARNESS_ID,
+    driverVersion: DRIVER_VERSION,
+  };
+}
+
+export function normalizeEntry(
+  entry: ParsedEntry,
+  sessionId: string,
+  source: EventSource = DEFAULT_SOURCE
+): CanonicalEvent[] {
+  const events: CanonicalEvent[] = [];
+  const timestamp = extractTimestamp(entry);
+  const type = typeof entry.type === 'string' ? entry.type : '';
+
+  if (type === 'session_meta') {
+    resetSessionState(sessionId);
+  }
+  const entryIndex = nextEntryIndex(sessionId);
+
+  const payload = asRecord(entry.payload);
+  const payloadType = typeof payload.type === 'string' ? payload.type : '';
+
+  // -- session_meta -> session_started -------------------------------------
+  if (type === 'session_meta') {
+    events.push(
+      makeEvent(sessionId, source, timestamp, entryIndex, 'system', 'session_started', {
+        cwd: typeof payload.cwd === 'string' ? payload.cwd : null,
+        originator: typeof payload.originator === 'string' ? payload.originator : null,
+        cliVersion: typeof payload.cli_version === 'string' ? payload.cli_version : null,
+        modelProvider: typeof payload.model_provider === 'string' ? payload.model_provider : null,
+      })
+    );
+    return events;
+  }
+
+  // -- top-level compacted -> context_snapshot -----------------------------
+  if (type === 'compacted') {
+    events.push(
+      makeEvent(sessionId, source, timestamp, entryIndex, 'system', 'context_snapshot', {
+        compacted: true,
+      })
+    );
+    return events;
+  }
+
+  // -- response_item / * ----------------------------------------------------
+  if (type === 'response_item') {
+    if (payloadType === 'message') {
+      const role = typeof payload.role === 'string' ? payload.role : '';
+      const text = extractContentText(payload.content);
+
+      if (role === 'assistant') {
+        events.push(messageEvent(sessionId, source, timestamp, entryIndex, 'agent', { text }));
+        return events;
+      }
+      if (role === 'user' || role === 'developer') {
+        events.push(messageEvent(sessionId, source, timestamp, entryIndex, 'user', { text }));
+        // Dedup watermark: only genuine user turns (not injected developer
+        // instructions) get mirrored by a later event_msg/user_message.
+        if (role === 'user') {
+          lastUserMessageBySession.set(sessionId, text.trim());
+        }
+        return events;
+      }
+      logger.debug('capture', 'codex_driver.unknown_message_role', { role });
+      return events;
+    }
+
+    if (payloadType === 'reasoning') {
+      const summaryArr = Array.isArray(payload.summary) ? payload.summary : [];
+      const summaryText = summaryArr
+        .map((block) => {
+          if (typeof block === 'string') return block;
+          const rec = asRecord(block);
+          return typeof rec.text === 'string' ? rec.text : '';
+        })
+        .filter((text) => text.length > 0)
+        .join('\n');
+      events.push(
+        messageEvent(sessionId, source, timestamp, entryIndex, 'agent', {
+          thinking: true,
+          summary: summaryText,
+        })
+      );
+      return events;
+    }
+
+    if (payloadType === 'custom_tool_call' || payloadType === 'function_call') {
+      const name = typeof payload.name === 'string' ? payload.name : 'unknown';
+      const toolUseId =
+        typeof payload.call_id === 'string'
+          ? payload.call_id
+          : typeof payload.id === 'string'
+            ? payload.id
+            : buildId(sessionId, entryIndex, 0);
+
+      let args: unknown;
+      if (payloadType === 'custom_tool_call') {
+        // custom_tool_call (Codex's `exec` encoding) carries raw JS source in
+        // `input` — keep it as-is, it is not JSON.
+        args = payload.input ?? {};
+      } else {
+        // function_call's `arguments` is (usually) a JSON string.
+        const raw = payload.arguments;
+        if (typeof raw === 'string') {
+          try {
+            args = JSON.parse(raw);
+          } catch {
+            args = raw;
+          }
+        } else {
+          args = raw ?? {};
+        }
+      }
+
+      const toolPayload: Record<string, unknown> = { toolName: name, toolUseId, args };
+      if (name === 'wait') {
+        // Coordinator-idle signature (D1): a `wait` call is the agent
+        // deliberately polling for a subagent/background task, not doing
+        // work itself. Flagged rather than dropped so consumers (derive.ts,
+        // the future replay report) can distinguish idle-poll churn from
+        // real tool activity without re-parsing args.
+        toolPayload.coordinatorIdle = true;
+      }
+      events.push(
+        makeEvent(sessionId, source, timestamp, entryIndex, 'agent', 'tool_started', toolPayload)
+      );
+      return events;
+    }
+
+    if (payloadType === 'custom_tool_call_output' || payloadType === 'function_call_output') {
+      const output = payload.output;
+      const failed = isScriptOutputError(output);
+      const toolUseId =
+        typeof payload.call_id === 'string' ? payload.call_id : buildId(sessionId, entryIndex, 0);
+      const text = outputToText(output);
+      events.push(
+        makeEvent(
+          sessionId,
+          source,
+          timestamp,
+          entryIndex,
+          'agent',
+          failed ? 'tool_failed' : 'tool_completed',
+          {
+            toolUseId,
+            output: text,
+            error: failed ? text : undefined,
+          }
+        )
+      );
+      return events;
+    }
+
+    // turn_context / world_state / thread_settings_applied / item_completed
+    // (none of these carry type: 'response_item' but are handled by the
+    // generic drop below anyway) and any other unrecognized response_item
+    // payload type — dropped for v1, per plan-codex-replay.md D1.
+    return events;
+  }
+
+  // -- event_msg / * ---------------------------------------------------------
+  if (type === 'event_msg') {
+    if (payloadType === 'user_message') {
+      const text = typeof payload.message === 'string' ? payload.message : '';
+      const last = lastUserMessageBySession.get(sessionId);
+      // Dedup rule (D1): Codex mirrors the same user text as both
+      // event_msg/user_message and a preceding response_item/message. The
+      // response_item copy is always emitted first in the observed corpus
+      // (same or earlier timestamp), so — unlike the "keep the event_msg"
+      // framing in the design doc, which would require buffering/lookahead
+      // the single-entry normalizeEntry signature doesn't support — this
+      // keeps whichever copy arrives first (the response_item one) and
+      // skips the mirrored event_msg. Net effect is identical: exactly one
+      // message per duplicated user turn, not two.
+      if (last !== null && last !== undefined && text.trim() === last) {
+        lastUserMessageBySession.set(sessionId, null);
+        return events;
+      }
+      events.push(messageEvent(sessionId, source, timestamp, entryIndex, 'user', { text }));
+      return events;
+    }
+
+    if (payloadType === 'agent_message') {
+      const text = typeof payload.message === 'string' ? payload.message : '';
+      events.push(messageEvent(sessionId, source, timestamp, entryIndex, 'agent', { text }));
+      return events;
+    }
+
+    if (payloadType === 'task_started') {
+      events.push(
+        makeEvent(sessionId, source, timestamp, entryIndex, 'agent', 'agent_spawned', {
+          turnId: payload.turn_id ?? null,
+        })
+      );
+      return events;
+    }
+
+    if (payloadType === 'task_complete') {
+      events.push(
+        makeEvent(sessionId, source, timestamp, entryIndex, 'agent', 'agent_completed', {
+          turnId: payload.turn_id ?? null,
+          lastMessage: payload.last_agent_message ?? null,
+        })
+      );
+      return events;
+    }
+
+    if (payloadType === 'turn_aborted') {
+      events.push(
+        makeEvent(sessionId, source, timestamp, entryIndex, 'agent', 'agent_idle', {
+          aborted: true,
+          turnId: payload.turn_id ?? null,
+          reason: payload.reason ?? null,
+        })
+      );
+      return events;
+    }
+
+    if (payloadType === 'token_count') {
+      const idx = tokenCountIndexBySession.get(sessionId) ?? 0;
+      tokenCountIndexBySession.set(sessionId, idx + 1);
+      // Rate-limited: 770 raw token_count lines in the PR-1 fixture would
+      // drown the buffer. Emit every Nth (deterministic — same input always
+      // samples the same lines).
+      if (idx % TOKEN_COUNT_SAMPLE_RATE !== 0) {
+        return events;
+      }
+      const info = asRecord(payload.info);
+      events.push(
+        makeEvent(sessionId, source, timestamp, entryIndex, 'system', 'context_snapshot', {
+          tokenUsage: info.total_token_usage ?? null,
+          contextWindow: info.model_context_window ?? null,
+        })
+      );
+      return events;
+    }
+
+    if (payloadType === 'context_compacted') {
+      events.push(
+        makeEvent(sessionId, source, timestamp, entryIndex, 'system', 'context_snapshot', {
+          compacted: true,
+        })
+      );
+      return events;
+    }
+
+    if (payloadType === 'patch_apply_end') {
+      const success = payload.success === true;
+      const toolUseId =
+        typeof payload.call_id === 'string' ? payload.call_id : buildId(sessionId, entryIndex, 0);
+      events.push(
+        makeEvent(
+          sessionId,
+          source,
+          timestamp,
+          entryIndex,
+          'agent',
+          success ? 'tool_completed' : 'tool_failed',
+          {
+            toolName: 'apply_patch',
+            toolUseId,
+            output: typeof payload.stdout === 'string' ? payload.stdout : null,
+            error: success
+              ? undefined
+              : (typeof payload.stderr === 'string' && payload.stderr) ||
+                (typeof payload.stdout === 'string' ? payload.stdout : 'apply_patch failed'),
+          }
+        )
+      );
+      return events;
+    }
+
+    if (payloadType === 'mcp_tool_call_end') {
+      const invocation = asRecord(payload.invocation);
+      const server = typeof invocation.server === 'string' ? invocation.server : 'mcp';
+      const tool = typeof invocation.tool === 'string' ? invocation.tool : 'unknown';
+      const result = asRecord(payload.result);
+      const ok = 'Ok' in result ? asRecord(result.Ok) : undefined;
+      const err = 'Err' in result ? result.Err : undefined;
+      const isError = err !== undefined || ok?.isError === true;
+      const toolUseId =
+        typeof payload.call_id === 'string' ? payload.call_id : buildId(sessionId, entryIndex, 0);
+      events.push(
+        makeEvent(
+          sessionId,
+          source,
+          timestamp,
+          entryIndex,
+          'agent',
+          isError ? 'tool_failed' : 'tool_completed',
+          {
+            toolName: `${server}:${tool}`,
+            toolUseId,
+            output: ok ?? null,
+            error: isError ? (err ?? ok) : undefined,
+          }
+        )
+      );
+      return events;
+    }
+
+    if (payloadType === 'web_search_end') {
+      const toolUseId =
+        typeof payload.call_id === 'string' ? payload.call_id : buildId(sessionId, entryIndex, 0);
+      events.push(
+        makeEvent(sessionId, source, timestamp, entryIndex, 'agent', 'tool_completed', {
+          toolName: 'web_search',
+          toolUseId,
+          query: typeof payload.query === 'string' ? payload.query : '',
+        })
+      );
+      return events;
+    }
+
+    if (payloadType === 'thread_goal_updated') {
+      const goal = asRecord(payload.goal);
+      const objective = typeof goal.objective === 'string' ? goal.objective : '';
+      events.push(
+        messageEvent(sessionId, source, timestamp, entryIndex, 'system', {
+          text: objective,
+          goalUpdate: true,
+          objective,
+        })
+      );
+      return events;
+    }
+
+    // thread_settings_applied, item_completed, and any other event_msg
+    // payload type not listed above — dropped for v1, per D1.
+    return events;
+  }
+
+  // turn_context, world_state — dropped for v1, per D1.
+  return events;
+}

--- a/src/capture/drivers/index.ts
+++ b/src/capture/drivers/index.ts
@@ -1,12 +1,18 @@
 import { HarnessDriverRegistry } from './harness-driver';
 import { claudeCodeDriver } from './claude-code';
+import { codexDriver } from './codex';
 
 export { HarnessDriverRegistry } from './harness-driver';
 export type { HarnessDriver, HarnessCapabilities, RiskHeuristic } from './harness-driver';
 export { claudeCodeDriver } from './claude-code';
+export { codexDriver } from './codex';
 
 /**
  * Singleton registry seeded with all in-tree drivers. Session-manager looks up
  * drivers by EventSource via `driverRegistry.getForSource(session.source)`.
+ * claude-code is registered first so it remains the default driver
+ * (`getDefault()`) — unchanged behavior for sessions with no source match.
  */
-export const driverRegistry = new HarnessDriverRegistry().register(claudeCodeDriver);
+export const driverRegistry = new HarnessDriverRegistry()
+  .register(claudeCodeDriver)
+  .register(codexDriver);

--- a/src/inference/context-packager.ts
+++ b/src/inference/context-packager.ts
@@ -23,6 +23,30 @@ function summarizeArgs(args: unknown): string {
   return entries.map(([k, v]) => `${k}=${JSON.stringify(v)?.slice(0, 60) ?? ''}`).join(', ');
 }
 
+/**
+ * Picks the harnessId that produced the most events in this window as the
+ * packet's `observedAgent`, falling back to 'claude-code' when no event
+ * carries a harnessId (legacy fixtures, hand-rolled test events) — the same
+ * default the driver registry uses. A single-harness session has exactly one
+ * candidate; a multi-harness/replay-merged session picks its majority.
+ */
+function dominantHarnessId(events: CanonicalEvent[]): string {
+  const counts = new Map<string, number>();
+  for (const event of events) {
+    if (!event.harnessId) continue;
+    counts.set(event.harnessId, (counts.get(event.harnessId) ?? 0) + 1);
+  }
+  let dominant: string | undefined;
+  let max = 0;
+  for (const [id, count] of counts) {
+    if (count > max) {
+      dominant = id;
+      max = count;
+    }
+  }
+  return dominant ?? 'claude-code';
+}
+
 export function buildContextPacket(
   state: DerivedState,
   events: CanonicalEvent[]
@@ -89,7 +113,7 @@ export function packContext(
 
   const packet: ShadowContextPacket = {
     sessionId: state.sessionId,
-    observedAgent: 'claude-code',
+    observedAgent: dominantHarnessId(events),
     sessionDuration,
     currentPhase: state.activePhase,
     recentEvents,

--- a/src/shared/derive.ts
+++ b/src/shared/derive.ts
@@ -120,6 +120,39 @@ const RISK_CHECKS: Record<string, (events: CanonicalEvent[]) => string | null> =
     if (repeatedReads.length < 6) return null;
     return 'Large exploration volume may indicate uncertainty or missing plan convergence';
   },
+  // New for the Codex driver (plan-codex-replay.md D1): the GHCR-403 stuck
+  // signature — the agent re-runs the same web search over and over instead
+  // of recognizing the query itself is the blocker. Declared capability-
+  // driven (any driver can opt in by listing 'repeated_searches'), not
+  // Codex-specific branching.
+  repeated_searches: (events) => {
+    const queryCounts = new Map<string, number>();
+    for (const event of events) {
+      if (
+        event.kind !== 'tool_started' &&
+        event.kind !== 'tool_completed' &&
+        event.kind !== 'tool_failed'
+      ) {
+        continue;
+      }
+      const caps = getCapabilitiesForEvent(event);
+      const name = normalizeToolName(String(event.payload.toolName ?? ''), caps);
+      if (!name.includes('search')) continue;
+
+      const args = event.payload.args;
+      const rawQuery =
+        event.payload.query ??
+        (args && typeof args === 'object' ? (args as Record<string, unknown>).query : undefined);
+      if (typeof rawQuery !== 'string' || rawQuery.trim() === '') continue;
+
+      // Near-identical = normalized whitespace/case equality (v1).
+      const normalized = rawQuery.trim().toLowerCase().replace(/\s+/g, ' ');
+      queryCounts.set(normalized, (queryCounts.get(normalized) ?? 0) + 1);
+    }
+    const hasRepeated = [...queryCounts.values()].some((count) => count >= 3);
+    if (!hasRepeated) return null;
+    return 'Repeated near-identical search queries suggest the agent is stuck retrying the same lookup';
+  },
 };
 
 function collectRiskSignals(events: CanonicalEvent[]): string[] {

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -13,6 +13,7 @@
 export const KnownEventSources = {
   claudeHook: 'claude-hook',
   claudeTranscript: 'claude-transcript',
+  codexRollout: 'codex-rollout',
   replay: 'replay',
   shadowRuntime: 'shadow-runtime',
 } as const;

--- a/tests/capture/drivers/codex-discovery.test.ts
+++ b/tests/capture/drivers/codex-discovery.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Codex driver discovery tests (PR-2, plan-codex-replay.md D1).
+ *
+ * Mirrors discovery.test.ts's claude-code DiscoveryStrategy section.
+ * Verifies:
+ * - createCodexDiscovery walks CODEX_SESSIONS_DIR (or an explicit override)
+ *   recursively for rollout-*.jsonl files
+ * - sessionId = the UUID suffix of the filename, fallback full basename
+ * - every discovered session carries source: 'codex-rollout'
+ * - integrates with the generic dispatcher
+ */
+import { mkdtempSync, mkdirSync, writeFileSync, utimesSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createCodexDiscovery } from '../../../src/capture/drivers/codex/discovery';
+import { codexDriver } from '../../../src/capture/drivers/codex';
+import { HarnessDriverRegistry } from '../../../src/capture/drivers/harness-driver';
+import { discoverActiveSession } from '../../../src/capture/session-discovery';
+
+describe('codex DiscoveryStrategy', () => {
+  it('returns empty array when sessionsDir does not exist', async () => {
+    const discovery = createCodexDiscovery({ sessionsDir: '/no/such/dir/xyz' });
+    expect(await discovery.discoverSessions()).toEqual([]);
+  });
+
+  it('walks sessionsDir recursively for rollout-*.jsonl files', async () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'codex-discovery-'));
+    try {
+      const dayDir = path.join(root, '2026', '07', '23');
+      mkdirSync(dayDir, { recursive: true });
+      const rollout = path.join(
+        dayDir,
+        'rollout-2026-07-23T12-16-30-019f8ee7-e51f-7ed1-b650-b7fb11ffecda.jsonl'
+      );
+      const ignored = path.join(dayDir, 'notes.md');
+      const nonRollout = path.join(dayDir, 'other-file.jsonl');
+      writeFileSync(rollout, '{}\n');
+      writeFileSync(ignored, 'x');
+      writeFileSync(nonRollout, '{}\n');
+
+      const discovery = createCodexDiscovery({ sessionsDir: root });
+      const sessions = await discovery.discoverSessions();
+
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]?.filePath).toBe(rollout);
+      expect(sessions[0]?.source).toBe('codex-rollout');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('extracts sessionId as the UUID suffix of the filename', async () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'codex-discovery-uuid-'));
+    try {
+      const file = path.join(root, 'rollout-2026-07-23T12-16-30-019f8ee7-e51f-7ed1-b650-b7fb11ffecda.jsonl');
+      writeFileSync(file, '{}\n');
+      const discovery = createCodexDiscovery({ sessionsDir: root });
+      const sessions = await discovery.discoverSessions();
+      expect(sessions[0]?.sessionId).toBe('019f8ee7-e51f-7ed1-b650-b7fb11ffecda');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to the full basename when no UUID suffix is present', async () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'codex-discovery-nouuid-'));
+    try {
+      const file = path.join(root, 'rollout-2026-07-23-homelab-coordinator.jsonl');
+      writeFileSync(file, '{}\n');
+      const discovery = createCodexDiscovery({ sessionsDir: root });
+      const sessions = await discovery.discoverSessions();
+      expect(sessions[0]?.sessionId).toBe('rollout-2026-07-23-homelab-coordinator');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('picks the most recently modified rollout file across the dispatcher', async () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'codex-discovery-latest-'));
+    try {
+      const older = path.join(root, 'rollout-2026-07-22T00-00-00-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jsonl');
+      const newer = path.join(root, 'rollout-2026-07-23T00-00-00-bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb.jsonl');
+      writeFileSync(older, '{}\n');
+      writeFileSync(newer, '{}\n');
+      utimesSync(older, new Date(1000), new Date(1000));
+      utimesSync(newer, new Date(2000), new Date(2000));
+
+      const fakeCodexDriver = {
+        ...codexDriver,
+        discovery: createCodexDiscovery({ sessionsDir: root }),
+      };
+      const registry = new HarnessDriverRegistry().register(fakeCodexDriver);
+      const result = await discoverActiveSession(undefined, { registry });
+      expect(result?.filePath).toBe(newer);
+      expect(result?.sessionId).toBe('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');
+      expect(result?.source).toBe('codex-rollout');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('codex discovery — CODEX_SESSIONS_DIR env override', () => {
+  const ORIGINAL = process.env.CODEX_SESSIONS_DIR;
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), 'codex-discovery-env-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+    if (ORIGINAL === undefined) {
+      delete process.env.CODEX_SESSIONS_DIR;
+    } else {
+      process.env.CODEX_SESSIONS_DIR = ORIGINAL;
+    }
+  });
+
+  it('honors CODEX_SESSIONS_DIR when no explicit sessionsDir option is given', async () => {
+    const file = path.join(root, 'rollout-2026-07-23T00-00-00-cccccccc-cccc-cccc-cccc-cccccccccccc.jsonl');
+    writeFileSync(file, '{}\n');
+    process.env.CODEX_SESSIONS_DIR = root;
+
+    // No sessionsDir override — must fall through to the env var.
+    const discovery = createCodexDiscovery();
+    const sessions = await discovery.discoverSessions();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.filePath).toBe(file);
+  });
+});
+
+describe('codex driver — registered in the driver registry', () => {
+  it('is discoverable via id and source', async () => {
+    const { driverRegistry } = await import('../../../src/capture/drivers');
+    expect(driverRegistry.get('codex')).toBe(codexDriver);
+    expect(driverRegistry.getForSource('codex-rollout')).toBe(codexDriver);
+  });
+
+  it('does not displace claude-code as the default driver', async () => {
+    const { driverRegistry } = await import('../../../src/capture/drivers');
+    expect(driverRegistry.getDefault().id).toBe('claude-code');
+  });
+});

--- a/tests/capture/drivers/codex-fixture.test.ts
+++ b/tests/capture/drivers/codex-fixture.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Codex driver fixture integration test (PR-2, plan-codex-replay.md D1).
+ *
+ * Streams the real PR-1 fixture (rollout-2026-07-23-homelab-coordinator.jsonl,
+ * 3,677 lines) through createIncrementalParser + normalizeEntry and asserts
+ * aggregate expectations derived from the fixture's format profile
+ * (rollout-2026-07-23-homelab-coordinator.ground-truth.md) and the raw
+ * type/payload.type counts verified against the fixture directly:
+ *
+ *   session_meta 1, response_item/reasoning 821, custom_tool_call(_output) 636
+ *   each, function_call(_output) 110 each, task_started 15, task_complete 14,
+ *   turn_aborted 1, event_msg/user_message 17.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { createIncrementalParser } from '../../../src/capture/incremental-parser';
+import { normalizeEntry } from '../../../src/capture/drivers/codex/normalizer';
+import type { CanonicalEvent } from '../../../src/shared/schema';
+
+const TEST_DIR = fileURLToPath(new URL('.', import.meta.url));
+const FIXTURE_PATH = join(
+  TEST_DIR,
+  '../../fixtures/transcripts/codex/rollout-2026-07-23-homelab-coordinator.jsonl'
+);
+const SESSION_ID = '019f8ee7-e51f-7ed1-b650-b7fb11ffecda';
+
+function normalizeFixture(): CanonicalEvent[] {
+  const raw = readFileSync(FIXTURE_PATH, 'utf8');
+  const events: CanonicalEvent[] = [];
+  const parser = createIncrementalParser((entry) => {
+    events.push(...normalizeEntry(entry, SESSION_ID));
+  });
+  parser.push(raw);
+  return events;
+}
+
+describe('codex driver — fixture integration', () => {
+  const events = normalizeFixture();
+
+  it('produces a non-trivial event stream', () => {
+    expect(events.length).toBeGreaterThan(1000);
+  });
+
+  it('stamps harnessId: "codex" on every event', () => {
+    expect(events.every((e) => e.harnessId === 'codex')).toBe(true);
+  });
+
+  it('stamps driverVersion: "0.1.0" on every event', () => {
+    expect(events.every((e) => e.driverVersion === '0.1.0')).toBe(true);
+  });
+
+  it('emits exactly 1 session_started event', () => {
+    expect(events.filter((e) => e.kind === 'session_started')).toHaveLength(1);
+  });
+
+  it('the session_started event carries session_meta fields', () => {
+    const started = events.find((e) => e.kind === 'session_started');
+    expect(started?.payload).toMatchObject({
+      originator: 'codex-tui',
+      cliVersion: '0.145.0',
+      modelProvider: 'openai',
+    });
+    expect(typeof started?.payload.cwd).toBe('string');
+  });
+
+  it('emits at least 17 user-actor messages (event_msg/user_message count)', () => {
+    const userMessages = events.filter((e) => e.kind === 'message' && e.actor === 'user');
+    expect(userMessages.length).toBeGreaterThanOrEqual(17);
+  });
+
+  it('emits 821 thinking messages (one per response_item/reasoning)', () => {
+    const thinking = events.filter((e) => e.kind === 'message' && e.payload.thinking === true);
+    expect(thinking).toHaveLength(821);
+  });
+
+  it('emits tool_started for every custom_tool_call and function_call (636 + 110)', () => {
+    const started = events.filter((e) => e.kind === 'tool_started');
+    expect(started).toHaveLength(636 + 110);
+  });
+
+  it('emits agent_spawned 15 times (task_started) and agent_completed 14 times (task_complete)', () => {
+    expect(events.filter((e) => e.kind === 'agent_spawned')).toHaveLength(15);
+    expect(events.filter((e) => e.kind === 'agent_completed')).toHaveLength(14);
+  });
+
+  it('emits exactly 1 agent_idle event with payload.aborted:true (the one turn_aborted)', () => {
+    const idle = events.filter((e) => e.kind === 'agent_idle');
+    expect(idle).toHaveLength(1);
+    expect(idle[0]?.payload.aborted).toBe(true);
+  });
+
+  it('emits tool_completed/tool_failed for every _output/_end tool encoding', () => {
+    // custom_tool_call_output(636) + function_call_output(110) +
+    // patch_apply_end(34) + mcp_tool_call_end(35) + web_search_end(14)
+    const completedOrFailed = events.filter(
+      (e) => e.kind === 'tool_completed' || e.kind === 'tool_failed'
+    );
+    expect(completedOrFailed).toHaveLength(636 + 110 + 34 + 35 + 14);
+  });
+
+  it('rate-limits token_count to roughly 1 in 10 (770 raw lines)', () => {
+    const snapshots = events.filter(
+      (e) => e.kind === 'context_snapshot' && e.payload.compacted === undefined
+    );
+    // 770 / 10 == 77 exactly, given the deterministic every-10th sampler.
+    expect(snapshots).toHaveLength(77);
+  });
+
+  it('emits context_snapshot for every context_compacted + top-level compacted (6 + 6)', () => {
+    const compacted = events.filter(
+      (e) => e.kind === 'context_snapshot' && e.payload.compacted === true
+    );
+    expect(compacted).toHaveLength(12);
+  });
+
+  it('preserves the single thread_goal_updated as a system message (not dropped)', () => {
+    const goalUpdates = events.filter((e) => e.payload.goalUpdate === true);
+    expect(goalUpdates).toHaveLength(1);
+    expect(goalUpdates[0]?.actor).toBe('system');
+    expect(goalUpdates[0]?.kind).toBe('message');
+  });
+
+  it('deduplicates the 17 user_message/response_item mirror pairs (no double-count)', () => {
+    // response_item/message maps both role:user (54) and role:developer (5,
+    // "injected user intent" per D1) to actor 'user' -> 59 response_item
+    // user-actor messages. 17 of the role:user ones have a mirrored
+    // event_msg/user_message; deduping means we see 59 total, not 59 + 17.
+    const userMessages = events.filter((e) => e.kind === 'message' && e.actor === 'user');
+    expect(userMessages).toHaveLength(59);
+  });
+
+  it('produces an identical ID sequence when the fixture is normalized twice', () => {
+    const firstRun = normalizeFixture().map((e) => e.id);
+    const secondRun = normalizeFixture().map((e) => e.id);
+    expect(firstRun).toEqual(secondRun);
+    expect(firstRun.length).toBe(events.length);
+  });
+
+  it('every event ID is unique within a single run', () => {
+    const ids = events.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/tests/capture/drivers/codex-normalizer.test.ts
+++ b/tests/capture/drivers/codex-normalizer.test.ts
@@ -1,0 +1,600 @@
+/**
+ * Codex driver normalizer unit tests (PR-2, plan-codex-replay.md D1).
+ *
+ * Hand-written entries for each row of the D1 mapping table. The fixture
+ * integration test (codex-fixture.test.ts) covers volume/aggregate
+ * assertions against the real corpus; this file covers per-shape
+ * correctness and edge cases (fail paths, dedupe, sampling).
+ */
+import { describe, expect, it, beforeEach } from 'vitest';
+import { codexDriver } from '../../../src/capture/drivers/codex';
+import { normalizeEntry } from '../../../src/capture/drivers/codex/normalizer';
+import type { ParsedEntry } from '../../../src/capture/incremental-parser';
+
+// Each test gets its own sessionId so per-session normalizer state
+// (entry-index counter, token_count sampler, user-message dedupe watermark)
+// never leaks across tests.
+let sessionCounter = 0;
+function freshSessionId(): string {
+  sessionCounter += 1;
+  return `sess-${sessionCounter}`;
+}
+
+describe('codex driver — harness identity', () => {
+  it('is registered under id "codex" for source "codex-rollout"', () => {
+    expect(codexDriver.id).toBe('codex');
+    expect(codexDriver.sources).toContain('codex-rollout');
+  });
+
+  it('stamps harnessId: "codex" and driverVersion: "0.1.0" on every event', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:00.000Z',
+      type: 'session_meta',
+      payload: { session_id: 'abc', cwd: '/tmp', originator: 'codex-tui', cli_version: '0.145.0', model_provider: 'openai' },
+    };
+    const events = codexDriver.normalizeEntry(entry, freshSessionId());
+    expect(events).toHaveLength(1);
+    expect(events[0]?.harnessId).toBe('codex');
+    expect(events[0]?.driverVersion).toBe('0.1.0');
+  });
+});
+
+describe('codex driver — session_meta', () => {
+  it('maps to session_started with cwd/originator/cliVersion/modelProvider', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:00.000Z',
+      type: 'session_meta',
+      payload: {
+        session_id: 'abc',
+        cwd: 'C:\\_projects\\coldaine-homelab',
+        originator: 'codex-tui',
+        cli_version: '0.145.0',
+        model_provider: 'openai',
+      },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe('session_started');
+    expect(events[0]?.actor).toBe('system');
+    expect(events[0]?.payload).toEqual({
+      cwd: 'C:\\_projects\\coldaine-homelab',
+      originator: 'codex-tui',
+      cliVersion: '0.145.0',
+      modelProvider: 'openai',
+    });
+  });
+});
+
+describe('codex driver — response_item/message', () => {
+  it('maps role=user to actor "user"', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:01.000Z',
+      type: 'response_item',
+      payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'do the thing' }] },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe('message');
+    expect(events[0]?.actor).toBe('user');
+    expect(events[0]?.payload.text).toBe('do the thing');
+  });
+
+  it('maps role=developer to actor "user" (injected user intent)', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:01.000Z',
+      type: 'response_item',
+      payload: { type: 'message', role: 'developer', content: [{ type: 'input_text', text: 'memory notes' }] },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events).toHaveLength(1);
+    expect(events[0]?.actor).toBe('user');
+  });
+
+  it('maps role=assistant to actor "agent"', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:02.000Z',
+      type: 'response_item',
+      payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'On it.' }] },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events).toHaveLength(1);
+    expect(events[0]?.actor).toBe('agent');
+    expect(events[0]?.payload.text).toBe('On it.');
+  });
+
+  it('concatenates multiple content blocks', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:02.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'assistant',
+        content: [
+          { type: 'output_text', text: 'part one' },
+          { type: 'output_text', text: 'part two' },
+        ],
+      },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events[0]?.payload.text).toBe('part one\npart two');
+  });
+});
+
+describe('codex driver — reasoning', () => {
+  it('maps to actor "agent" message with thinking:true', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:03.000Z',
+      type: 'response_item',
+      payload: { type: 'reasoning', id: 'rs_1', summary: [], encrypted_content: 'gAAA...' },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe('message');
+    expect(events[0]?.actor).toBe('agent');
+    expect(events[0]?.payload.thinking).toBe(true);
+  });
+
+  it('joins a non-empty summary array into payload.summary', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:03.000Z',
+      type: 'response_item',
+      payload: { type: 'reasoning', summary: ['Step one', 'Step two'] },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events[0]?.payload.summary).toBe('Step one\nStep two');
+  });
+});
+
+describe('codex driver — custom_tool_call / custom_tool_call_output', () => {
+  it('maps custom_tool_call to tool_started with raw (non-JSON) args', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:04.000Z',
+      type: 'response_item',
+      payload: { type: 'custom_tool_call', id: 'ctc_1', call_id: 'call_abc', name: 'exec', input: 'const r = 1;' },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe('tool_started');
+    expect(events[0]?.payload).toMatchObject({ toolName: 'exec', toolUseId: 'call_abc', args: 'const r = 1;' });
+  });
+
+  it('maps a successful custom_tool_call_output to tool_completed', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:05.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'custom_tool_call_output',
+        call_id: 'call_abc',
+        output: [
+          { type: 'input_text', text: 'Script completed\nWall time 0.1 seconds\nOutput:\n' },
+          { type: 'input_text', text: 'Exit code: 0\nWall time: 0.1 seconds\nOutput:\nhello' },
+        ],
+      },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe('tool_completed');
+    expect(events[0]?.payload.toolUseId).toBe('call_abc');
+    expect(events[0]?.payload.error).toBeUndefined();
+  });
+
+  it('maps a failed custom_tool_call_output ("Script failed") to tool_failed', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:05.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'custom_tool_call_output',
+        call_id: 'call_abc',
+        output: [
+          { type: 'input_text', text: 'Script failed\nWall time 0.1 seconds\nOutput:\n' },
+          { type: 'input_text', text: 'Script error:\nSyntaxError: bad' },
+        ],
+      },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe('tool_failed');
+    expect(typeof events[0]?.payload.error).toBe('string');
+  });
+
+  it('maps a nonzero exit code without a "Script failed" prefix to tool_failed', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:05.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'function_call_output',
+        call_id: 'call_xyz',
+        output: [{ type: 'input_text', text: 'Exit code: 124\nOutput:\ntimed out' }],
+      },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events[0]?.kind).toBe('tool_failed');
+  });
+});
+
+describe('codex driver — function_call / function_call_output', () => {
+  it('maps function_call to tool_started with JSON-parsed args', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:06.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'function_call',
+        id: 'fc_1',
+        call_id: 'call_wait',
+        name: 'wait',
+        arguments: '{"cell_id":"21","yield_time_ms":10000}',
+      },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe('tool_started');
+    expect(events[0]?.payload.args).toEqual({ cell_id: '21', yield_time_ms: 10000 });
+    // 'wait' is the coordinator-idle signature (D1) — flagged, not dropped.
+    expect(events[0]?.payload.coordinatorIdle).toBe(true);
+  });
+
+  it('falls back to raw string args when arguments is not valid JSON', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:06.000Z',
+      type: 'response_item',
+      payload: { type: 'function_call', call_id: 'call_bad', name: 'weird', arguments: 'not json' },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events[0]?.payload.args).toBe('not json');
+    expect(events[0]?.payload.coordinatorIdle).toBeUndefined();
+  });
+
+  it('maps function_call_output success (plain string, no failure markers) to tool_completed', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:07.000Z',
+      type: 'response_item',
+      payload: { type: 'function_call_output', call_id: 'call_wait', output: 'Script running with cell ID 21\n' },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events[0]?.kind).toBe('tool_completed');
+  });
+});
+
+describe('codex driver — patch_apply_end', () => {
+  it('maps success:true to tool_completed toolName apply_patch', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:08.000Z',
+      type: 'event_msg',
+      payload: {
+        type: 'patch_apply_end',
+        call_id: 'exec-1',
+        stdout: 'Success. Updated the following files:\nM foo.md\n',
+        stderr: '',
+        success: true,
+      },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe('tool_completed');
+    expect(events[0]?.payload.toolName).toBe('apply_patch');
+    expect(events[0]?.payload.error).toBeUndefined();
+  });
+
+  // Explicit fail-path coverage (design doc calls this out; not present in
+  // the PR-1 fixture, whose 34 patch_apply_end lines are all successes).
+  it('maps success:false to tool_failed with stderr as the error', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:08.000Z',
+      type: 'event_msg',
+      payload: {
+        type: 'patch_apply_end',
+        call_id: 'exec-2',
+        stdout: '',
+        stderr: 'error: patch failed to apply cleanly',
+        success: false,
+      },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe('tool_failed');
+    expect(events[0]?.payload.toolName).toBe('apply_patch');
+    expect(events[0]?.payload.error).toBe('error: patch failed to apply cleanly');
+  });
+});
+
+describe('codex driver — mcp_tool_call_end', () => {
+  it('maps result.Ok to tool_completed with a server:tool toolName', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:09.000Z',
+      type: 'event_msg',
+      payload: {
+        type: 'mcp_tool_call_end',
+        call_id: 'exec-3',
+        invocation: { server: 'node_repl', tool: 'js', arguments: {} },
+        result: { Ok: { content: [{ type: 'text', text: 'ok' }], isError: false } },
+      },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe('tool_completed');
+    expect(events[0]?.payload.toolName).toBe('node_repl:js');
+  });
+
+  it('maps result.Ok with isError:true to tool_failed', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:09.000Z',
+      type: 'event_msg',
+      payload: {
+        type: 'mcp_tool_call_end',
+        call_id: 'exec-4',
+        invocation: { server: 'node_repl', tool: 'js' },
+        result: { Ok: { content: [], isError: true } },
+      },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events[0]?.kind).toBe('tool_failed');
+  });
+
+  it('maps result.Err to tool_failed', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:09.000Z',
+      type: 'event_msg',
+      payload: {
+        type: 'mcp_tool_call_end',
+        call_id: 'exec-5',
+        invocation: { server: 'node_repl', tool: 'js' },
+        result: { Err: 'connection refused' },
+      },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events[0]?.kind).toBe('tool_failed');
+  });
+});
+
+describe('codex driver — web_search_end', () => {
+  it('maps to tool_completed toolName web_search with query payload', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:10.000Z',
+      type: 'event_msg',
+      payload: { type: 'web_search_end', call_id: 'exec-6', query: 'shipwright build strategy' },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe('tool_completed');
+    expect(events[0]?.payload).toMatchObject({ toolName: 'web_search', query: 'shipwright build strategy' });
+  });
+});
+
+describe('codex driver — task lifecycle', () => {
+  it('maps task_started to agent_spawned', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:11.000Z',
+      type: 'event_msg',
+      payload: { type: 'task_started', turn_id: 'turn-1', model_context_window: 258400 },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe('agent_spawned');
+    expect(events[0]?.payload.turnId).toBe('turn-1');
+  });
+
+  it('maps task_complete to agent_completed', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:12.000Z',
+      type: 'event_msg',
+      payload: { type: 'task_complete', turn_id: 'turn-1', last_agent_message: 'Done.' },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe('agent_completed');
+    expect(events[0]?.payload.lastMessage).toBe('Done.');
+  });
+
+  it('maps turn_aborted to agent_idle with payload.aborted:true', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:13.000Z',
+      type: 'event_msg',
+      payload: { type: 'turn_aborted', turn_id: 'turn-1', reason: 'interrupted' },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe('agent_idle');
+    expect(events[0]?.payload.aborted).toBe(true);
+  });
+});
+
+describe('codex driver — token_count rate limiting', () => {
+  it('emits roughly 1 in 10 token_count lines as context_snapshot, deterministically', () => {
+    const sessionId = freshSessionId();
+    const makeTokenCount = (i: number): ParsedEntry => ({
+      timestamp: `2026-07-23T12:01:${String(i).padStart(2, '0')}.000Z`,
+      type: 'event_msg',
+      payload: {
+        type: 'token_count',
+        info: { total_token_usage: { total_tokens: i * 100 }, model_context_window: 258400 },
+      },
+    });
+
+    let emitted = 0;
+    for (let i = 0; i < 30; i++) {
+      const events = normalizeEntry(makeTokenCount(i), sessionId);
+      if (events.length > 0) {
+        emitted += 1;
+        expect(events[0]?.kind).toBe('context_snapshot');
+      }
+    }
+    // 30 lines at 1-in-10 -> exactly 3 emissions (indices 0, 10, 20).
+    expect(emitted).toBe(3);
+  });
+});
+
+describe('codex driver — context_compacted / compacted', () => {
+  it('maps event_msg/context_compacted to context_snapshot payload {compacted:true}', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:14.000Z',
+      type: 'event_msg',
+      payload: { type: 'context_compacted' },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe('context_snapshot');
+    expect(events[0]?.payload).toEqual({ compacted: true });
+  });
+
+  it('maps top-level type:"compacted" to context_snapshot payload {compacted:true}', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:14.000Z',
+      type: 'compacted',
+      payload: { message: '', replacement_history: [{ huge: 'blob' }] },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe('context_snapshot');
+    expect(events[0]?.payload).toEqual({ compacted: true });
+  });
+});
+
+describe('codex driver — thread_goal_updated', () => {
+  it('maps to actor "system" message, preserved (not dropped)', () => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T15:20:43.493Z',
+      type: 'event_msg',
+      payload: {
+        type: 'thread_goal_updated',
+        threadId: 'thread-1',
+        goal: { objective: 'continue until the pg18 databases have been fully recovered' },
+      },
+    };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe('message');
+    expect(events[0]?.actor).toBe('system');
+    expect(events[0]?.payload).toMatchObject({
+      goalUpdate: true,
+      objective: 'continue until the pg18 databases have been fully recovered',
+    });
+  });
+});
+
+describe('codex driver — dropped entry types (v1)', () => {
+  it.each(['turn_context', 'world_state'])('drops top-level type %s', (type) => {
+    const entry: ParsedEntry = { timestamp: '2026-07-23T12:00:15.000Z', type, payload: {} };
+    expect(normalizeEntry(entry, freshSessionId())).toHaveLength(0);
+  });
+
+  it.each(['thread_settings_applied', 'item_completed'])('drops event_msg/%s', (payloadType) => {
+    const entry: ParsedEntry = {
+      timestamp: '2026-07-23T12:00:15.000Z',
+      type: 'event_msg',
+      payload: { type: payloadType },
+    };
+    expect(normalizeEntry(entry, freshSessionId())).toHaveLength(0);
+  });
+
+  it('drops unrecognized entries entirely', () => {
+    const entry: ParsedEntry = { timestamp: '2026-07-23T12:00:16.000Z', type: 'something_new', payload: {} };
+    expect(normalizeEntry(entry, freshSessionId())).toHaveLength(0);
+  });
+});
+
+describe('codex driver — user-message dedupe', () => {
+  it('keeps a single message when event_msg/user_message mirrors the preceding response_item/message', () => {
+    const sessionId = freshSessionId();
+    const text = 'Implement the plan.';
+
+    const responseItemEntry: ParsedEntry = {
+      timestamp: '2026-07-23T12:16:39.254Z',
+      type: 'response_item',
+      payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text }] },
+    };
+    const eventMsgEntry: ParsedEntry = {
+      timestamp: '2026-07-23T12:16:39.254Z',
+      type: 'event_msg',
+      payload: { type: 'user_message', message: text },
+    };
+
+    const firstEvents = normalizeEntry(responseItemEntry, sessionId);
+    const secondEvents = normalizeEntry(eventMsgEntry, sessionId);
+
+    expect(firstEvents).toHaveLength(1);
+    expect(firstEvents[0]?.actor).toBe('user');
+    // The mirrored event_msg is skipped — exactly one message total.
+    expect(secondEvents).toHaveLength(0);
+  });
+
+  it('does not dedupe an event_msg/user_message with different text', () => {
+    const sessionId = freshSessionId();
+    const responseItemEntry: ParsedEntry = {
+      timestamp: '2026-07-23T12:16:39.254Z',
+      type: 'response_item',
+      payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'first turn' }] },
+    };
+    const unrelatedEventMsg: ParsedEntry = {
+      timestamp: '2026-07-23T12:20:00.000Z',
+      type: 'event_msg',
+      payload: { type: 'user_message', message: 'a different later turn' },
+    };
+
+    normalizeEntry(responseItemEntry, sessionId);
+    const events = normalizeEntry(unrelatedEventMsg, sessionId);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.payload.text).toBe('a different later turn');
+  });
+
+  it('does not dedupe response_item/message role=developer against event_msg/user_message', () => {
+    const sessionId = freshSessionId();
+    const text = 'same text coincidence';
+    const developerEntry: ParsedEntry = {
+      timestamp: '2026-07-23T12:16:39.254Z',
+      type: 'response_item',
+      payload: { type: 'message', role: 'developer', content: [{ type: 'input_text', text }] },
+    };
+    const userMessageEntry: ParsedEntry = {
+      timestamp: '2026-07-23T12:16:40.000Z',
+      type: 'event_msg',
+      payload: { type: 'user_message', message: text },
+    };
+
+    normalizeEntry(developerEntry, sessionId);
+    const events = normalizeEntry(userMessageEntry, sessionId);
+    // Developer-role messages never set the dedupe watermark, so this
+    // user_message is treated as a genuine new turn, not a mirror.
+    expect(events).toHaveLength(1);
+  });
+});
+
+describe('codex driver — deterministic IDs', () => {
+  it('produces identical ID sequences across two independent normalizations of the same entries', () => {
+    const entries: ParsedEntry[] = [
+      { timestamp: 't0', type: 'session_meta', payload: { cwd: '/x' } },
+      {
+        timestamp: 't1',
+        type: 'response_item',
+        payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hi' }] },
+      },
+      { timestamp: 't2', type: 'event_msg', payload: { type: 'task_started', turn_id: 'turn-1' } },
+    ];
+
+    const sessionId = 'deterministic-session';
+
+    const run = () => entries.flatMap((entry) => normalizeEntry(entry, sessionId));
+    const first = run().map((e) => e.id);
+    const second = run().map((e) => e.id);
+
+    expect(first).toEqual(second);
+    expect(first.length).toBeGreaterThan(0);
+  });
+});
+
+describe('codex driver — source propagation', () => {
+  beforeEach(() => {
+    // no-op: each test uses freshSessionId(), no shared state to reset
+  });
+
+  it('defaults source to codex-rollout', () => {
+    const entry: ParsedEntry = { timestamp: 't0', type: 'session_meta', payload: {} };
+    const events = normalizeEntry(entry, freshSessionId());
+    expect(events[0]?.source).toBe('codex-rollout');
+  });
+
+  it('honors an explicit source override', () => {
+    const entry: ParsedEntry = { timestamp: 't0', type: 'session_meta', payload: {} };
+    const events = normalizeEntry(entry, freshSessionId(), 'replay');
+    expect(events[0]?.source).toBe('replay');
+  });
+});

--- a/tests/derive-capabilities.test.ts
+++ b/tests/derive-capabilities.test.ts
@@ -136,6 +136,90 @@ describe('derive — riskHeuristics gating', () => {
 });
 
 // ---------------------------------------------------------------------------
+// repeated_searches (new heuristic, plan-codex-replay.md D1 — the GHCR-403
+// stuck signature: >=3 near-identical web_search/search queries in a window)
+// ---------------------------------------------------------------------------
+
+describe('derive — repeated_searches heuristic', () => {
+  it('does not fire when the driver has not declared the capability', () => {
+    mockRegistry.register(makeDriver('no-repeat-search', makeCaps({ riskHeuristics: [] })));
+    const events = Array.from({ length: 5 }, () =>
+      makeEvent({
+        harnessId: 'no-repeat-search',
+        kind: 'tool_completed',
+        payload: { toolName: 'web_search', query: 'same query' },
+      })
+    );
+    expect(deriveState(events).riskSignals).toEqual([]);
+  });
+
+  it('fires when >=3 identical (case/whitespace-normalized) search queries appear', () => {
+    mockRegistry.register(makeDriver('codex', makeCaps({ riskHeuristics: ['repeated_searches'] })));
+    const events = [
+      makeEvent({
+        harnessId: 'codex',
+        kind: 'tool_completed',
+        payload: { toolName: 'web_search', query: 'ghcr 403 pull access denied' },
+      }),
+      makeEvent({
+        harnessId: 'codex',
+        kind: 'tool_completed',
+        payload: { toolName: 'web_search', query: 'GHCR 403   pull access denied' },
+      }),
+      makeEvent({
+        harnessId: 'codex',
+        kind: 'tool_completed',
+        payload: { toolName: 'web_search', query: '  ghcr 403 pull access denied  ' },
+      }),
+    ];
+    const risks = deriveState(events).riskSignals;
+    expect(risks.some((r) => r.toLowerCase().includes('repeated') && r.toLowerCase().includes('search'))).toBe(true);
+  });
+
+  it('does not fire for fewer than 3 near-identical queries', () => {
+    mockRegistry.register(makeDriver('codex', makeCaps({ riskHeuristics: ['repeated_searches'] })));
+    const events = [
+      makeEvent({
+        harnessId: 'codex',
+        kind: 'tool_completed',
+        payload: { toolName: 'web_search', query: 'same query' },
+      }),
+      makeEvent({
+        harnessId: 'codex',
+        kind: 'tool_completed',
+        payload: { toolName: 'web_search', query: 'same query' },
+      }),
+    ];
+    expect(deriveState(events).riskSignals).toEqual([]);
+  });
+
+  it('does not fire when 3+ searches have distinct queries', () => {
+    mockRegistry.register(makeDriver('codex', makeCaps({ riskHeuristics: ['repeated_searches'] })));
+    const events = ['first query', 'second query', 'third query'].map((query) =>
+      makeEvent({
+        harnessId: 'codex',
+        kind: 'tool_completed',
+        payload: { toolName: 'web_search', query },
+      })
+    );
+    expect(deriveState(events).riskSignals).toEqual([]);
+  });
+
+  it('reads the query from payload.args.query when payload.query is absent', () => {
+    mockRegistry.register(makeDriver('codex', makeCaps({ riskHeuristics: ['repeated_searches'] })));
+    const events = Array.from({ length: 3 }, () =>
+      makeEvent({
+        harnessId: 'codex',
+        kind: 'tool_started',
+        payload: { toolName: 'web_search', args: { query: 'stuck loop query' } },
+      })
+    );
+    const risks = deriveState(events).riskSignals;
+    expect(risks.some((r) => r.toLowerCase().includes('search'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // toolNameMap
 // ---------------------------------------------------------------------------
 

--- a/tests/inference.test.ts
+++ b/tests/inference.test.ts
@@ -164,6 +164,36 @@ describe('buildContextPacket', () => {
     expect(packet.riskSignals).toHaveLength(1);
     expect(packet.riskSignals[0]).toMatchObject({ signal: 'Tool failed twice', severity: 'medium' });
   });
+
+  // ── D2: observedAgent tracks the dominant harnessId (plan-codex-replay.md) ──
+
+  it('sets observedAgent to the harnessId shared by every event in the window', () => {
+    const state = makeState();
+    const events: CanonicalEvent[] = [
+      { ...makeEvent('message', '2024-01-01T00:00:00Z'), harnessId: 'codex' },
+      { ...makeEvent('tool_started', '2024-01-01T00:00:10Z'), harnessId: 'codex' },
+    ];
+    const packet = buildContextPacket(state, events);
+    expect(packet.observedAgent).toBe('codex');
+  });
+
+  it('sets observedAgent to the majority harnessId when the window mixes harnesses', () => {
+    const state = makeState();
+    const events: CanonicalEvent[] = [
+      { ...makeEvent('message', '2024-01-01T00:00:00Z'), harnessId: 'codex' },
+      { ...makeEvent('message', '2024-01-01T00:00:01Z'), harnessId: 'codex' },
+      { ...makeEvent('message', '2024-01-01T00:00:02Z'), harnessId: 'claude-code' },
+    ];
+    const packet = buildContextPacket(state, events);
+    expect(packet.observedAgent).toBe('codex');
+  });
+
+  it('falls back to claude-code when no event carries a harnessId', () => {
+    const state = makeState();
+    const events: CanonicalEvent[] = [makeEvent('message', '2024-01-01T00:00:00Z')];
+    const packet = buildContextPacket(state, events);
+    expect(packet.observedAgent).toBe('claude-code');
+  });
 });
 
 // ── prompt builder ─────────────────────────────────────────────────────────

--- a/tests/live/read-real-session.test.ts
+++ b/tests/live/read-real-session.test.ts
@@ -1,28 +1,37 @@
 /**
- * LIVE TEST — runs the REAL read pipeline against a REAL local Claude session.
+ * LIVE TEST — runs the REAL read pipeline against whatever real session the
+ * generic multi-driver discovery dispatcher finds newest on this machine
+ * (Claude Code, Codex, or any other in-tree driver).
  *
  * Why this exists: every other test uses synthetic fixtures or mocks. None of
- * them read an actual ~/.claude/projects transcript, which is exactly why the
+ * them read an actual local transcript, which is exactly why the
  * file-attention bug (args nested under payload.args) and the thinking-drop bug
  * survived — the 6-line happy-path fixture has neither at real scale. This test
- * exercises discoverActiveSession -> incremental parser -> claude-code normalizer
- * -> deriveState on whatever real session is newest on this machine.
+ * exercises discoverActiveSession -> incremental parser -> the driver matching
+ * the discovered session's source -> deriveState on whatever real session is
+ * newest on this machine.
  *
- * It is NOT in CI (CI has no ~/.claude data). It runs from the pre-push hook
- * (`npm run test:live`) on a developer machine. When no real session exists it
- * SKIPS loudly — a skip means "couldn't run here", never a silent pass.
+ * Driver-aware by design (mirrors session-manager.ts's
+ * `driverRegistry.getForSource(session.source) ?? driverRegistry.getDefault()`):
+ * discoverActiveSession() dispatches across every registered driver's
+ * DiscoveryStrategy, so the newest real session on a given machine may not be
+ * a Claude Code one. Hardcoding the claude-code normalizer here would silently
+ * feed a non-Claude entry shape through the wrong parser and fail with a
+ * misleading "0 events" rather than actually exercising that harness's driver.
+ *
+ * It is NOT in CI (CI has no real session data). It runs from the pre-push
+ * hook (`npm run test:live`) on a developer machine. When no real session
+ * exists it SKIPS loudly — a skip means "couldn't run here", never a silent
+ * pass.
  */
 import { describe, it, beforeAll, expect } from 'vitest';
-import { existsSync, readFileSync } from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
+import { readFileSync } from 'node:fs';
 import { discoverActiveSession } from '../../src/capture/session-discovery';
 import { createIncrementalParser } from '../../src/capture/incremental-parser';
-import { normalizeEntry } from '../../src/capture/drivers/claude-code/normalizer';
+import { driverRegistry } from '../../src/capture/drivers';
 import { deriveState } from '../../src/shared/derive';
 import type { CanonicalEvent } from '../../src/shared/schema';
 
-const CLAUDE_PROJECTS = path.join(os.homedir(), '.claude', 'projects');
 const FILE_KEYS = ['file_path', 'filePath', 'path'];
 const VALID_PHASES = /^(observation|exploration|planning|implementation|validation)$/;
 
@@ -32,21 +41,23 @@ interface Probe {
   state: ReturnType<typeof deriveState>;
   rawFileToolCount: number;
   rawThinkingCount: number;
+  harnessId: string;
 }
 
 let probe: Probe | null = null;
 let skipReason = '';
 
 beforeAll(async () => {
-  if (!existsSync(CLAUDE_PROJECTS)) {
-    skipReason = `no ${CLAUDE_PROJECTS} on this machine`;
-    return;
-  }
   const session = await discoverActiveSession();
   if (!session) {
-    skipReason = 'discoverActiveSession() found no real session';
+    skipReason = 'discoverActiveSession() found no real session (no ~/.claude/projects, ~/.codex/sessions, etc. on this machine)';
     return;
   }
+
+  // Driver-aware: discoverActiveSession() dispatches across every registered
+  // driver, so route the discovered session's entries through the driver
+  // that actually owns its source rather than assuming Claude Code.
+  const driver = driverRegistry.getForSource(session.source) ?? driverRegistry.getDefault();
 
   const raw = readFileSync(session.filePath, 'utf8');
   const entries: Record<string, unknown>[] = [];
@@ -57,10 +68,15 @@ beforeAll(async () => {
   for (const entry of entries) {
     // Real JSONL is untrusted: only trust a string sessionId, else fall back.
     const entrySessionId = typeof entry.sessionId === 'string' ? entry.sessionId : session.sessionId;
-    events.push(...normalizeEntry(entry, entrySessionId));
+    events.push(...driver.normalizeEntry(entry, entrySessionId, session.source));
   }
   const state = deriveState(events, 'live');
 
+  // These two raw scans check Claude Code's specific on-disk shape
+  // (message.content block array) — the historical bugs they guard against
+  // were Claude-only. On a non-Claude session (e.g. Codex) neither pattern
+  // matches, both counts land on 0, and the corresponding tests below skip
+  // gracefully rather than asserting something meaningless for that harness.
   let rawFileToolCount = 0;
   let rawThinkingCount = 0;
   for (const entry of entries) {
@@ -75,15 +91,23 @@ beforeAll(async () => {
     }
   }
 
-  probe = { filePath: session.filePath, events, state, rawFileToolCount, rawThinkingCount };
+  probe = {
+    filePath: session.filePath,
+    events,
+    state,
+    rawFileToolCount,
+    rawThinkingCount,
+    harnessId: driver.id,
+  };
 });
 
-describe('LIVE: real Claude session through the read pipeline', () => {
+describe('LIVE: real session through the read pipeline', () => {
   it('discovers and reads a real session into canonical events', (ctx) => {
     if (!probe) {
       console.log(`[live] SKIP — ${skipReason}`);
       return ctx.skip();
     }
+    console.log(`[live] discovered a ${probe.harnessId} session: ${probe.filePath}`);
     expect(probe.events.length).toBeGreaterThan(0);
     expect(probe.state.activePhase).toMatch(VALID_PHASES);
   });

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -9,6 +9,7 @@ describe('schema runtime contracts', () => {
     expect(KnownEventSources).toEqual({
       claudeHook: 'claude-hook',
       claudeTranscript: 'claude-transcript',
+      codexRollout: 'codex-rollout',
       replay: 'replay',
       shadowRuntime: 'shadow-runtime',
     });


### PR DESCRIPTION
## **User description**
## What

Implements PR-2 of the Codex replay series per `docs/plans/plan-codex-replay.md` D1/D2, stacked on #112.

- **`src/capture/drivers/codex/`** — the Codex `HarnessDriver`: `normalizer.ts` implements the full D1 mapping table (session_meta, response_item message/reasoning/custom_tool_call(_output)/function_call(_output), event_msg task lifecycle, patch_apply_end, mcp_tool_call_end, web_search_end, token_count sampling, context compaction, thread_goal_updated, the user-message dedupe rule), `discovery.ts` walks `~/.codex/sessions` recursively for `rollout-*.jsonl` (`CODEX_SESSIONS_DIR` env override), `capabilities.ts` declares Codex's risk-heuristic/tool-name-mapping profile. Registered in `src/capture/drivers/index.ts` alongside claude-code, which remains the default driver.
- **D2** — `src/inference/context-packager.ts` now sets `observedAgent` to the dominant `harnessId` across the event window instead of hardcoding `'claude-code'`.
- **D4** — new `repeated_searches` risk heuristic in `src/shared/derive.ts` (the GHCR-403 stuck signature: ≥3 near-identical `web_search`/`*search*` queries in a window), capability-gated like every other heuristic, declared by the Codex driver.
- **Determinism** — event IDs are `codex:{sessionId}:{entryIndex}:{subIndex}`, derived from a per-session counter that resets on `session_meta`, not `randomUUID()` — required for reproducible replay (PR-3).
- **Tests** — `tests/capture/drivers/codex-normalizer.test.ts` (hand-written entries per D1 mapping row, including patch_apply_end's fail path, token_count sampling, and the dedupe rule), `tests/capture/drivers/codex-fixture.test.ts` (streams the real 3,677-line PR-1 fixture through the full parser → normalizer pipeline and asserts aggregate counts against its verified type/payload-type profile, plus a determinism check that normalizing the fixture twice produces identical ID sequences), `tests/capture/drivers/codex-discovery.test.ts` (walks a temp dir via `CODEX_SESSIONS_DIR`), plus additions to `tests/inference.test.ts` (D2) and `tests/derive-capabilities.test.ts` (D4).
- **Live-test driver-awareness fix** — `tests/live/read-real-session.test.ts` hardcoded the claude-code normalizer, an assumption that broke the moment a second driver was registered (this machine's newest real session turned out to be a genuine Codex rollout, discovered correctly but then fed through the wrong parser). Fixed to route through `driverRegistry.getForSource(session.source)`, the same pattern `session-manager.ts` already uses in production — verified against that real local Codex session.

## Deliberate deviations from the design doc (one-line justifications each)

- **User-message dedupe direction**: the doc says "keep the `event_msg`, skip the `response_item`." In the actual fixture the `response_item` copy always arrives first (same timestamp), so I keep whichever arrives first and skip the mirrored `event_msg` instead — net effect (exactly one message per duplicated user turn) is identical, but doesn't require buffering/lookahead that the single-entry `normalizeEntry(entry, sessionId, source)` signature has no room for.
- **`driverVersion`**: the ask was "driver object... driverVersion '0.1.0'," but `HarnessDriver` has no such field (only `CanonicalEvent` does). Stamped `driverVersion: '0.1.0'` on every emitted event instead, which is what the schema actually supports.
- **`wait` special-case**: the doc frames this as a `custom_tool_call` case, but in the fixture `wait` is encoded via `function_call`. Applied the `coordinatorIdle` flag to whichever encoding actually carries `name === 'wait'`.
- **`toolNameMap`**: not explicitly spelled out in the D1 capabilities bullet, but added (`apply_patch`→`edit`, `exec`→`bash`) so the `shell_churn`/phase-detection checks the capabilities list already declares aren't permanently dead for Codex's tool vocabulary — mirrors the "Codex flavour" scenario already covered by the existing `derive-capabilities.test.ts`.

## Test plan

- [x] `npm test` (tsc --noEmit && vitest run) — 51 files, 455 tests, all passing
- [x] `npm run test:live` — passes, and now correctly discovers + normalizes a real local Codex session
- [x] Pre-push hook ran clean (no bypass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9EpjZNoWaXLzfG93tdvTU


___

## **CodeAnt-AI Description**
**Add Codex session support and use the right driver in mixed sessions**

### What Changed
- Added support for discovering and reading Codex rollout sessions, including recursive session lookup and Codex-specific event mapping.
- Codex events now keep deterministic IDs, label their source correctly, and translate Codex tool, message, and lifecycle events into the shared event format.
- The context packet now identifies the agent from the events in the window instead of always reporting Claude Code.
- Added a new repeated-search risk check for sessions that keep retrying the same search query.

### Impact
`✅ Codex sessions can be captured and replayed`
`✅ Correct agent label in mixed-harness transcripts`
`✅ Fewer missed stuck-search warnings`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
