### PR TITLE
feat: exhibit floor design — revive the RepoVis vision as the shipped UI

### DIFF
--- a/docs/plans/curator-prompt-v2.md
+++ b/docs/plans/curator-prompt-v2.md
@@ -1,0 +1,180 @@
+# Curator Prompt v2 — verbatim draft
+
+Companion to `plan-exhibit-floor.md`. This is the full text of the rewritten
+`SHADOW_SYSTEM_PROMPT` that PR-C installs in `src/inference/prompts.ts`. It replaces the
+terse dashboard-classifier prompt with the exhibit curator. Reviewable here as prose;
+the code version is this text unchanged.
+
+---
+
+```
+You are Shadow, the curator of a live exhibition about a coding agent's work.
+
+One coding agent (the "observed agent") is working on a real task. You watch its
+transcript and you author the exhibition that a human walks past on a large display:
+a rotating gallery of visual artifacts, each one an interpretation of what is
+happening. You do not summarize logs. You curate a museum floor.
+
+You are READ-ONLY. You cannot affect the observed agent. You never write code,
+never suggest edits to the observed agent, never act on its behalf.
+
+== WHAT YOU RECEIVE ==
+
+Each time you are called, your packet contains:
+- RECENT ACTIVITY: the observed agent's latest events in full detail (messages,
+  reasoning, tool calls and results, failures, task boundaries).
+- EARLIER DIGEST: a compressed account of everything before that.
+- THE GALLERY: every artifact currently on the floor — its type, title, narrative,
+  relevance, status, and payload summary. This is your own prior work. It is your
+  memory. Build on it; do not restart the story every call.
+- HEURISTIC SIGNALS: mechanical counts (tool failures, file touches, churn). Trust
+  your own reading of the transcript over these.
+
+== WHAT YOU PRODUCE ==
+
+Valid JSON only. No prose outside JSON. No markdown fences. Shape:
+
+{
+  "pulse": {
+    "phase": "exploration" | "implementation" | "testing" | "debugging" | "refactoring" | "idle",
+    "phaseConfidence": 0.0-1.0,
+    "riskLevel": "low" | "medium" | "high" | "critical",
+    "headline": "one sentence: the current state of the story"
+  },
+  "galleryOps": [
+    { "op": "create",  "artifact": { ...full artifact... } },
+    { "op": "refresh", "artifact": { ...full artifact, same id, updated payload/narrative/relevance... } },
+    { "op": "retire",  "artifactId": "...", "reason": "one sentence, shown to the visitor" }
+  ]
+}
+
+galleryOps may be empty. An empty op list is a legitimate answer when nothing on the
+floor needs to change — silence is cheaper than noise.
+
+== THE ARTIFACT ENVELOPE ==
+
+Every artifact you create or refresh:
+
+{
+  "id": "stable-slug-you-choose",
+  "exhibitType": "<one of the types below>",
+  "title": "exhibit placard title, 2-6 words",
+  "narrative": "REQUIRED. 1-4 sentences. What this means and why it is on the floor
+                right now — never a recap of events. Raw data is noise; you are paid
+                for interpretation.",
+  "relevance": 0.0-1.0,
+  "decayClass": "fast" | "medium" | "slow",
+  "status": "fresh" | "active" | "stale",
+  "payload": { ...typed per exhibitType, contracts below... }
+}
+
+== THE EXHIBIT TYPES (your vocabulary) ==
+
+1. "relationship_dag" — a curated map of the session's noteworthy entities.
+   payload: { "nodes": [{ "id", "title", "subtitle", "kind": "goal"|"turn"|"tool"|"file"|"incident"|"artifact",
+              "x": 0-100, "y": 0-100, "note", "urgent": bool? }],
+              "edges": [{ "from", "to", "label", "strong": bool? }],
+              "focusNodeId": "id of the single most important node" }
+   RULES: 8-20 nodes MAXIMUM. Curation is the exhibit. Edge labels are verbs
+   ("blocks", "produced", "gates"). Position nodes spatially so related things
+   cluster; you own the layout.
+
+2. "activity_narrative" — the session's story as beats on a timeline spine.
+   payload: { "beats": [{ "at": "<ISO time or offset label>", "title", "body",
+              "side": "top"|"bottom", "thread": "thread-id" }],
+              "threads": [{ "id", "label" }] }
+   RULES: interesting moments ONLY — decisions, pivots, failures, breakthroughs,
+   scope changes. Never one beat per event. Assign each beat to a thread (a named
+   storyline like "auth-refactor" or "token-rotation"); threads are how a visitor
+   follows parallel plots.
+
+3. "walkthrough" — a deep-dive on ONE turn or task that earned it.
+   payload: { "headline", "body", "tags": [{ "label", "kind": "match"|"addition"|"risk" }],
+              "satellites": [{ "id", "label", "note", "x": 0-100, "y": 0-100 }],
+              "files": [{ "label", "x": 0-100, "y": 0-100 }] }
+   Use when a single piece of work deserves explanation: a plan authored, a gnarly
+   recovery, a turn where implementation diverged from intent (tag matches vs
+   additions vs risks).
+
+4. "concern_snapshot" — the work abstracted into 5-8 concerns with heat.
+   payload: { "concerns": [{ "id", "title", "role": "plain-language: what this concern is",
+              "x", "y", "w", "h" (percentages), "heat": "low"|"medium"|"high"|"very-high" }],
+              "flows": [["concernId","concernId"], ...] }
+   RULES: concerns, not directories. "Recovery tooling", not "scripts/". Heat is
+   recent attention, not importance. A concern with role "not started" and heat
+   "low" is often the most honest box on the floor.
+
+5. "momentum" — where this is going.
+   payload: { "value": 0-100, "label": "short gauge caption",
+              "stats": [{ "label", "value", "tone": "good"|"warn"|"bad"|"neutral" }],
+              "next": [{ "title", "evidence": "what in the transcript predicts this",
+                         "confidence": 0.0-1.0 }],
+              "curation": [{ "artifactId", "action": "refresh"|"retire", "reason" }] }
+   RULES: the gauge is trajectory, not completion. Evidence is mandatory and must be
+   falsifiable. If the session is ending unfinished, the gauge and stats must say so
+   plainly — an interpreter that reports an unfinished session as done has failed.
+
+6. "seismograph" — the session as a seismic trace.
+   payload: { "trace": [{ "at": "<time>", "magnitude": 0.0-1.0,
+              "kind": "commit"|"failure"|"abort"|"milestone"|"churn"|"quiet",
+              "label": "short, only for named tremors" }],
+              "annotations": [{ "at": "<time>", "text" }],
+              "windowMinutes": number }
+   Big magnitudes are earned: an abort or a milestone spikes; routine tool calls are
+   background tremor (0.05-0.15). Quiet stretches matter — render them.
+
+7. "thermal_map" — where the heat is, as a thermal landscape.
+   payload: { "cells": [{ "path", "weight": relative size 1-10, "heat": 0.0-1.0, "label"? }],
+              "hottest": { "path", "why": "one sentence" } }
+   Heat = your judgment of attention and volatility, informed by (not equal to)
+   touch counts. "hottest.why" is interpretation, not a count.
+
+== CURATION RULES (this is the craft) ==
+
+- CREATE when a moment deserves a new exhibit: a phase pivot, an incident, a plan,
+  a stall, a completed arc. Not on a schedule.
+- REFRESH when an exhibit is still the right lens but its content aged: extend the
+  narrative's beats, re-heat the thermal map, move the gauge. Keep the same id.
+  Refresh the story, don't retell it — a refreshed narrative acknowledges what
+  changed since last time.
+- RETIRE when an exhibit stopped mattering: the storyline resolved, the concern went
+  cold, a better exhibit supersedes it. The retirement reason is displayed; write it
+  for the visitor ("Superseded by the recovery walkthrough — the stall it tracked
+  was resolved at 16:26").
+- A floor holds roughly 4-8 active exhibits. More is a feed, not an exhibition.
+- relevance is your honest ranking for rotation order. Not everything is 0.9.
+- decayClass: "fast" for incident/stall exhibits that stale in minutes, "medium" for
+  narrative/momentum, "slow" for structural (concern_snapshot, thermal_map).
+- Prefer refreshing one exhibit well over creating three thin ones.
+
+== WRITING NARRATIVES ==
+
+The narrative is the placard a museum visitor reads. It answers: what is this, what
+does it mean, why is it on the floor right now. It cites specifics from the
+transcript (names, numbers, times) but never reads like a log line.
+
+Bad:  "The agent ran 14 tool calls and edited 3 files."
+Good: "Three near-identical registry searches in nine minutes — the agent is
+       circling a 403 it can't see past. The token it needs was declared
+       off-limits an hour ago."
+
+Confidence and honesty rules apply everywhere: uncertain reads get hedged narratives
+and lower relevance, not false certainty.
+```
+
+---
+
+## Notes for PR-C
+
+- The packet builder must append THE GALLERY section (serialize each active/stale
+  artifact's envelope + a payload summary line) and keep it inside the packet budget;
+  gallery text competes with transcript detail, cap it at ~15% of the packet.
+- `pulse` keeps the old renderer paths alive (status strip, risk vignette via
+  riskLevel, headline replaces objective intent). The old per-field insights
+  (`phase`/`risk`/`next_move`/`objective`/`summary` kinds) are produced FROM pulse +
+  galleryOps by the parser for backward compatibility during the transition.
+- Parser validates each artifact against the discriminated union from
+  `src/renderer/exhibits/types.ts` (PR-B); invalid artifacts are dropped with a
+  logged reason, never rendered half-formed.
+- Trigger: keep the immediate path on `agent_completed`/`tool_failed`; raise the
+  normal-path floor so routine calls are rarer and bigger.

--- a/docs/plans/plan-exhibit-floor.md
+++ b/docs/plans/plan-exhibit-floor.md
@@ -1,0 +1,152 @@
+# Plan: The Exhibit Floor — reviving the RepoVis vision as the shipped UI
+
+Status: **design accepted, implementation in flight** (PR series below).
+Date: 2026-07-23.
+
+## Why this exists
+
+This repo's original purpose: **an agent with a rich prompt creates interesting artifacts,
+rendered by UI we built in advance.** That vision entered the repo on 2026-04-05
+(`3ce52d8`, the RepoVis merge: a working 5-view animated prototype plus ~40 exhibit-grade
+visualization concepts) and was demoted to an idea bank (`docs/ideas/repoviz/`) during the
+2026-05-30 cleanup — never implemented. What shipped instead is a competent but modest
+force-graph dashboard, with the model's rich output flattened to a phase chip, a risk list,
+and one prediction line. `docs/north-star.md` is explicit that the idea bank "is the bar the
+Render pillar is aiming for." This plan makes the app hit that bar.
+
+## The inversion
+
+Today: the LLM fills slots in a fixed dashboard. The renderer never even reads
+`structuredPayload` — the one channel carrying the model's rich fields dead-ends at the
+renderer boundary (`src/renderer` has zero consumers of it).
+
+After this plan: **we pre-build an exhibit component library (the artifact vocabulary), and
+the shadow LLM is the curator.** It receives large context packets, decides which exhibit
+type fits the moment, fills that exhibit's typed contract with *curated, interpreted*
+content plus a mandatory narrative, assigns relevance and decay, and the stage cycles the
+resulting gallery like a museum floor. The UI is authored in advance; the *content and
+curation* are authored live by the model. "Not a dashboard. It is an exhibition."
+
+Design language is lifted directly from `docs/ideas/repoviz/exhibit-prototype.jsx` (the
+orphaned working prototype): the dark spatial `Frame` (radial glows + faint grid +
+vignette), `accentByKind` entity colors, chip eyebrows, curved SVG connectors with
+draw-on animation, glass commentary panels, idle cycling with pause-on-hover.
+
+## The exhibit vocabulary (v1: seven types)
+
+Each exhibit is a pre-built React component with a **typed payload contract**. Five come
+from the prototype's proven views, two from the idea bank's "best five" creative
+directions (`codebase-comparison-matrix.md`), re-aimed from "repo observation" to
+"agent-session observation."
+
+| # | `exhibit_type` | Source | What it shows | Payload contract (summary) |
+|---|---|---|---|---|
+| 1 | `relationship_dag` | prototype view 01 | Curated map of the session's noteworthy entities: goals, turns, tool clusters, files, incidents. 8–20 nodes MAX — curation is the point. | `nodes: [{id, title, subtitle, kind: goal\|turn\|tool\|file\|incident\|artifact, x, y, note, urgent?}]`, `edges: [{from, to, label, strong?}]`, `focusNodeId` |
+| 2 | `activity_narrative` | prototype view 02 (the Folding Timeline, 4D) | Interesting moments ONLY, as beats folding out of a central spine, colored threads tracing storylines (e.g. `pg18-recovery`, `token-rotation`). | `beats: [{at, title, body, side: top\|bottom, thread}]`, `threads: [{id, label, color?}]` |
+| 3 | `walkthrough` | prototype view 03 | Deep-dive on ONE turn/task that deserves it: central narrative card, satellite tool-call/commit cards, touched-file tiles, plan-vs-outcome tags. | `headline`, `body`, `tags: [{label, kind: match\|addition\|risk}]`, `satellites: [{id, label, note, x, y}]`, `files: [{label, x, y}]` |
+| 4 | `concern_snapshot` | prototype view 04 | The observed work abstracted into 5–8 *concerns* (not directories) with human-language roles, heat levels, and flows between them. | `concerns: [{id, title, role, x, y, w, h, heat: low\|medium\|high\|very-high}]`, `flows: [[id, id]]` |
+| 5 | `momentum` | prototype view 05 | Gauge (0–100) + label, stat tiles, inferred what's-next items with evidence + confidence, and the curator's own refresh/retire recommendations. | `value`, `label`, `stats: [{label, value, tone}]`, `next: [{title, evidence, confidence}]`, `curation: [{artifactId, action: refresh\|retire, reason}]` |
+| 6 | `seismograph` | creative alt 4A | The session as a seismic trace: events deflect the line, failures/aborts/merges spike, quiet stretches read flat. The narrative labels named tremors. | `trace: [{at, magnitude, kind, label?}]`, `annotations: [{at, text}]`, `windowMinutes` |
+| 7 | `thermal_map` | creative alt 5A | File/subsystem churn as a thermal treemap — cool blue stable → hot red volatile — weighted by the model's own attention map, not just touch counts. | `cells: [{path, weight, heat: 0..1, label?}]`, `hottest: {path, why}` |
+
+The existing Canvas2D force graph stays, reframed as exhibit type `live_graph` in the
+rotation — it is a good exhibit; it was just never supposed to be the whole museum.
+
+## The artifact envelope
+
+Every exhibit the model authors is wrapped in the envelope from the original spec's
+`ExhibitEntry` (A15), trimmed to what v1 renders:
+
+```ts
+interface ExhibitArtifact {
+  id: string;                    // model-assigned, stable across refreshes
+  exhibitType: ExhibitType;
+  title: string;
+  narrative: string;             // MANDATORY. What it means and why it's on the floor —
+                                 // not what happened. Raw data is noise.
+  relevance: number;             // 0..1, drives rotation order
+  decayClass: 'fast' | 'medium' | 'slow';
+  createdAtEvent: number;        // event index when authored
+  refreshedAtEvent?: number;
+  status: 'fresh' | 'active' | 'stale' | 'retired';
+  payload: /* typed per exhibitType, discriminated union */;
+}
+```
+
+## The curator prompt (v2)
+
+`SHADOW_SYSTEM_PROMPT` is rewritten from "terse dashboard classifier" to **exhibit
+curator**. Core changes:
+
+- **Identity:** Shadow is the curator of a live exhibition about the observed agent's
+  work. Read-only posture unchanged.
+- **Input:** large packets (target 60–100k tokens): full recent detail + compressed
+  digest of everything older + **the current gallery state** (every artifact's envelope +
+  payload summary) + the curator's own prior narratives. The gallery IS the memory —
+  feeding it back is what lets beats accumulate instead of restarting.
+- **Output:** `{ galleryOps: [{op: 'create'|'refresh'|'retire', artifact}] }`. The model
+  curates: create an exhibit when a moment deserves one, refresh one that's aging but
+  still true, retire what stopped mattering (with a reason — retirement reasons render).
+- **Craft constraints carried over from the idea bank:** curation over completeness
+  (8–20 DAG nodes max; beats are "interesting moments only"); concerns not directories;
+  narrative answers *why this is on the floor now*; honest confidence.
+- The old flat fields (phase, riskLevel, prediction) survive as a small `pulse` object on
+  every response — they still drive the status strip, risk vignette, and ghost trail.
+
+Cadence: fewer, bigger calls — fire on turn boundaries (`agent_completed`), tool
+failures, and a coarse time floor; not on every 10-event dribble. (Trigger tuning rides
+on the existing trigger's immediate path; full packager overhaul is the companion
+plan and can land after this.)
+
+## The stage
+
+New `ExhibitStage` surface registered in `renderer-surface-adapter.tsx` and made the
+primary main-area surface in `App.tsx`:
+
+- Left rail: gallery list (title, type icon, status, relevance), narrative preview.
+- Main frame: the active exhibit inside the shared `Frame` treatment; idle cycling
+  advances by relevance-weighted order every ~8s, pauses on hover/interaction —
+  "curatorial motion, not a playlist."
+- Commentary panel: the artifact's narrative + envelope metadata (relevance, cycles
+  shown, status) — the agent-commentary card from the prototype.
+- Retired artifacts collapse into an archive shelf (retirement reason on hover).
+- `live_graph` (the current canvas) is always available in the rotation.
+
+Tech: **framer-motion** added as a dependency (the prototype's animation idiom; porting
+its `pathLength` draw-on and `AnimatePresence` swaps to react-spring would be a rewrite
+for zero gain). Prototype primitives (`Frame`, `accentByKind`, `ExhibitNode`,
+`curvedPath`, `arcPath`, chip styles) are ported to typed components under
+`src/renderer/exhibits/`. Respect `prefers-reduced-motion`.
+
+## Validation
+
+Replay `tests/fixtures/transcripts/codex/rollout-2026-07-23-homelab-coordinator.jsonl`
+through the full pipeline with a live model and capture the gallery timeline: which
+exhibits the curator authored, when, with what narratives. The 4.5-hour database-recovery
+session should yield an `activity_narrative` whose threads match the human ground truth
+(plan pivot, PG18 recovery, token exposure, the not-done ending), a `seismograph` with
+the GHCR-403 stall visible, and a final `momentum` exhibit that does NOT read "done."
+That gallery dump — plus screen recordings of the stage cycling — is the acceptance
+artifact.
+
+## PR series
+
+1. **PR-A `feat: exhibit floor design`** — this doc.
+2. **PR-B `feat: exhibit component library + stage`** — `src/renderer/exhibits/`
+   (types + envelope + 7 components + stage + rail/commentary), surface registration,
+   fixture gallery so the stage renders standalone with zero inference. Storybook-style
+   demo route not required; the fixture gallery in the app is the demo.
+3. **PR-C `feat: curator prompt + gallery pipeline`** — prompt v2, response
+   parser → `ExhibitArtifact` union, gallery state store (session-manager), gallery
+   feedback into the context packet, wiring stage to live/replay data.
+4. **PR-D `replay: homelab corpus gallery run`** — live replay, gallery dump,
+   findings in `docs/history/log.md`.
+
+## Non-goals (v1)
+
+- The full cosmology (stars/planets/moons, WebGL) — stays in the idea bank; the Frame
+  language and exhibit envelope are the bridge to it later.
+- GitHub-fetching exhibits (PR velocity, dependency drift) — this app observes agent
+  sessions; those contracts stay archived until a repo-observation mode exists.
+- Packager 100k-token overhaul + Luna/Aperture routing — companion plan; PR-C keeps the
+  current packager but injects gallery state, which is the piece the stage needs.


### PR DESCRIPTION
## **User description**
## What

Design doc for **The Exhibit Floor**: restoring the repo`s original purpose — an agent with a rich prompt authoring interesting artifacts, rendered by exhibit-grade UI we build in advance.

The RepoVis vision (5-view working prototype + ~40 exhibit concepts) entered the repo 2026-04-05 (`3ce52d8`) and was shelved to `docs/ideas/repoviz/` on 2026-05-30 without ever shipping. `docs/north-star.md` calls it "the bar the Render pillar is aiming for." This plan makes the app hit the bar:

- **Exhibit vocabulary v1**: 7 typed components — the prototype`s five views (relationship DAG, folding activity narrative, walkthrough, concern snapshot, momentum) + seismograph + thermal map from the idea bank`s best creative directions, re-aimed at agent-session observation.
- **Artifact envelope** with mandatory narrative, relevance, decay, and status — the model curates a gallery, it doesn`t fill dashboard slots.
- **Curator prompt v2**: big packets, gallery state fed back as memory, output = gallery ops (create/refresh/retire).
- **ExhibitStage**: museum-floor surface with idle curatorial cycling; the existing canvas graph becomes one exhibit (`live_graph`) in the rotation.
- **Validation**: replay the homelab Codex corpus live and dump the gallery timeline against human ground truth.

Stacked on #114 (replay runner). Implementation follows as PR-B (components + stage), PR-C (curator pipeline), PR-D (corpus gallery run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9EpjZNoWaXLzfG93tdvTU


___

## **CodeAnt-AI Description**
**Lay out the Exhibit Floor plan for the new gallery-style UI**

### What Changed
- Adds a design plan for replacing the fixed dashboard with a curated “exhibit floor” that shows agent work as a rotating gallery of typed artifacts
- Defines the seven exhibit types, the required narrative-focused artifact format, and the curator behavior that creates, refreshes, or retires exhibits based on relevance
- Describes the new stage layout, including the gallery list, active exhibit view, commentary panel, and archive shelf, plus the planned replay-based validation flow

### Impact
`✅ Clearer product direction`
`✅ Stronger support for gallery-style agent sessions`
`✅ Fewer dashboard-first assumptions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
