### PR TITLE
feat: deterministic replay runner (PR-3)

### DIFF
--- a/docs/history/log.md
+++ b/docs/history/log.md
@@ -122,3 +122,24 @@
 - Pulse origin uses node position when available, falls back to canvas center (0.5, 0.5)
 - Pulse mapping documented inline in `canvas-pulse.ts` with rationale table
 - 285 tests passing
+
+## 2026-07-23 — First deterministic replay of the Codex corpus (heuristic + live shadow)
+
+- Replayed `tests/fixtures/transcripts/codex/rollout-2026-07-23-homelab-coordinator.jsonl`
+  (2,885 canonical events, 276.8 virtual minutes) through the new replay runner twice:
+  `--speed 0 --infer none` and `--speed 60 --infer live` (DeepSeek via openai-compatible).
+- Determinism proven: identical `sha256:4c82bd11e8c9…` event/trigger hash in both modes —
+  278 trigger firings (194 normal, 84 immediate) regardless of inference or speed.
+- Latency (live, DeepSeek): p50 10.5 s, p95 16.7 s, max 20.1 s per inference. Against the
+  design budget (p95 < 30 s for 1× real-time observation): PASS — live shadowing of a real
+  Codex coordinator is feasible at "not real time but pretty close" fidelity.
+- At 60×, single-flight collapsed 278 triggers into 24 inference calls (one per ~11 virtual
+  minutes); insight staleness p50 9.4 virtual minutes. High-speed replay is a corpus-sweep
+  mode; fidelity measurement needs ≤10× or 1×.
+- Checkpoints (heuristics-only): 0/4 surfaced. With live shadow: plan-pivot surfaced
+  (26.8 min lag at 60×); GHCR stall and final-not-done "surfaced" only via loose text
+  matches (matcher precision follow-up); scope-drift abort missed at 60× (window flew by in
+  <40 s wall). The shadow model is the show; heuristics alone see almost nothing.
+- Follow-ups filed from findings: checkpoint matcher precision; windowed (not cumulative)
+  failed-tool risk counts; 1×/10× fidelity run; pre-push Doppler gate still references the
+  renamed `ai-models` project (now `ai-automation`) and silently skips live inference.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:electron": "node electron.esbuild.mjs",
     "build": "npm run build:web && npm run build:renderer && npm run build:electron",
     "start": "electron dist-electron/main.cjs",
+    "replay": "node scripts/replay.mjs",
     "test": "tsc --noEmit && vitest run",
     "test:live": "vitest run --config vitest.live.config.ts",
     "test:coverage": "vitest run --coverage",

--- a/scripts/replay.mjs
+++ b/scripts/replay.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * `npm run replay` shim. The replay CLI is TypeScript (scripts/replay.ts) and
+ * the repo has no standalone TS runner, but it *does* ship esbuild (used by the
+ * Electron build). So we bundle the CLI on the fly to a temp ESM file — keeping
+ * node_modules external — and import it. process.argv is preserved, so the
+ * bundled CLI parses flags exactly as if run directly.
+ */
+import { build } from 'esbuild';
+import { mkdtempSync } from 'node:fs';
+import { rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const entry = join(here, 'replay.ts');
+const outDir = mkdtempSync(join(tmpdir(), 'shadow-replay-cli-'));
+const outFile = join(outDir, 'replay.mjs');
+
+try {
+  await build({
+    entryPoints: [entry],
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    target: 'node20',
+    packages: 'external',
+    outfile: outFile,
+    logLevel: 'warning',
+  });
+  await import(pathToFileURL(outFile).href);
+} finally {
+  // The bundled CLI may call process.exit(); a 'exit' hook guarantees cleanup.
+  process.on('exit', () => {
+    try {
+      rmSync(outDir, { recursive: true, force: true });
+    } catch {
+      // best effort
+    }
+  });
+}

--- a/scripts/replay.ts
+++ b/scripts/replay.ts
@@ -1,0 +1,133 @@
+/**
+ * CLI entry for the deterministic replay runner (see src/replay/replay-runner.ts
+ * and plan-codex-replay.md D3). Wired as `npm run replay`.
+ *
+ * Usage:
+ *   npm run replay -- <file> [flags]
+ *   doppler run -p ai-models -c dev -- npm run replay -- <file> --infer live
+ *
+ * Flags:
+ *   --driver codex|claude-code   Force a driver for raw transcripts (sniffed otherwise).
+ *   --speed N                    60 (default) | 1 (real time) | 0 (as-fast-as-possible).
+ *   --infer none|live            none (heuristics only, default) | live (real provider chain).
+ *   --export-replay <path>       Write normalized CanonicalEvents (Electron-loadable) here.
+ *   --report <path>              Write the JSON report here.
+ *   --title <text>               Session title for derive/report.
+ */
+import { runReplay, type InferMode, type ReplayOptions } from '../src/replay/replay-runner';
+
+interface ParsedArgs {
+  file?: string;
+  options: ReplayOptions;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const options: ReplayOptions = {};
+  let file: string | undefined;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = (): string => {
+      const value = argv[i + 1];
+      if (value === undefined) throw new Error(`Missing value for ${arg}`);
+      i += 1;
+      return value;
+    };
+    switch (arg) {
+      case '--driver': {
+        const value = next();
+        if (value !== 'codex' && value !== 'claude-code') {
+          throw new Error(`--driver must be codex|claude-code, got "${value}"`);
+        }
+        options.driver = value;
+        break;
+      }
+      case '--speed':
+        options.speed = Number(next());
+        break;
+      case '--infer': {
+        const value = next();
+        if (value !== 'none' && value !== 'live') {
+          throw new Error(`--infer must be none|live, got "${value}"`);
+        }
+        options.infer = value as InferMode;
+        break;
+      }
+      case '--export-replay':
+        options.exportReplayPath = next();
+        break;
+      case '--report':
+        options.reportPath = next();
+        break;
+      case '--title':
+        options.title = next();
+        break;
+      case '--help':
+      case '-h':
+        file = '--help';
+        break;
+      default:
+        if (arg.startsWith('--')) throw new Error(`Unknown flag: ${arg}`);
+        file = arg;
+    }
+  }
+
+  options.filePath = file;
+  return { file, options };
+}
+
+const HELP = `Deterministic replay runner
+
+Usage: npm run replay -- <file> [flags]
+
+  --driver codex|claude-code   Force driver for raw transcripts (sniffed otherwise)
+  --speed N                    60 (default) | 1 (real time) | 0 (as-fast-as-possible)
+  --infer none|live            none (heuristics only, default) | live (real provider chain)
+  --export-replay <path>       Write normalized CanonicalEvents (Electron-loadable)
+  --report <path>              Write JSON report
+  --title <text>               Session title
+`;
+
+async function main(): Promise<void> {
+  const { file, options } = parseArgs(process.argv.slice(2));
+
+  if (!file || file === '--help') {
+    process.stdout.write(HELP);
+    process.exit(file === '--help' ? 0 : 1);
+  }
+
+  const report = await runReplay(options);
+
+  const { meta, aggregates, determinismHash, checkpoints } = report;
+  const lines: string[] = [];
+  lines.push(`replay: ${meta.input}`);
+  lines.push(`  driver=${meta.driver} session=${meta.sessionId} speed=${meta.speed} infer=${meta.infer}`);
+  lines.push(
+    `  events=${meta.events} virtual=${meta.durationVirtualMinutes.toFixed(1)}min ` +
+      `(${meta.startVirtualUtc ?? '?'} → ${meta.endVirtualUtc ?? '?'})`,
+  );
+  lines.push(`  ${determinismHash}`);
+  lines.push(
+    `  triggersFired=${aggregates.triggersFired} inferCalls=${aggregates.inferCalls} ` +
+      `latency p50/p95/max=${aggregates.latencyMs.p50}/${aggregates.latencyMs.p95}/${aggregates.latencyMs.max}ms ` +
+      `bufferDepthMax=${aggregates.bufferDepthMax}`,
+  );
+  lines.push('  checkpoints:');
+  for (const cp of checkpoints) {
+    if (cp.surfaced) {
+      const lead = cp.leadMinutes ?? 0;
+      const dir = lead >= 0 ? 'lead' : 'lag';
+      lines.push(`    [surfaced] ${cp.label} — ${Math.abs(lead).toFixed(1)}min ${dir}`);
+    } else {
+      lines.push(`    [ missed ] ${cp.label}`);
+    }
+  }
+  if (options.reportPath) lines.push(`  report → ${options.reportPath}`);
+  if (options.exportReplayPath) lines.push(`  replay → ${options.exportReplayPath}`);
+  process.stdout.write(`${lines.join('\n')}\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`replay failed: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/src/electron/session-io.ts
+++ b/src/electron/session-io.ts
@@ -2,7 +2,7 @@ import { dialog, type BrowserWindow } from 'electron';
 import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { paymentRefactorSession } from '../shared/fixtures/payment-refactor-session';
-import { parseReplay, serializeEvents } from '../shared/replay-store';
+import { detectReplayFormat, parseReplay, serializeEvents } from '../shared/replay-store';
 import { DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS } from '../shared/privacy';
 import type {
   CanonicalEvent,
@@ -45,33 +45,10 @@ export function createSnapshot(
   return snapshot;
 }
 
-export function detectReplayFormat(raw: string): 'replay' | 'transcript' {
-  const lines = raw
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .slice(0, 25);
-
-  if (lines.length === 0) {
-    return 'replay';
-  }
-
-  for (const line of lines) {
-    try {
-      const parsed = JSON.parse(line) as Record<string, unknown>;
-      if (typeof parsed.kind === 'string') {
-        return 'replay';
-      }
-      if ('sessionId' in parsed || 'message' in parsed) {
-        return 'transcript';
-      }
-    } catch {
-      // Try later lines. JSONL may contain non-JSON prelude lines.
-    }
-  }
-
-  return 'transcript';
-}
+// detectReplayFormat now lives in shared/replay-store.ts (no electron
+// dependency) so the headless replay runner can reuse it. Re-exported here to
+// preserve the existing import surface (`electron/session-io`).
+export { detectReplayFormat };
 
 export async function loadSnapshotFromFile(
   filePath: string,

--- a/src/inference/trigger.ts
+++ b/src/inference/trigger.ts
@@ -10,6 +10,7 @@
  */
 import type { CanonicalEvent, EventKind } from '../shared/schema';
 import { createLogger } from '../shared/logger';
+import { realClock, type Clock, type ClockTimer } from '../shared/clock';
 
 const logger = createLogger({ minLevel: 'info' });
 
@@ -27,7 +28,12 @@ const DEFAULT_CONFIG: TriggerConfig = {
   maxEventsBetween: 50,
 };
 
-export type TriggerCallback = () => void;
+/** Which condition caused a trigger to fire. */
+export type TriggerReason = 'immediate_kind' | 'max_events' | 'normal';
+
+// Callers may ignore the reason argument (existing ones do), so a plain
+// `() => void` remains assignable to TriggerCallback.
+export type TriggerCallback = (reason: TriggerReason) => void;
 
 export interface InferenceTrigger {
   onEvents(events: CanonicalEvent[]): void;
@@ -37,33 +43,34 @@ export interface InferenceTrigger {
 
 export function createInferenceTrigger(
   onTrigger: TriggerCallback,
-  config: Partial<TriggerConfig> = {}
+  config: Partial<TriggerConfig> = {},
+  clock: Clock = realClock
 ): InferenceTrigger {
   const cfg = { ...DEFAULT_CONFIG, ...config };
   let eventsSinceLastInference = 0;
   let lastInferenceAt = 0;
-  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let debounceTimer: ClockTimer | null = null;
 
-  const fire = () => {
-    if (debounceTimer) clearTimeout(debounceTimer);
+  const fire = (reason: TriggerReason) => {
+    if (debounceTimer) clock.clearTimeout(debounceTimer);
     debounceTimer = null;
     eventsSinceLastInference = 0;
-    lastInferenceAt = Date.now();
+    lastInferenceAt = clock.now();
     logger.info('inference', 'trigger.fired');
-    onTrigger();
+    onTrigger(reason);
   };
 
   const scheduleDebounced = () => {
     if (debounceTimer) return; // already pending
-    debounceTimer = setTimeout(() => {
-      fire();
+    debounceTimer = clock.setTimeout(() => {
+      fire('normal');
     }, 200); // small debounce to batch rapid events
   };
 
   return {
     onEvents(events: CanonicalEvent[]) {
       eventsSinceLastInference += events.length;
-      const now = Date.now();
+      const now = clock.now();
       const elapsed = now - lastInferenceAt;
 
       // Immediate conditions
@@ -72,14 +79,14 @@ export function createInferenceTrigger(
         logger.debug('inference', 'trigger.immediate_kind', {
           kinds: events.filter((e) => IMMEDIATE_KINDS.has(e.kind)).map((e) => e.kind),
         });
-        fire();
+        fire('immediate_kind');
         return;
       }
 
       // Force condition
       if (eventsSinceLastInference >= cfg.maxEventsBetween) {
         logger.debug('inference', 'trigger.max_events', { count: eventsSinceLastInference });
-        fire();
+        fire('max_events');
         return;
       }
 
@@ -99,12 +106,12 @@ export function createInferenceTrigger(
     reset() {
       eventsSinceLastInference = 0;
       lastInferenceAt = 0;
-      if (debounceTimer) clearTimeout(debounceTimer);
+      if (debounceTimer) clock.clearTimeout(debounceTimer);
       debounceTimer = null;
     },
 
     stop() {
-      if (debounceTimer) clearTimeout(debounceTimer);
+      if (debounceTimer) clock.clearTimeout(debounceTimer);
       debounceTimer = null;
     },
   };

--- a/src/replay/replay-runner.ts
+++ b/src/replay/replay-runner.ts
@@ -1,0 +1,663 @@
+/**
+ * Deterministic replay runner (plan-codex-replay.md, decision D3).
+ *
+ * Replays a captured harness session — raw transcript or normalized
+ * `.replay.jsonl` — through the real capture → derive → trigger → (optional)
+ * inference pipeline on a *virtual clock*, then answers the two questions the
+ * plan poses: is interpretation fast enough, and does it say the right things
+ * at the right times?
+ *
+ * Determinism comes from the virtual clock (src/shared/clock.ts). It drives
+ * both event release *and* the inference trigger's time gate + debounce, so the
+ * sequence of trigger firings is identical at every `--speed`. Wall-clock time
+ * only controls how long the runner sleeps between events (`delta / speed`);
+ * at speed 0 it never sleeps, yet virtual time still advances by the event
+ * timestamps, so the firing sequence is unchanged.
+ *
+ * In `--infer live` the provider call runs on wall-clock time while virtual
+ * time keeps advancing, so the report can measure how *stale* an insight is
+ * (virtual minutes between the trigger firing and the insight landing) — the
+ * latency-budget question from the plan.
+ */
+import { createHash } from 'node:crypto';
+import { readFile, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { CanonicalEvent, DerivedState, ShadowInsight } from '../shared/schema';
+import { createVirtualClock } from '../shared/clock';
+import { deriveState } from '../shared/derive';
+import { detectReplayFormat, parseReplay, serializeEvents } from '../shared/replay-store';
+import { createEventBuffer } from '../capture/event-buffer';
+import { createIncrementalParser, type ParsedEntry } from '../capture/incremental-parser';
+import { driverRegistry } from '../capture/drivers';
+import type { HarnessDriver } from '../capture/drivers/harness-driver';
+import {
+  createInferenceTrigger,
+  type TriggerConfig,
+  type TriggerReason,
+} from '../inference/trigger';
+import { buildContextPacket } from '../inference/context-packager';
+import { buildInferenceRequest } from '../inference/prompt-builder';
+import { parseModelResponse } from '../inference/response-parser';
+import { createInferenceClient } from '../inference/inference-client-factory';
+import type { InferenceClient } from '../inference/inference-client';
+import { createLogger, type Logger } from '../shared/logger';
+
+export type InferMode = 'none' | 'live';
+
+export interface ReplayOptions {
+  /** Path to a raw transcript or `.replay.jsonl`. Mutually exclusive with `events`. */
+  filePath?: string;
+  /** Pre-normalized CanonicalEvents (used by tests / programmatic callers). */
+  events?: CanonicalEvent[];
+  /** Force a driver for raw transcripts; sniffed when omitted. */
+  driver?: 'codex' | 'claude-code';
+  /** Replay speed multiplier. 60 = 60× (default), 1 = real time, 0 = as-fast-as-possible. */
+  speed?: number;
+  /** Inference mode. `none` = deriveState heuristics only; `live` = real provider chain. */
+  infer?: InferMode;
+  title?: string;
+  triggerConfig?: Partial<TriggerConfig>;
+  /** Write normalized CanonicalEvents (loadable by the Electron replay path) here. */
+  exportReplayPath?: string;
+  /** Write the JSON report here. */
+  reportPath?: string;
+  /** Injected client for tests; live mode uses the provider chain when absent. */
+  inferenceClient?: InferenceClient;
+  logger?: Logger;
+}
+
+export interface TriggerRecord {
+  seq: number;
+  reason: TriggerReason;
+  /** Virtual session time (ms since epoch) when the trigger fired. */
+  virtualTimeMs: number;
+  virtualTimeUtc: string;
+  /** Count of events released when the trigger fired. */
+  eventIndex: number;
+  /** Wall-clock latency of the inference call (0 for heuristic `none` mode). */
+  wallLatencyMs: number;
+  /** Virtual session time when the insight landed. */
+  insightVirtualTimeMs: number;
+  /** insightVirtualTimeMs − virtualTimeMs: how stale the insight is, in virtual ms. */
+  stalenessVirtualMs: number;
+  /** Events released between firing and insight landing (live latency signal). */
+  eventsBehind: number;
+  phase: string;
+  risks: string[];
+  insightSummaries: string[];
+  /** True when a live inference was already in flight and this firing was coalesced. */
+  coalesced?: boolean;
+  error?: string;
+}
+
+export interface CheckpointResult {
+  id: string;
+  label: string;
+  groundTruthUtc: string;
+  groundTruthVirtualMs: number;
+  surfaced: boolean;
+  firstInsightVirtualMs: number | null;
+  firstInsightUtc: string | null;
+  /** groundTruth − firstInsight, in virtual minutes. Positive = surfaced early (lead). */
+  leadMinutes: number | null;
+  matchedBy: string | null;
+}
+
+export interface ReplayReport {
+  meta: {
+    input: string;
+    sessionId: string;
+    driver: string;
+    speed: number;
+    infer: InferMode;
+    events: number;
+    startVirtualUtc: string | null;
+    endVirtualUtc: string | null;
+    durationVirtualMinutes: number;
+  };
+  determinismHash: string;
+  triggers: TriggerRecord[];
+  aggregates: {
+    events: number;
+    triggersFired: number;
+    inferCalls: number;
+    latencyMs: { p50: number; p95: number; max: number };
+    eventsBehind: { p50: number; p95: number; max: number };
+    bufferDepthMax: number;
+  };
+  checkpoints: CheckpointResult[];
+}
+
+/** One (virtual time, insight) observation, fed to the checkpoint scorer. */
+export interface InsightObservation {
+  virtualMs: number;
+  insight: ShadowInsight;
+}
+
+export interface Checkpoint {
+  id: string;
+  label: string;
+  /** The human-verified UTC moment this checkpoint occurred (from fixture timestamps). */
+  groundTruthUtc: string;
+  /** Does this insight surface the checkpoint? Matches over summary text / kind. */
+  match: (insight: ShadowInsight) => boolean;
+}
+
+const hasWord = (haystack: string, ...words: string[]): boolean =>
+  words.some((w) => haystack.includes(w));
+
+/**
+ * The four ground-truth checkpoints for the homelab-coordinator fixture, with
+ * their UTC moments taken from the fixture's own timestamps (see the
+ * ground-truth companion doc):
+ *   - the scope-drift turn_aborted at 12:54Z,
+ *   - the plan pivot (user reorients to a databases-only plan) at 13:39Z,
+ *     reinforced by "Implement the plan." at 14:04Z,
+ *   - the GHCR-403 stall — repeated near-identical web searches, 16:12–16:26Z,
+ *   - the final task_complete at 16:48Z that reports done while work is NOT done.
+ */
+export const DEFAULT_CHECKPOINTS: Checkpoint[] = [
+  {
+    id: 'scope_drift_abort',
+    label: 'Scope-drift turn aborted (~12:54Z)',
+    groundTruthUtc: '2026-07-23T12:54:24.326Z',
+    match: (i) =>
+      hasWord(
+        i.summary.toLowerCase(),
+        'abort',
+        'drift',
+        'off track',
+        'off-track',
+        'derail',
+        'interrupted the turn',
+      ),
+  },
+  {
+    id: 'plan_pivot',
+    label: 'Pivot to databases-only plan (13:39Z → 14:04Z)',
+    groundTruthUtc: '2026-07-23T13:39:12.004Z',
+    match: (i) => {
+      const s = i.summary.toLowerCase();
+      if (hasWord(s, 're-plan', 'replan', 'new plan', 'pivot', 'databases-only', 'database-only')) {
+        return true;
+      }
+      return s.includes('plan') && hasWord(s, 'database');
+    },
+  },
+  {
+    id: 'ghcr_stall',
+    label: 'GHCR-403 repeated-search stall (16:12–16:26Z)',
+    groundTruthUtc: '2026-07-23T16:12:10.188Z',
+    match: (i) =>
+      hasWord(
+        i.summary.toLowerCase(),
+        'repeated near-identical',
+        'repeated search',
+        'stuck retrying',
+        'retrying the same',
+        'same lookup',
+        'ghcr',
+        '403',
+      ),
+  },
+  {
+    id: 'final_not_done',
+    label: 'Final task_complete but work NOT done (16:48Z)',
+    groundTruthUtc: '2026-07-23T16:48:41.750Z',
+    match: (i) =>
+      hasWord(
+        i.summary.toLowerCase(),
+        'not done',
+        'incomplete',
+        'unfinished',
+        'not deployed',
+        'not started',
+        'undeployed',
+        'not complete',
+        'still not',
+        'prematurely',
+        'false completion',
+      ),
+  },
+];
+
+/**
+ * Pure checkpoint scorer: for each checkpoint, find the earliest observed
+ * insight that matches it and report lead/lag (in virtual minutes) versus the
+ * human ground-truth moment. Exported for unit testing with synthetic insights.
+ *
+ * `objective`-kind insights are excluded from matching: in heuristic mode the
+ * objective is a verbatim echo of the user's stated goal, so counting it as the
+ * interpreter "surfacing" a checkpoint would falsely credit a detection at
+ * t=0. Checkpoints must be surfaced by the interpreter's *analytical* insights
+ * (phase / risk / next_move / attention / summary), which is exactly what live
+ * inference is expected to add over the heuristics.
+ */
+export function scoreCheckpoints(
+  checkpoints: Checkpoint[],
+  observations: InsightObservation[],
+): CheckpointResult[] {
+  const ordered = [...observations]
+    .filter((o) => o.insight.kind !== 'objective')
+    .sort((a, b) => a.virtualMs - b.virtualMs);
+  return checkpoints.map((cp) => {
+    const groundTruthVirtualMs = Date.parse(cp.groundTruthUtc);
+    const hit = ordered.find((o) => cp.match(o.insight));
+    if (!hit) {
+      return {
+        id: cp.id,
+        label: cp.label,
+        groundTruthUtc: cp.groundTruthUtc,
+        groundTruthVirtualMs,
+        surfaced: false,
+        firstInsightVirtualMs: null,
+        firstInsightUtc: null,
+        leadMinutes: null,
+        matchedBy: null,
+      };
+    }
+    return {
+      id: cp.id,
+      label: cp.label,
+      groundTruthUtc: cp.groundTruthUtc,
+      groundTruthVirtualMs,
+      surfaced: true,
+      firstInsightVirtualMs: hit.virtualMs,
+      firstInsightUtc: new Date(hit.virtualMs).toISOString(),
+      leadMinutes: (groundTruthVirtualMs - hit.virtualMs) / 60_000,
+      matchedBy: hit.insight.summary,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Loading + driver routing
+// ---------------------------------------------------------------------------
+
+const CODEX_TOP_TYPES = new Set(['session_meta', 'response_item', 'event_msg', 'turn_context', 'compacted']);
+
+function sniffDriverId(raw: string): 'codex' | 'claude-code' {
+  const lines = raw
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .slice(0, 25);
+  for (const line of lines) {
+    try {
+      const parsed = JSON.parse(line) as Record<string, unknown>;
+      if (typeof parsed.type === 'string' && CODEX_TOP_TYPES.has(parsed.type)) {
+        return 'codex';
+      }
+    } catch {
+      // ignore non-JSON prelude lines
+    }
+  }
+  return 'claude-code';
+}
+
+function extractCodexSessionId(raw: string, fallback: string): string {
+  const lines = raw.split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || !trimmed.includes('session_meta')) continue;
+    try {
+      const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+      if (parsed.type !== 'session_meta') continue;
+      const payload = (parsed.payload ?? {}) as Record<string, unknown>;
+      const id = payload.session_id ?? payload.id;
+      if (typeof id === 'string' && id.length > 0) return id;
+    } catch {
+      // keep scanning
+    }
+  }
+  return fallback;
+}
+
+interface LoadedEvents {
+  events: CanonicalEvent[];
+  sessionId: string;
+  driverId: string;
+}
+
+function dominantHarnessId(events: CanonicalEvent[]): string {
+  const counts = new Map<string, number>();
+  for (const e of events) {
+    const id = e.harnessId ?? e.source;
+    counts.set(id, (counts.get(id) ?? 0) + 1);
+  }
+  let best = 'replay';
+  let max = 0;
+  for (const [id, n] of counts) {
+    if (n > max) {
+      best = id;
+      max = n;
+    }
+  }
+  return best;
+}
+
+/**
+ * Load and normalize a transcript/replay file into CanonicalEvents. A
+ * `.replay.jsonl` is parsed directly (already normalized); a raw transcript is
+ * routed through the incremental parser and the chosen driver's normalizer —
+ * the same deterministic-ID path the live capture layer uses.
+ */
+export function loadEvents(raw: string, source: string, driverOverride?: 'codex' | 'claude-code'): LoadedEvents {
+  const fallbackSessionId = path.basename(source).replace(/\.[^.]+$/, '') || 'replay-session';
+
+  if (detectReplayFormat(raw) === 'replay') {
+    const events = parseReplay(raw);
+    return { events, sessionId: events[0]?.sessionId ?? fallbackSessionId, driverId: dominantHarnessId(events) };
+  }
+
+  const driverId = driverOverride ?? sniffDriverId(raw);
+  const driver: HarnessDriver = driverRegistry.get(driverId) ?? driverRegistry.getDefault();
+  const sessionId =
+    driverId === 'codex' ? extractCodexSessionId(raw, fallbackSessionId) : fallbackSessionId;
+  const driverSource = driver.sources[0];
+
+  const events: CanonicalEvent[] = [];
+  const parser = createIncrementalParser((entry: ParsedEntry) => {
+    for (const event of driver.normalizeEntry(entry, sessionId, driverSource)) {
+      events.push(event);
+    }
+  });
+  parser.push(raw);
+  parser.push('\n'); // flush any trailing line held in the parser buffer
+  return { events, sessionId, driverId: driver.id };
+}
+
+// ---------------------------------------------------------------------------
+// Report helpers
+// ---------------------------------------------------------------------------
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+  return sorted[idx];
+}
+
+function summarizeMetric(values: number[]): { p50: number; p95: number; max: number } {
+  const sorted = [...values].sort((a, b) => a - b);
+  return {
+    p50: percentile(sorted, 50),
+    p95: percentile(sorted, 95),
+    max: sorted.length ? sorted[sorted.length - 1] : 0,
+  };
+}
+
+/** Max characters kept per insight summary in the report (keeps it readable). */
+const SUMMARY_PREVIEW_LIMIT = 200;
+
+function insightSummaries(insights: ShadowInsight[]): string[] {
+  return insights.map((i) => {
+    const oneLine = i.summary.replace(/\s+/g, ' ').trim();
+    const preview =
+      oneLine.length > SUMMARY_PREVIEW_LIMIT ? `${oneLine.slice(0, SUMMARY_PREVIEW_LIMIT)}…` : oneLine;
+    return `${i.kind}: ${preview}`;
+  });
+}
+
+function virtualMsOf(event: CanonicalEvent): number {
+  const parsed = Date.parse(event.timestamp);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function realWait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+export async function runReplay(options: ReplayOptions): Promise<ReplayReport> {
+  const logger = options.logger ?? createLogger({ minLevel: 'warn' });
+  const speed = options.speed ?? 60;
+  const inferMode: InferMode = options.infer ?? 'none';
+  const title = options.title ?? 'Replayed session';
+
+  // --- load ----------------------------------------------------------------
+  let loaded: LoadedEvents;
+  let inputLabel: string;
+  if (options.events) {
+    loaded = {
+      events: options.events,
+      sessionId: options.events[0]?.sessionId ?? 'synthetic',
+      driverId: dominantHarnessId(options.events),
+    };
+    inputLabel = '<in-memory events>';
+  } else if (options.filePath) {
+    const raw = await readFile(options.filePath, 'utf8');
+    loaded = loadEvents(raw, options.filePath, options.driver);
+    inputLabel = options.filePath;
+  } else {
+    throw new Error('runReplay requires either `events` or `filePath`.');
+  }
+
+  const { events, sessionId, driverId } = loaded;
+
+  // --- virtual clock + buffer + trigger ------------------------------------
+  const clock = createVirtualClock(events.length ? virtualMsOf(events[0]) : 0);
+  const buffer = createEventBuffer({
+    // Keep everything in memory (no spill) so the runner reads a stable,
+    // untouched event window and the run stays byte-deterministic.
+    memoryCapacity: Math.max(1, events.length + 16),
+    totalCapacity: Math.max(1, events.length + 16),
+    sessionId: `replay-${sessionId}-${process.pid}-${Date.now()}`,
+    persistenceRoot: path.join(os.tmpdir(), 'shadow-agent-replay-runner'),
+  });
+
+  const released: CanonicalEvent[] = [];
+  const triggerFirings: Array<{ eventIndex: number; reason: TriggerReason }> = [];
+  const triggerRecords: TriggerRecord[] = [];
+  const observations: InsightObservation[] = [];
+  let bufferDepthMax = 0;
+  let seq = 0;
+
+  // Live-mode single-in-flight inference with one coalesced slot (mirrors the
+  // shadow engine's concurrency contract).
+  let client: InferenceClient | null = null;
+  let inflight = false;
+  let queued: TriggerRecord | null = null;
+  const inflightPromises: Array<Promise<void>> = [];
+
+  const recordHeuristic = (record: TriggerRecord, state: DerivedState, firedVirtualMs: number) => {
+    record.wallLatencyMs = 0;
+    record.insightVirtualTimeMs = firedVirtualMs;
+    record.stalenessVirtualMs = 0;
+    record.eventsBehind = 0;
+    record.phase = state.activePhase;
+    record.risks = state.riskSignals;
+    record.insightSummaries = insightSummaries(state.shadowInsights);
+    for (const insight of state.shadowInsights) {
+      observations.push({ virtualMs: firedVirtualMs, insight });
+    }
+  };
+
+  const startLiveInference = (record: TriggerRecord) => {
+    if (!client) return;
+    inflight = true;
+    const snapshot = released.slice();
+    const state = deriveState(snapshot, title);
+    const packet = buildContextPacket(state, snapshot);
+    const request = buildInferenceRequest(packet, {
+      delivery: 'off-host',
+      privacy: { allowRawTranscriptStorage: true, allowOffHostInference: true },
+    });
+    const dispatchEventIndex = released.length;
+    const wallStart = Date.now();
+    const activeClient = client;
+    const promise = activeClient
+      .infer(request)
+      .then((response) => {
+        const insights = parseModelResponse(response.text);
+        const landVirtualMs = clock.now();
+        record.wallLatencyMs = Date.now() - wallStart;
+        record.insightVirtualTimeMs = landVirtualMs;
+        record.stalenessVirtualMs = landVirtualMs - record.virtualTimeMs;
+        record.eventsBehind = released.length - dispatchEventIndex;
+        record.phase = state.activePhase;
+        record.risks = state.riskSignals;
+        record.insightSummaries = insightSummaries(insights);
+        for (const insight of insights) {
+          observations.push({ virtualMs: landVirtualMs, insight });
+        }
+      })
+      .catch((err: unknown) => {
+        record.error = err instanceof Error ? err.message : String(err);
+        logger.error('inference', 'replay.live_infer_error', { error: err });
+      })
+      .finally(() => {
+        inflight = false;
+        if (queued) {
+          const next = queued;
+          queued = null;
+          startLiveInference(next);
+        }
+      });
+    inflightPromises.push(promise);
+  };
+
+  const onTrigger = (reason: TriggerReason) => {
+    const firedVirtualMs = clock.now();
+    const eventIndex = released.length;
+    triggerFirings.push({ eventIndex, reason });
+
+    const record: TriggerRecord = {
+      seq: seq++,
+      reason,
+      virtualTimeMs: firedVirtualMs,
+      virtualTimeUtc: new Date(firedVirtualMs).toISOString(),
+      eventIndex,
+      wallLatencyMs: 0,
+      insightVirtualTimeMs: firedVirtualMs,
+      stalenessVirtualMs: 0,
+      eventsBehind: 0,
+      phase: '',
+      risks: [],
+      insightSummaries: [],
+    };
+    triggerRecords.push(record);
+
+    if (inferMode === 'none' || !client) {
+      const state = deriveState(released.slice(), title);
+      recordHeuristic(record, state, firedVirtualMs);
+      return;
+    }
+
+    // live
+    if (inflight) {
+      if (queued) queued.coalesced = true;
+      queued = record;
+      return;
+    }
+    startLiveInference(record);
+  };
+
+  const trigger = createInferenceTrigger(onTrigger, options.triggerConfig, clock);
+
+  const unsubscribe = buffer.subscribe((batch) => {
+    trigger.onEvents(batch);
+  });
+
+  if (inferMode === 'live') {
+    client = options.inferenceClient ?? (await createInferenceClient());
+    if (!client) {
+      logger.warn('inference', 'replay.no_live_client', {
+        message: 'No inference client available; falling back to heuristics.',
+      });
+    }
+  }
+
+  // --- pacing loop ---------------------------------------------------------
+  let prevMs = events.length ? virtualMsOf(events[0]) : 0;
+  for (const event of events) {
+    const ms = Math.max(virtualMsOf(event), prevMs); // clamp non-decreasing
+    if (speed > 0) {
+      const waitMs = (ms - prevMs) / speed;
+      if (waitMs > 0) await realWait(waitMs);
+    }
+    // Advance virtual time to this event *first* so any debounced trigger
+    // scheduled by earlier events fires at its correct virtual moment, before
+    // this event is counted as released.
+    clock.advanceTo(ms);
+    released.push(event);
+    await buffer.push([event]);
+    const depth = buffer.getMetrics().totalDepth;
+    if (depth > bufferDepthMax) bufferDepthMax = depth;
+    prevMs = ms;
+  }
+
+  // Flush any still-pending debounce so a final normal-condition trigger fires.
+  clock.drain();
+
+  // Wait for live inference (in-flight + one coalesced slot) to settle.
+  while (inflightPromises.length > 0) {
+    const pending = inflightPromises.splice(0, inflightPromises.length);
+    await Promise.allSettled(pending);
+  }
+
+  trigger.stop();
+  unsubscribe();
+  await buffer.clear();
+
+  // --- report --------------------------------------------------------------
+  const inferCalls = triggerRecords.filter((r) => !r.coalesced).length;
+  const latencyValues = triggerRecords.filter((r) => !r.coalesced).map((r) => r.wallLatencyMs);
+  const eventsBehindValues = triggerRecords.filter((r) => !r.coalesced).map((r) => r.eventsBehind);
+
+  const startVirtualMs = events.length ? virtualMsOf(events[0]) : null;
+  const endVirtualMs = events.length ? Math.max(...events.map(virtualMsOf)) : null;
+
+  const hashInput =
+    events.map((e) => e.id).join('\n') +
+    '\n@@TRIGGERS@@\n' +
+    triggerFirings.map((t) => `${t.eventIndex}:${t.reason}`).join(',');
+  const determinismHash = `sha256:${createHash('sha256').update(hashInput).digest('hex')}`;
+
+  const report: ReplayReport = {
+    meta: {
+      input: inputLabel,
+      sessionId,
+      driver: driverId,
+      speed,
+      infer: inferMode,
+      events: events.length,
+      startVirtualUtc: startVirtualMs !== null ? new Date(startVirtualMs).toISOString() : null,
+      endVirtualUtc: endVirtualMs !== null ? new Date(endVirtualMs).toISOString() : null,
+      durationVirtualMinutes:
+        startVirtualMs !== null && endVirtualMs !== null
+          ? (endVirtualMs - startVirtualMs) / 60_000
+          : 0,
+    },
+    determinismHash,
+    triggers: triggerRecords,
+    aggregates: {
+      events: events.length,
+      triggersFired: triggerFirings.length,
+      inferCalls,
+      latencyMs: summarizeMetric(latencyValues),
+      eventsBehind: summarizeMetric(eventsBehindValues),
+      bufferDepthMax,
+    },
+    checkpoints: scoreCheckpoints(DEFAULT_CHECKPOINTS, observations),
+  };
+
+  // --- side outputs --------------------------------------------------------
+  if (options.exportReplayPath) {
+    const serialized = serializeEvents(
+      events,
+      { storeRawTranscript: true },
+      { allowRawTranscriptStorage: true, allowOffHostInference: false },
+    );
+    await writeFile(options.exportReplayPath, `${serialized}\n`, 'utf8');
+  }
+  if (options.reportPath) {
+    await writeFile(options.reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  }
+
+  return report;
+}

--- a/src/shared/clock.ts
+++ b/src/shared/clock.ts
@@ -1,0 +1,149 @@
+/**
+ * Clock abstraction — an injectable time source.
+ *
+ * The essential surface is `now(): number` (see plan-codex-replay.md D3, item
+ * A). It is extended here with `setTimeout` / `clearTimeout` because the only
+ * consumer that needs a *virtual* clock — the deterministic replay runner —
+ * also needs debounced timers (the inference trigger's 200 ms batch window) to
+ * advance on virtual time rather than wall time. Without that, a debounce
+ * scheduled with the real `setTimeout` would fire on the host event loop and
+ * make trigger firing depend on replay speed, breaking determinism.
+ *
+ * `realClock` delegates to the host globals, so injecting it (or nothing) is
+ * byte-for-byte identical to the pre-existing `Date.now()` / `setTimeout`
+ * behavior — every existing caller and test is unaffected.
+ */
+
+/**
+ * Opaque handle returned by {@link Clock.setTimeout}. For the real clock this
+ * is the host timer object; for the virtual clock it is a small branded token.
+ */
+export type ClockTimer = ReturnType<typeof setTimeout> | { readonly __virtualTimerId: number };
+
+export interface Clock {
+  /** Current time in milliseconds (wall-clock for the real clock). */
+  now(): number;
+  /** Schedule `handler` to run after `ms` of this clock's time has elapsed. */
+  setTimeout(handler: () => void, ms: number): ClockTimer;
+  /** Cancel a pending timer. No-op for null/undefined/unknown handles. */
+  clearTimeout(timer: ClockTimer | null | undefined): void;
+}
+
+/**
+ * The default clock: reads wall-clock time and schedules real host timers.
+ * Behaviorally identical to calling the globals directly.
+ */
+export const realClock: Clock = {
+  now: () => Date.now(),
+  setTimeout: (handler, ms) => setTimeout(handler, ms),
+  clearTimeout: (timer) => {
+    if (timer != null && !(typeof timer === 'object' && '__virtualTimerId' in timer)) {
+      clearTimeout(timer);
+    }
+  },
+};
+
+interface VirtualTimer {
+  id: number;
+  due: number;
+  seq: number;
+  handler: () => void;
+}
+
+/**
+ * A virtual clock for deterministic simulation. Time never flows on its own —
+ * it only moves when {@link VirtualClock.advanceTo} or
+ * {@link VirtualClock.drain} is called, at which point any timers whose due
+ * time has been reached fire in (due, insertion) order. Because both the
+ * current time and every scheduled callback are driven purely by these calls,
+ * a replay produces an identical sequence of `now()` reads and timer firings
+ * regardless of how fast (or slow) wall-clock time is passing.
+ */
+export interface VirtualClock extends Clock {
+  /** Set the current virtual time without firing any timers. */
+  setStart(virtualMs: number): void;
+  /**
+   * Advance virtual time to `virtualMs`, firing every timer due at or before
+   * it (in order). Never moves time backwards. Handlers may schedule further
+   * timers, which fire too if they fall within the advance window.
+   */
+  advanceTo(virtualMs: number): void;
+  /** Fire all remaining timers in due order, advancing time to the last one. */
+  drain(): void;
+  /** Number of timers still pending. */
+  pendingTimers(): number;
+}
+
+export function createVirtualClock(startMs = 0): VirtualClock {
+  let current = startMs;
+  let nextId = 1;
+  let seqCounter = 0;
+  let timers: VirtualTimer[] = [];
+
+  const earliestDueIndex = (upTo: number | null): number => {
+    let best = -1;
+    for (let i = 0; i < timers.length; i += 1) {
+      const t = timers[i];
+      if (upTo !== null && t.due > upTo) continue;
+      if (
+        best === -1 ||
+        t.due < timers[best].due ||
+        (t.due === timers[best].due && t.seq < timers[best].seq)
+      ) {
+        best = i;
+      }
+    }
+    return best;
+  };
+
+  const fireDue = (upTo: number | null): void => {
+    // Loop rather than iterate a snapshot: a fired handler may enqueue a new
+    // timer that is itself due within this same advance window.
+    for (;;) {
+      const idx = earliestDueIndex(upTo);
+      if (idx === -1) break;
+      const timer = timers[idx];
+      timers.splice(idx, 1);
+      current = Math.max(current, timer.due);
+      timer.handler();
+    }
+  };
+
+  return {
+    now: () => current,
+    setTimeout(handler, ms) {
+      const timer: VirtualTimer = {
+        id: nextId++,
+        due: current + Math.max(0, ms),
+        seq: seqCounter++,
+        handler,
+      };
+      timers.push(timer);
+      return { __virtualTimerId: timer.id };
+    },
+    clearTimeout(timer) {
+      if (timer && typeof timer === 'object' && '__virtualTimerId' in timer) {
+        const id = timer.__virtualTimerId;
+        timers = timers.filter((t) => t.id !== id);
+      }
+    },
+    setStart(virtualMs) {
+      current = virtualMs;
+    },
+    advanceTo(virtualMs) {
+      if (virtualMs <= current) {
+        // Still fire anything already due at `current` (e.g. a 0 ms timer).
+        fireDue(current);
+        return;
+      }
+      fireDue(virtualMs);
+      current = Math.max(current, virtualMs);
+    },
+    drain() {
+      fireDue(null);
+    },
+    pendingTimers() {
+      return timers.length;
+    },
+  };
+}

--- a/src/shared/replay-store.ts
+++ b/src/shared/replay-store.ts
@@ -10,6 +10,42 @@ export function serializeEvents(
   return prepared.map((event) => JSON.stringify(event)).join('\n');
 }
 
+/**
+ * Sniff whether a raw JSONL blob is an already-normalized CanonicalEvent
+ * replay (`.replay.jsonl`) or a raw harness transcript. A CanonicalEvent line
+ * always carries a top-level `kind`; a raw transcript line does not. Lives here
+ * (next to parseReplay/serializeEvents) rather than in the Electron layer so
+ * headless consumers — the replay runner CLI — can reuse it without importing
+ * `electron`. Re-exported from `electron/session-io.ts` for the app path.
+ */
+export function detectReplayFormat(raw: string): 'replay' | 'transcript' {
+  const lines = raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, 25);
+
+  if (lines.length === 0) {
+    return 'replay';
+  }
+
+  for (const line of lines) {
+    try {
+      const parsed = JSON.parse(line) as Record<string, unknown>;
+      if (typeof parsed.kind === 'string') {
+        return 'replay';
+      }
+      if ('sessionId' in parsed || 'message' in parsed) {
+        return 'transcript';
+      }
+    } catch {
+      // Try later lines. JSONL may contain non-JSON prelude lines.
+    }
+  }
+
+  return 'transcript';
+}
+
 export function parseReplay(text: string): CanonicalEvent[] {
   const events: CanonicalEvent[] = [];
   const lines = text.split(/\r?\n/);

--- a/tests/replay/replay-runner.test.ts
+++ b/tests/replay/replay-runner.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from 'vitest';
+import { readFile, mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  runReplay,
+  loadEvents,
+  scoreCheckpoints,
+  DEFAULT_CHECKPOINTS,
+  type Checkpoint,
+} from '../../src/replay/replay-runner';
+import { detectReplayFormat, parseReplay } from '../../src/shared/replay-store';
+import type { CanonicalEvent, ShadowInsight } from '../../src/shared/schema';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.resolve(
+  HERE,
+  '../fixtures/transcripts/codex/rollout-2026-07-23-homelab-coordinator.jsonl',
+);
+
+/** A small synthetic canonical event stream for speed-invariance testing. */
+function syntheticEvents(): CanonicalEvent[] {
+  const start = Date.parse('2026-01-01T00:00:00.000Z');
+  const spanMs = 5 * 60_000; // 5 virtual minutes
+  const count = 30;
+  const events: CanonicalEvent[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const ts = new Date(start + Math.round((spanMs * i) / (count - 1))).toISOString();
+    // Sprinkle a couple of immediate-kind events so trigger firings are non-trivial.
+    const kind: CanonicalEvent['kind'] = i === 12 ? 'tool_failed' : i === 25 ? 'agent_completed' : 'message';
+    events.push({
+      id: `synthetic:${i}`,
+      sessionId: 'synthetic-session',
+      source: 'codex-rollout',
+      timestamp: ts,
+      actor: i % 2 === 0 ? 'agent' : 'user',
+      kind,
+      payload: kind === 'message' ? { text: `event ${i}` } : { toolName: 'bash', toolUseId: `t${i}` },
+      harnessId: 'codex',
+    });
+  }
+  return events;
+}
+
+describe('replay-runner determinism', () => {
+  it('produces identical determinism hashes and trigger firings across two speed-0 runs', async () => {
+    const runA = await runReplay({ filePath: FIXTURE, speed: 0, infer: 'none' });
+    const runB = await runReplay({ filePath: FIXTURE, speed: 0, infer: 'none' });
+
+    expect(runA.determinismHash).toBe(runB.determinismHash);
+    expect(runA.meta.events).toBe(runB.meta.events);
+    expect(runA.meta.events).toBeGreaterThan(0);
+
+    const firingsA = runA.triggers.map((t) => `${t.eventIndex}:${t.reason}`);
+    const firingsB = runB.triggers.map((t) => `${t.eventIndex}:${t.reason}`);
+    expect(firingsA).toEqual(firingsB);
+    expect(firingsA.length).toBeGreaterThan(0);
+  }, 60_000);
+});
+
+describe('replay-runner speed invariance', () => {
+  it('produces the identical trigger sequence at speed 0 and a high speed', async () => {
+    const events = syntheticEvents();
+    const slow = await runReplay({ events, speed: 100_000, infer: 'none' });
+    const fast = await runReplay({ events, speed: 0, infer: 'none' });
+
+    expect(slow.determinismHash).toBe(fast.determinismHash);
+    const firingsSlow = slow.triggers.map((t) => `${t.eventIndex}:${t.reason}`);
+    const firingsFast = fast.triggers.map((t) => `${t.eventIndex}:${t.reason}`);
+    expect(firingsSlow).toEqual(firingsFast);
+    // The two immediate-kind events must both force a firing.
+    expect(firingsFast.some((f) => f.endsWith('immediate_kind'))).toBe(true);
+  }, 30_000);
+});
+
+describe('replay-runner report + export', () => {
+  it('reports aggregates and scores every ground-truth checkpoint', async () => {
+    const report = await runReplay({ filePath: FIXTURE, speed: 0, infer: 'none' });
+
+    expect(report.meta.driver).toBe('codex');
+    expect(report.aggregates.events).toBe(report.meta.events);
+    expect(report.aggregates.triggersFired).toBeGreaterThan(0);
+    expect(report.checkpoints).toHaveLength(4);
+
+    for (const cp of report.checkpoints) {
+      expect(cp.groundTruthVirtualMs).toBe(Date.parse(cp.groundTruthUtc));
+    }
+
+    // The semantic checkpoints (a scope-drift abort, a false "done" claim) are
+    // NOT recoverable by deriveState heuristics — surfacing them is exactly the
+    // job of live inference (plan-codex-replay.md D3). The report makes that
+    // blind spot explicit rather than guessing.
+    const abort = report.checkpoints.find((c) => c.id === 'scope_drift_abort')!;
+    const notDone = report.checkpoints.find((c) => c.id === 'final_not_done')!;
+    expect(abort.surfaced).toBe(false);
+    expect(notDone.surfaced).toBe(false);
+  }, 60_000);
+
+  it('exports normalized CanonicalEvents that the replay parser can reload', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'replay-runner-test-'));
+    const exportPath = path.join(dir, 'out.replay.jsonl');
+    const reportPath = path.join(dir, 'report.json');
+    try {
+      const report = await runReplay({
+        filePath: FIXTURE,
+        speed: 0,
+        infer: 'none',
+        exportReplayPath: exportPath,
+        reportPath,
+      });
+
+      const exported = await readFile(exportPath, 'utf8');
+      expect(detectReplayFormat(exported)).toBe('replay');
+      const reloaded = parseReplay(exported);
+      expect(reloaded).toHaveLength(report.meta.events);
+      expect(reloaded[0].id.startsWith('codex:')).toBe(true);
+
+      const writtenReport = JSON.parse(await readFile(reportPath, 'utf8'));
+      expect(writtenReport.determinismHash).toBe(report.determinismHash);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }, 60_000);
+});
+
+describe('loadEvents driver routing', () => {
+  it('routes a raw codex transcript through the codex driver with deterministic ids', async () => {
+    const raw = await readFile(FIXTURE, 'utf8');
+    const a = loadEvents(raw, FIXTURE);
+    const b = loadEvents(raw, FIXTURE);
+    expect(a.driverId).toBe('codex');
+    expect(a.events.length).toBeGreaterThan(0);
+    expect(a.events.map((e) => e.id)).toEqual(b.events.map((e) => e.id));
+    expect(a.events[0].id.startsWith('codex:')).toBe(true);
+  });
+
+  it('parses an already-normalized replay stream without a driver', () => {
+    const events: CanonicalEvent[] = [
+      {
+        id: 'x:1',
+        sessionId: 's',
+        source: 'codex-rollout',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        actor: 'agent',
+        kind: 'message',
+        payload: { text: 'hi' },
+        harnessId: 'codex',
+      },
+    ];
+    const jsonl = events.map((e) => JSON.stringify(e)).join('\n');
+    const loaded = loadEvents(jsonl, 'x.replay.jsonl');
+    expect(loaded.events).toHaveLength(1);
+    expect(loaded.driverId).toBe('codex');
+  });
+});
+
+describe('scoreCheckpoints', () => {
+  const makeInsight = (summary: string, kind: ShadowInsight['kind'] = 'risk'): ShadowInsight => ({
+    kind,
+    source: 'heuristic',
+    confidence: 0.6,
+    scope: 'session',
+    summary,
+    evidenceEventIds: [],
+  });
+
+  it('reports the first matching insight and computes lead in virtual minutes', () => {
+    const gt = Date.parse('2026-07-23T16:12:10.188Z');
+    const early = gt - 5 * 60_000; // surfaced 5 min before the human moment
+    const later = gt + 2 * 60_000;
+    const observations = [
+      { virtualMs: later, insight: makeInsight('agent is stuck retrying the same lookup') },
+      { virtualMs: early, insight: makeInsight('repeated near-identical search queries detected') },
+    ];
+    const results = scoreCheckpoints(DEFAULT_CHECKPOINTS, observations);
+    const ghcr = results.find((r) => r.id === 'ghcr_stall')!;
+    expect(ghcr.surfaced).toBe(true);
+    expect(ghcr.firstInsightVirtualMs).toBe(early); // earliest match wins
+    expect(ghcr.leadMinutes).toBeCloseTo(5, 5);
+  });
+
+  it('marks a checkpoint unsurfaced when nothing matches', () => {
+    const results = scoreCheckpoints(DEFAULT_CHECKPOINTS, [
+      { virtualMs: 0, insight: makeInsight('current phase appears to be exploration', 'phase') },
+    ]);
+    const abort = results.find((r) => r.id === 'scope_drift_abort')!;
+    expect(abort.surfaced).toBe(false);
+    expect(abort.leadMinutes).toBeNull();
+    expect(abort.matchedBy).toBeNull();
+  });
+
+  it('reports negative lead (lag) when the insight surfaces after the moment', () => {
+    const gt = Date.parse('2026-07-23T13:39:12.004Z');
+    const late = gt + 10 * 60_000;
+    const custom: Checkpoint[] = DEFAULT_CHECKPOINTS.filter((c) => c.id === 'plan_pivot');
+    const results = scoreCheckpoints(custom, [
+      { virtualMs: late, insight: makeInsight('the agent has pivoted to a new plan', 'summary') },
+    ]);
+    expect(results[0].surfaced).toBe(true);
+    expect(results[0].leadMinutes).toBeCloseTo(-10, 5);
+  });
+
+  it('ignores verbatim objective-echo insights when matching', () => {
+    const custom: Checkpoint[] = DEFAULT_CHECKPOINTS.filter((c) => c.id === 'plan_pivot');
+    // Same text that would match, but as an `objective` echo of the user goal —
+    // must not count as the interpreter surfacing the pivot.
+    const results = scoreCheckpoints(custom, [
+      { virtualMs: 0, insight: makeInsight('write a new plan for the databases', 'objective') },
+    ]);
+    expect(results[0].surfaced).toBe(false);
+  });
+});

--- a/tests/replay/virtual-clock.test.ts
+++ b/tests/replay/virtual-clock.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createVirtualClock, realClock } from '../../src/shared/clock';
+import { createInferenceTrigger } from '../../src/inference/trigger';
+import type { CanonicalEvent } from '../../src/shared/schema';
+
+const makeEvent = (kind: CanonicalEvent['kind'] = 'message'): CanonicalEvent => ({
+  id: `${kind}-${Math.random()}`,
+  kind,
+  timestamp: new Date().toISOString(),
+  source: 'codex-rollout',
+  sessionId: 'sess',
+  actor: 'agent',
+  payload: {},
+  harnessId: 'codex',
+});
+
+describe('createVirtualClock', () => {
+  it('does not advance time on its own', () => {
+    const clock = createVirtualClock(1000);
+    expect(clock.now()).toBe(1000);
+    expect(clock.now()).toBe(1000);
+  });
+
+  it('fires timers in due order as time advances', () => {
+    const clock = createVirtualClock(0);
+    const order: string[] = [];
+    clock.setTimeout(() => order.push('b'), 200);
+    clock.setTimeout(() => order.push('a'), 100);
+    clock.setTimeout(() => order.push('c'), 300);
+
+    clock.advanceTo(150);
+    expect(order).toEqual(['a']);
+    expect(clock.now()).toBe(150);
+
+    clock.advanceTo(250);
+    expect(order).toEqual(['a', 'b']);
+
+    clock.advanceTo(1000);
+    expect(order).toEqual(['a', 'b', 'c']);
+    expect(clock.now()).toBe(1000);
+  });
+
+  it('clearTimeout cancels a pending virtual timer', () => {
+    const clock = createVirtualClock(0);
+    const spy = vi.fn();
+    const t = clock.setTimeout(spy, 100);
+    clock.clearTimeout(t);
+    clock.advanceTo(1000);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('drain fires all remaining timers in due order', () => {
+    const clock = createVirtualClock(0);
+    const order: number[] = [];
+    clock.setTimeout(() => order.push(2), 200);
+    clock.setTimeout(() => order.push(1), 100);
+    clock.drain();
+    expect(order).toEqual([1, 2]);
+    expect(clock.pendingTimers()).toBe(0);
+  });
+
+  it('handlers may schedule further timers that still fire within the advance', () => {
+    const clock = createVirtualClock(0);
+    const order: string[] = [];
+    clock.setTimeout(() => {
+      order.push('first');
+      clock.setTimeout(() => order.push('second'), 50);
+    }, 100);
+    clock.advanceTo(1000);
+    expect(order).toEqual(['first', 'second']);
+  });
+
+  it('realClock exposes now/setTimeout/clearTimeout', () => {
+    expect(typeof realClock.now()).toBe('number');
+    const handle = realClock.setTimeout(() => undefined, 10_000);
+    realClock.clearTimeout(handle); // must not throw
+  });
+});
+
+describe('createInferenceTrigger with an injected virtual clock', () => {
+  it('time gate reads virtual time, not wall time', () => {
+    const clock = createVirtualClock(0);
+    const cb = vi.fn();
+    const trigger = createInferenceTrigger(
+      cb,
+      { minEventsBetween: 2, timeBetweenMs: 1000, maxEventsBetween: 999 },
+      clock,
+    );
+
+    // Enough events, but only 0 virtual ms elapsed → time gate blocks.
+    trigger.onEvents([makeEvent(), makeEvent()]);
+    expect(cb).not.toHaveBeenCalled();
+
+    // Advance virtual time past the gate, deliver one more event → schedules
+    // the 200 ms debounce on the virtual clock.
+    clock.advanceTo(2000);
+    trigger.onEvents([makeEvent()]);
+    expect(cb).not.toHaveBeenCalled(); // debounce still pending
+
+    // Advancing past the debounce window fires exactly one 'normal' trigger.
+    clock.advanceTo(2200);
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith('normal');
+    trigger.stop();
+  });
+
+  it('immediate kinds fire synchronously regardless of the clock', () => {
+    const clock = createVirtualClock(5000);
+    const cb = vi.fn();
+    const trigger = createInferenceTrigger(cb, {}, clock);
+    trigger.onEvents([makeEvent('tool_failed')]);
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith('immediate_kind');
+    trigger.stop();
+  });
+
+  it('max events forces a firing under the virtual clock', () => {
+    const clock = createVirtualClock(0);
+    const cb = vi.fn();
+    const trigger = createInferenceTrigger(
+      cb,
+      { minEventsBetween: 100, timeBetweenMs: 9_999_999, maxEventsBetween: 3 },
+      clock,
+    );
+    trigger.onEvents([makeEvent(), makeEvent(), makeEvent()]);
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith('max_events');
+    trigger.stop();
+  });
+});


### PR DESCRIPTION
## **User description**
Implements **PR-3** of the Codex ingestion + deterministic replay series (`docs/plans/plan-codex-replay.md`, decision **D3**). Stacked on #113 (`feat/codex-driver`).

## What this adds

- **Virtual clock** (`src/shared/clock.ts`): a `Clock` abstraction (`now` + `setTimeout`/`clearTimeout`) with a `realClock` default and a `createVirtualClock` for deterministic simulation. `createInferenceTrigger` now takes an optional clock (default `realClock`) and routes its time gate **and** debounce through it — default behavior is byte-identical, existing trigger tests unchanged. The trigger callback also reports the firing reason (`immediate_kind | max_events | normal`).

- **Replay runner** (`src/replay/replay-runner.ts`, CLI `scripts/replay.ts`, wired as `npm run replay`):
  - Input: raw transcript (routed through the incremental parser + a sniffed/`--driver`-forced driver) or a normalized `.replay.jsonl` (reuses `detectReplayFormat`, now moved to `shared/replay-store.ts` so the headless runner avoids importing `electron`).
  - Pacing: events scheduled by their timestamps on the virtual clock. `--speed N` (60 default, 1 real-time, 0 as-fast-as-possible). The **same** virtual clock drives event release and the trigger's time gate, so the trigger firing sequence is identical at every speed.
  - Inference: `--infer none` (deriveState heuristics) or `--infer live` (real provider chain, single-in-flight; measures insight *staleness* in virtual minutes since inference runs on wall time while virtual time advances).
  - `--export-replay <path>` writes normalized CanonicalEvents (loadable by the Electron open-replay path); `--report <path>` writes the JSON report: per-trigger records, aggregates (latency + events-behind p50/p95/max, buffer depth), a **determinism hash** over the event-id sequence + trigger firing indices, and **checkpoint scoring** against the four homelab ground-truth moments (lead/lag in virtual minutes).

## Empirical result (fixture, `--speed 0 --infer none`)
2,885 events over 276.8 virtual min; 278 triggers fired; determinism hash stable across runs. All four semantic checkpoints are **missed by heuristics** — surfacing them is exactly the job of live inference (PR-4).

## Tests
`tests/replay/*` (19 new): determinism (identical hash + firings across two speed-0 runs), speed invariance, the virtual-clock-driven trigger gate, the pure checkpoint scorer, and export round-trip. Full suite: **474 passed**. `npm run replay` runs via an esbuild shim (no new dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9EpjZNoWaXLzfG93tdvTU


___

## **CodeAnt-AI Description**
**Add a deterministic replay runner with virtual-time reporting**

### What Changed
- Added a replay runner and CLI that can read a raw transcript or a normalized replay file, then output a report with trigger timing, latency, buffer depth, and checkpoint results
- Replays now use a virtual clock so trigger timing stays the same at any replay speed, and trigger firings now record which condition caused them
- Raw transcripts are now routed through the same format detection in shared code, and replay exports can be saved back as normalized events for reuse in the app
- Added tests for virtual-time behavior, replay determinism, checkpoint scoring, and replay export/load round-tripping

### Impact
`✅ Reproducible replay results`
`✅ Faster investigation of agent timing issues`
`✅ Clearer replay reports for missed or late insights`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
