### PR TITLE
feat: curator prompt + gallery pipeline

### DIFF
--- a/docs/plans/curator-prompt-v2.md
+++ b/docs/plans/curator-prompt-v2.md
@@ -1,148 +1,14 @@
-/**
- * # Shadow System Prompt — the Curator
- *
- * Sent to the shadow's AI model every time the inference engine fires. The
- * model receives this as the system prompt + a user message containing the
- * ShadowContextPacket (recent events, derived state, transcript turns, and —
- * new in the curator design — the current gallery state).
- *
- * Goal: the model is no longer a terse dashboard classifier filling fixed
- * slots. It is the **curator of a live exhibition** about the observed coding
- * agent's work: it decides which pre-built exhibit type fits the moment, fills
- * that exhibit's typed contract with curated, interpreted content plus a
- * mandatory narrative, assigns relevance and decay, and issues `galleryOps`
- * (create / refresh / retire) against the standing gallery. See
- * `docs/plans/plan-exhibit-floor.md` (the accepted design) and
- * `docs/plans/curator-prompt-v2.md` (the verbatim prompt source).
- *
- * ---
- *
- * ## Philosophy
- *
- * Five design principles carry over from the dashboard prompt; the curator
- * rewrite reframes rather than discards them:
- *
- * 1. **Interpretation over transcription.** The gallery renders on a large
- *    display a human walks past. Raw data is noise; every artifact exists for
- *    its narrative — *what it means and why it is on the floor now*.
- * 2. **Curation over completeness.** 8–20 DAG nodes max; beats are
- *    "interesting moments only"; a floor holds ~4–8 active exhibits. Fewer,
- *    better exhibits beat a feed.
- * 3. **Honest confidence.** Uncertain reads get hedged narratives and lower
- *    relevance, not a false 0.9. An interpreter that reports an unfinished
- *    session as "done" has failed — the momentum gauge is trajectory, not
- *    completion.
- * 4. **Structured JSON only.** No markdown, no prose outside the schema. The
- *    response parser (`response-parser.ts`) calls JSON.parse() directly and
- *    validates each artifact against the discriminated union in
- *    `src/renderer/exhibits/types.ts`.
- * 5. **Read-only posture.** The shadow observes and curates. It never writes
- *    code, instructs the observed agent, or acts on its behalf.
- *
- * ---
- *
- * ## Section rationale
- *
- * The prompt below is organized as a curator's brief. Each section addresses a
- * specific failure mode; if you weaken a constraint, document why here and in
- * `git log`.
- *
- * - **WHAT YOU RECEIVE.** Names the packet's four parts — RECENT ACTIVITY,
- *   EARLIER DIGEST, THE GALLERY, HEURISTIC SIGNALS. THE GALLERY is the model's
- *   own prior work fed back: it is the memory that lets beats accumulate
- *   instead of the story restarting every call.
- * - **WHAT YOU PRODUCE.** The `{ pulse, galleryOps }` contract. `pulse`
- *   (phase / phaseConfidence / riskLevel / headline) keeps the legacy renderer
- *   paths alive — the parser derives the old `phase` / `risk` / `objective`
- *   insights FROM it. `galleryOps` is the curation channel. An empty op list is
- *   a legitimate answer: silence is cheaper than noise.
- * - **THE ARTIFACT ENVELOPE.** The `ExhibitArtifact` shape (id, exhibitType,
- *   title, mandatory narrative, relevance, decayClass, status, payload). The
- *   `id` is stable across refreshes so the gallery store can replace by id.
- * - **THE EXHIBIT TYPES.** The seven-type vocabulary with per-type payload
- *   contracts and craft rules (curation caps, verbs on edges, concerns-not-
- *   directories, falsifiable evidence, earned seismograph magnitudes).
- * - **CURATION RULES.** When to create vs refresh vs retire, the ~4–8 floor
- *   cap, honest relevance, and decayClass guidance (fast/medium/slow).
- * - **WRITING NARRATIVES.** The bad/good example pins the bar: a narrative
- *   cites specifics but never reads like a log line.
- *
- * ---
- *
- * ## Companion: context packet
- *
- * The user message accompanying this system prompt is built by
- * `prompt-builder.ts` from the `ShadowContextPacket` (`context-packager.ts`):
- * session metadata, recent events, tool history, transcript turns, file
- * attention, heuristic risk signals, and THE GALLERY section (each active/stale
- * artifact's envelope + a one-line payload summary, plus retired-this-session
- * ids and reasons so the model does not recreate what it retired). The gallery
- * section is capped at ~15% of the packet token budget.
- *
- * Delivery is local-only by default. Transcript-like fields are sanitized
- * before rendering or off-host inclusion. Off-host delivery requires explicit
- * runtime opt-in; raw transcript delivery requires a separate explicit opt-in.
- *
- * The packet is plain text, not JSON, because the model reads it as context to
- * scan — not as structured input to transform. JSON is the *output* contract;
- * the input should be readable.
- *
- * ---
- *
- * ## Evaluation
- *
- * No eval harness exists yet. When the time comes, the obvious starting point:
- *
- * - **Golden set:** captured sessions with hand-authored expected galleries —
- *   which exhibit types the curator should author, with what narrative threads.
- *   The homelab-coordinator fixture (a 4.5-hour database recovery) is the first
- *   such case: a live replay should produce an `activity_narrative` matching the
- *   human ground truth, a `seismograph` with the GHCR-403 stall visible, and a
- *   final `momentum` exhibit that does NOT read "done".
- * - **Judge model:** a separate LLM scoring gallery quality against that
- *   expected exhibition.
- * - **Regression suite:** runs on every prompt edit; fails CI on judge-score
- *   drift.
- *
- * Until then: this prompt is evaluated by personal use and replay dumps.
- *
- * ---
- *
- * ## When to upgrade this setup
- *
- * Today this file is the single source of truth: rationale lives in this doc
- * comment, the prompt itself in the template literal below. Appropriate while
- * shadow-agent has one developer, no paying users, no A/B requirement, and no
- * regression detection beyond "did it break?". Triggers to graduate to a
- * prompt-management platform: first non-me user; first "this got weirdly worse"
- * complaint; first cost-attribution question; first multi-prompt scenario where
- * structured metadata earns its keep. See `docs/tooling-philosophy.md`.
- *
- * ---
- *
- * ## Iteration log
- *
- * Use `git log shadow-agent/src/inference/prompts.ts` for the canonical
- * history. Notable milestones:
- *
- * - 2026-04-01: Initial version. Established from
- *   `docs/research/shadow-inference-architecture.md`.
- * - 2026-04-17: Documented local-only default and explicit transcript
- *   consent gates.
- * - 2026-05-20: Collapsed the JSON-source + generated-docs + generated-runtime
- *   triad into this single file. See `docs/plans/plan-multi-harness-mvp.md`
- *   ("Rejected alternatives") and `docs/tooling-philosophy.md` for the why.
- * - 2026-07-23: **Curator rewrite.** Replaced the terse dashboard-classifier
- *   prompt with the exhibit curator: `{ pulse, galleryOps }` output over the
- *   seven-type exhibit vocabulary, THE GALLERY fed back as memory, curation
- *   over completeness. The old flat fields survive as the small `pulse` object,
- *   from which the parser derives the legacy insight kinds for backward
- *   compatibility. Prompt text installed verbatim from
- *   `docs/plans/curator-prompt-v2.md`; design in
- *   `docs/plans/plan-exhibit-floor.md` (PR-C).
- */
+# Curator Prompt v2 — verbatim draft
 
-export const SHADOW_SYSTEM_PROMPT = `You are Shadow, the curator of a live exhibition about a coding agent's work.
+Companion to `plan-exhibit-floor.md`. This is the full text of the rewritten
+`SHADOW_SYSTEM_PROMPT` that PR-C installs in `src/inference/prompts.ts`. It replaces the
+terse dashboard-classifier prompt with the exhibit curator. Reviewable here as prose;
+the code version is this text unchanged.
+
+---
+
+```
+You are Shadow, the curator of a live exhibition about a coding agent's work.
 
 One coding agent (the "observed agent") is working on a real task. You watch its
 transcript and you author the exhibition that a human walks past on a large display:
@@ -293,4 +159,22 @@ Good: "Three near-identical registry searches in nine minutes — the agent is
        off-limits an hour ago."
 
 Confidence and honesty rules apply everywhere: uncertain reads get hedged narratives
-and lower relevance, not false certainty.`;
+and lower relevance, not false certainty.
+```
+
+---
+
+## Notes for PR-C
+
+- The packet builder must append THE GALLERY section (serialize each active/stale
+  artifact's envelope + a payload summary line) and keep it inside the packet budget;
+  gallery text competes with transcript detail, cap it at ~15% of the packet.
+- `pulse` keeps the old renderer paths alive (status strip, risk vignette via
+  riskLevel, headline replaces objective intent). The old per-field insights
+  (`phase`/`risk`/`next_move`/`objective`/`summary` kinds) are produced FROM pulse +
+  galleryOps by the parser for backward compatibility during the transition.
+- Parser validates each artifact against the discriminated union from
+  `src/renderer/exhibits/types.ts` (PR-B); invalid artifacts are dropped with a
+  logged reason, never rendered half-formed.
+- Trigger: keep the immediate path on `agent_completed`/`tool_failed`; raise the
+  normal-path floor so routine calls are rarer and bigger.

--- a/scripts/replay.ts
+++ b/scripts/replay.ts
@@ -12,6 +12,7 @@
  *   --infer none|live            none (heuristics only, default) | live (real provider chain).
  *   --export-replay <path>       Write normalized CanonicalEvents (Electron-loadable) here.
  *   --report <path>              Write the JSON report here.
+ *   --gallery-out <path>         Write the final curator gallery (JSON) here.
  *   --title <text>               Session title for derive/report.
  */
 import { runReplay, type InferMode, type ReplayOptions } from '../src/replay/replay-runner';
@@ -59,6 +60,9 @@ function parseArgs(argv: string[]): ParsedArgs {
       case '--report':
         options.reportPath = next();
         break;
+      case '--gallery-out':
+        options.galleryOutPath = next();
+        break;
       case '--title':
         options.title = next();
         break;
@@ -85,6 +89,7 @@ Usage: npm run replay -- <file> [flags]
   --infer none|live            none (heuristics only, default) | live (real provider chain)
   --export-replay <path>       Write normalized CanonicalEvents (Electron-loadable)
   --report <path>              Write JSON report
+  --gallery-out <path>         Write the final curator gallery (JSON)
   --title <text>               Session title
 `;
 
@@ -122,8 +127,13 @@ async function main(): Promise<void> {
       lines.push(`    [ missed ] ${cp.label}`);
     }
   }
+  if (report.gallery.length > 0) {
+    const retired = report.gallery.filter((a) => a.status === 'retired').length;
+    lines.push(`  gallery: ${report.gallery.length} exhibits (${report.gallery.length - retired} active, ${retired} retired)`);
+  }
   if (options.reportPath) lines.push(`  report → ${options.reportPath}`);
   if (options.exportReplayPath) lines.push(`  replay → ${options.exportReplayPath}`);
+  if (options.galleryOutPath) lines.push(`  gallery → ${options.galleryOutPath}`);
   process.stdout.write(`${lines.join('\n')}\n`);
 }
 

--- a/src/capture/session-manager.ts
+++ b/src/capture/session-manager.ts
@@ -8,6 +8,7 @@
 import type { WebContents } from 'electron';
 import { DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS } from '../shared/privacy';
 import type { SnapshotPayload, LoadedSource, TranscriptPrivacySettings, ShadowInsight } from '../shared/schema';
+import type { ExhibitArtifact } from '../renderer/exhibits/types';
 import { buildRendererInput } from '../shared/renderer-input-adapter';
 import { createIncrementalParser } from './incremental-parser';
 import { driverRegistry } from './drivers';
@@ -43,6 +44,12 @@ export interface SessionManager {
    * and a renderer re-pull is nudged via the IPC bridge.
    */
   setModelInsights(insights: ShadowInsight[]): void;
+  /**
+   * Store the latest curator gallery. It rides the next snapshot (as
+   * `snapshot.gallery`) so the renderer's ExhibitStage shows the live floor,
+   * and a renderer re-pull is nudged via the IPC bridge.
+   */
+  setGallery(artifacts: ExhibitArtifact[]): void;
 }
 
 export function createSessionManager(
@@ -64,6 +71,7 @@ export function createSessionManager(
   let bridgeCleanup: (() => void) | null = null;
   let bridge: IpcBridge | null = null;
   let latestModelInsights: ShadowInsight[] = [];
+  let latestGallery: ExhibitArtifact[] = [];
   let sessionTitle = 'Live session';
   const transport =
     options.transport && 'start' in options.transport
@@ -97,6 +105,10 @@ export function createSessionManager(
         ...rendererInput.state,
         shadowInsights
       },
+      // The curator gallery only rides live/replay snapshots. When empty
+      // (no inference yet), leave it undefined so ExhibitStage falls back to
+      // its hand-authored fixture gallery rather than rendering an empty floor.
+      gallery: latestGallery.length > 0 ? latestGallery : undefined,
       captureQueue: buffer.getMetrics()
     };
   };
@@ -218,6 +230,13 @@ export function createSessionManager(
       latestModelInsights = insights;
       // Nudge the renderer to re-pull the snapshot so new model insights
       // surface even between transcript events (and on idle / session-end).
+      bridge?.markDirty();
+    },
+
+    setGallery(artifacts: ExhibitArtifact[]) {
+      latestGallery = artifacts;
+      // Same dirty-refresh path: surface the curated floor without waiting on
+      // the next transcript event.
       bridge?.markDirty();
     },
   };

--- a/src/electron/start-main-process.ts
+++ b/src/electron/start-main-process.ts
@@ -167,6 +167,14 @@ export function startMainProcess(): void {
             if (process.env.SHADOW_DISABLE_INSIGHT_RENDER !== '1') {
               currentSessionManager.setModelInsights(insights);
             }
+          },
+          onGallery: (artifacts) => {
+            logger.info('inference', 'gallery_received', { count: artifacts.length });
+            // Forward the curated exhibit floor to the renderer via the same
+            // stable session manager + dirty-refresh path as insights.
+            if (process.env.SHADOW_DISABLE_INSIGHT_RENDER !== '1') {
+              currentSessionManager.setGallery(artifacts);
+            }
           }
         });
       const refreshInferenceEngine = async () => {

--- a/src/inference/context-packager.ts
+++ b/src/inference/context-packager.ts
@@ -5,16 +5,110 @@
  * Total context budget: ~10,000 tokens. Truncates from the front — recent events are more valuable.
  */
 import type { CanonicalEvent, DerivedState } from '../shared/schema';
-import type { ShadowContextPacket } from './prompt-builder';
+import type { ExhibitArtifact } from '../renderer/exhibits/types';
+import type { GalleryPacketEntry, ShadowContextPacket } from './prompt-builder';
 
 const MAX_RECENT_EVENTS = 30;
 const MAX_TOOL_HISTORY = 20;
 const MAX_TRANSCRIPT_TURNS = 10;
 const MAX_FILE_ATTENTION = 15;
 const MAX_CONTEXT_TOKENS = 10_000;
+/**
+ * THE GALLERY competes with transcript detail for packet space. Cap it at 15%
+ * of the token budget: over that, drop payload summaries (envelopes only), then
+ * drop the least-relevant exhibits until it fits. Retired-line feedback is kept
+ * regardless — it is one cheap line each and prevents recreating retired work.
+ */
+const GALLERY_BUDGET_FRACTION = 0.15;
 
 function estimateTokens(value: unknown): number {
   return Math.ceil(JSON.stringify(value).length / 4);
+}
+
+/** One-line payload summary per exhibit type, for THE GALLERY section. */
+function payloadSummary(artifact: ExhibitArtifact): string {
+  switch (artifact.exhibitType) {
+    case 'relationship_dag': {
+      const p = artifact.payload;
+      return `${p.nodes.length} nodes, ${p.edges.length} edges, focus: ${p.focusNodeId}`;
+    }
+    case 'activity_narrative': {
+      const p = artifact.payload;
+      const threads = p.threads.map((t) => t.label).join(', ');
+      return `${p.beats.length} beats across threads: ${threads}`;
+    }
+    case 'walkthrough': {
+      const p = artifact.payload;
+      return `${p.headline} — ${p.satellites.length} satellites, ${p.files.length} files`;
+    }
+    case 'concern_snapshot': {
+      const p = artifact.payload;
+      return `${p.concerns.length} concerns, ${p.flows.length} flows`;
+    }
+    case 'momentum': {
+      const p = artifact.payload;
+      return `gauge ${p.value} (${p.label}), ${p.next.length} next moves`;
+    }
+    case 'seismograph': {
+      const p = artifact.payload;
+      return `${p.trace.length} tremors over ${p.windowMinutes}min`;
+    }
+    case 'thermal_map': {
+      const p = artifact.payload;
+      return `${p.cells.length} cells, hottest ${p.hottest.path}`;
+    }
+    case 'live_graph':
+      return 'live agent topology';
+    default:
+      return '';
+  }
+}
+
+function toEnvelopeEntry(artifact: ExhibitArtifact): GalleryPacketEntry {
+  return {
+    id: artifact.id,
+    exhibitType: artifact.exhibitType,
+    title: artifact.title,
+    narrative: artifact.narrative,
+    relevance: artifact.relevance,
+    decayClass: artifact.decayClass,
+    status: artifact.status,
+    createdAtEvent: artifact.createdAtEvent,
+    ...(artifact.refreshedAtEvent !== undefined ? { refreshedAtEvent: artifact.refreshedAtEvent } : {}),
+  };
+}
+
+/**
+ * Serialize the active/stale gallery into packet entries, honoring the 15% cap:
+ * full entries (with payload summaries) when they fit; envelope-only, then
+ * relevance-pruned, when they do not.
+ */
+function packGallery(
+  artifacts: ExhibitArtifact[],
+  retired: Array<{ id: string; reason: string }>,
+  tokenBudget: number
+): { gallery: GalleryPacketEntry[]; retiredGallery: Array<{ id: string; reason: string }> } {
+  const cap = Math.floor(tokenBudget * GALLERY_BUDGET_FRACTION);
+  const byRelevance = [...artifacts].sort((a, b) => b.relevance - a.relevance);
+  const estimate = (entries: GalleryPacketEntry[]): number => estimateTokens({ gallery: entries, retiredGallery: retired });
+
+  // 1. Full entries (envelope + payload summary).
+  let entries: GalleryPacketEntry[] = byRelevance.map((a) => ({
+    ...toEnvelopeEntry(a),
+    payloadSummary: payloadSummary(a),
+  }));
+  if (estimate(entries) <= cap) {
+    return { gallery: entries, retiredGallery: retired };
+  }
+
+  // 2. Envelopes only, prioritized by relevance.
+  entries = byRelevance.map(toEnvelopeEntry);
+
+  // 3. Still over: drop the least-relevant exhibits until it fits.
+  while (entries.length > 0 && estimate(entries) > cap) {
+    entries.pop();
+  }
+  return { gallery: entries, retiredGallery: retired };
 }
 
 function summarizeArgs(args: unknown): string {
@@ -47,14 +141,22 @@ function dominantHarnessId(events: CanonicalEvent[]): string {
   return dominant ?? 'claude-code';
 }
 
-export function buildContextPacket(
-  state: DerivedState,
-  events: CanonicalEvent[]
-): ShadowContextPacket {
-  return packContext(state, events).packet;
+export interface GalleryContext {
+  /** Active/stale exhibits currently on the floor (the curator's memory). */
+  gallery?: ExhibitArtifact[];
+  /** Ids + reasons retired this session, so the model does not recreate them. */
+  retiredGallery?: Array<{ id: string; reason: string }>;
 }
 
-export interface PackContextOptions {
+export function buildContextPacket(
+  state: DerivedState,
+  events: CanonicalEvent[],
+  galleryContext: GalleryContext = {}
+): ShadowContextPacket {
+  return packContext(state, events, galleryContext).packet;
+}
+
+export interface PackContextOptions extends GalleryContext {
   tokenBudget?: number;
   recentWindowSize?: number;
 }
@@ -111,6 +213,12 @@ export function packContext(
     severity: 'medium',
   }));
 
+  const { gallery, retiredGallery } = packGallery(
+    options.gallery ?? [],
+    options.retiredGallery ?? [],
+    tokenBudget
+  );
+
   const packet: ShadowContextPacket = {
     sessionId: state.sessionId,
     observedAgent: dominantHarnessId(events),
@@ -121,6 +229,8 @@ export function packContext(
     recentTranscript,
     fileAttention,
     riskSignals,
+    gallery,
+    retiredGallery,
   };
 
   let approximateTokens = estimateTokens(packet);

--- a/src/inference/gallery-store.ts
+++ b/src/inference/gallery-store.ts
@@ -1,0 +1,247 @@
+/**
+ * Gallery store — the live memory of the exhibit floor.
+ *
+ * The curator prompt (see `prompts.ts`) does not re-send the whole gallery each
+ * call; it emits *ops* against a standing gallery: `create` a new exhibit,
+ * `refresh` one that aged but is still true, `retire` one that stopped
+ * mattering. This store holds the current `ExhibitArtifact` map, applies those
+ * ops, and tracks the lifecycle fields the model does not own — event stamps,
+ * status transitions, and staleness — so two things can read a coherent
+ * gallery: the renderer (what to show on the floor) and the next context packet
+ * (THE GALLERY section fed back as the curator's memory).
+ *
+ * Design (see `docs/plans/plan-exhibit-floor.md`):
+ *
+ * - **The store owns status, not the model.** A created exhibit is `fresh`;
+ *   surviving to the *next* packet promotes it to `active`; ageing past its
+ *   decay budget marks it `stale`; a retire op marks it `retired`. Retired
+ *   artifacts are kept (not deleted) so the archive shelf can render them with
+ *   their retirement reason.
+ * - **`create` vs `refresh`.** Both replace by id. `create` (re)starts an
+ *   exhibit as `fresh` and stamps `createdAtEvent`; `refresh` keeps the
+ *   original `createdAtEvent`, re-stamps `refreshedAtEvent`, and returns the
+ *   exhibit to `active`. A refresh of an unknown id is tolerated as a create;
+ *   a create colliding with an existing id resets that exhibit.
+ * - **Staleness is dual-gated** by `decayClass`: an exhibit goes `stale` once
+ *   it has been un-refreshed for either N events *or* M minutes, whichever
+ *   comes first (see {@link STALENESS_THRESHOLDS}). Event-age keeps fast-moving
+ *   sessions honest; wall-minute-age keeps a stalled session from freezing a
+ *   stale exhibit as forever-active. A refresh un-stales.
+ */
+import type {
+  DecayClass,
+  ExhibitArtifact,
+  ExhibitStatus,
+} from '../renderer/exhibits/types';
+
+/** One create/refresh/retire instruction from a parsed curator response. */
+export type GalleryOp =
+  | { op: 'create'; artifact: ExhibitArtifact }
+  | { op: 'refresh'; artifact: ExhibitArtifact }
+  | { op: 'retire'; artifactId: string; reason: string };
+
+/** Event-count and wall-minute thresholds after which an exhibit goes stale. */
+export interface DecayThreshold {
+  /** Events since last refresh before the exhibit is stale. */
+  events: number;
+  /** Wall-clock minutes since last refresh before the exhibit is stale. */
+  minutes: number;
+}
+
+/**
+ * Staleness budgets per decay class. Deliberately generous on events and
+ * tighter on minutes: `fast` incident/stall exhibits should visibly age within
+ * a few minutes even if the transcript is quiet, while `slow` structural
+ * exhibits (concern_snapshot, thermal_map) can ride a long session. Tuned for
+ * the curator cadence (fewer, bigger calls — trigger floor 25 events / 120s),
+ * so a `fast` exhibit stales after roughly one skipped curator call.
+ */
+export const STALENESS_THRESHOLDS: Record<DecayClass, DecayThreshold> = {
+  fast: { events: 15, minutes: 3 },
+  medium: { events: 40, minutes: 12 },
+  slow: { events: 100, minutes: 45 },
+};
+
+/** Outcome of applying a batch of ops — counts + ids, for logs/reports. */
+export interface GalleryApplyResult {
+  created: string[];
+  refreshed: string[];
+  retired: string[];
+  /** Ops that named nothing actionable (e.g. retire of an unknown id). */
+  ignored: number;
+}
+
+export interface GalleryStore {
+  /**
+   * Apply a batch of curator ops as of event index `atEvent` (the number of
+   * events observed when the response was produced) and wall-clock `nowMs`.
+   * Promotes surviving `fresh` exhibits to `active`, applies the ops, then
+   * recomputes staleness.
+   */
+  applyOps(ops: GalleryOp[], atEvent: number, nowMs?: number): GalleryApplyResult;
+  /** Every artifact, including retired, most-relevant first (retired last). */
+  getArtifacts(): ExhibitArtifact[];
+  /** Non-retired artifacts (fresh/active/stale), most-relevant first. */
+  getActive(): ExhibitArtifact[];
+  /** Retired artifacts, kept for the archive shelf. */
+  getRetired(): ExhibitArtifact[];
+  /** id + reason for every retire seen this session (for the packet feedback). */
+  getRetiredSummaries(): Array<{ id: string; reason: string }>;
+  /** Recompute staleness without applying ops (e.g. before building a packet). */
+  refreshStaleness(atEvent: number, nowMs?: number): void;
+  /** Total artifact count (including retired). */
+  size(): number;
+}
+
+interface StoredEntry {
+  artifact: ExhibitArtifact;
+  /** Wall-clock ms when this exhibit was last created/refreshed. */
+  refreshedAtMs: number;
+}
+
+function isAged(
+  decayClass: DecayClass,
+  refreshedAtEvent: number,
+  refreshedAtMs: number,
+  atEvent: number,
+  nowMs: number
+): boolean {
+  const threshold = STALENESS_THRESHOLDS[decayClass];
+  const eventAge = atEvent - refreshedAtEvent;
+  const minuteAge = (nowMs - refreshedAtMs) / 60_000;
+  return eventAge >= threshold.events || minuteAge >= threshold.minutes;
+}
+
+export function createGalleryStore(): GalleryStore {
+  const entries = new Map<string, StoredEntry>();
+  // Insertion order of ids retired this session, so feedback is stable.
+  const retiredReasons = new Map<string, string>();
+
+  const setStatus = (id: string, status: ExhibitStatus): void => {
+    const entry = entries.get(id);
+    if (entry) {
+      entry.artifact = { ...entry.artifact, status };
+    }
+  };
+
+  const refreshStaleness = (atEvent: number, nowMs: number): void => {
+    for (const entry of entries.values()) {
+      const { artifact, refreshedAtMs } = entry;
+      // Retired is terminal; fresh has not survived a packet yet, so it is not
+      // subject to staleness until it is promoted.
+      if (artifact.status === 'retired' || artifact.status === 'fresh') {
+        continue;
+      }
+      const aged = isAged(
+        artifact.decayClass,
+        artifact.refreshedAtEvent ?? artifact.createdAtEvent,
+        refreshedAtMs,
+        atEvent,
+        nowMs
+      );
+      setStatus(artifact.id, aged ? 'stale' : 'active');
+    }
+  };
+
+  const upsert = (
+    incoming: ExhibitArtifact,
+    atEvent: number,
+    nowMs: number,
+    mode: 'create' | 'refresh'
+  ): void => {
+    const existing = entries.get(incoming.id);
+    const createdAtEvent =
+      mode === 'refresh' && existing ? existing.artifact.createdAtEvent : atEvent;
+    // create → fresh (a new or reset exhibit); refresh of a known id → active;
+    // refresh of an unknown id is tolerated as a create (fresh).
+    const status: ExhibitStatus = mode === 'refresh' && existing ? 'active' : 'fresh';
+    const artifact: ExhibitArtifact = {
+      ...incoming,
+      createdAtEvent,
+      refreshedAtEvent: atEvent,
+      status,
+      // A refreshed/recreated id sheds any prior retirement.
+      retirementReason: undefined,
+    } as ExhibitArtifact;
+    entries.set(incoming.id, { artifact, refreshedAtMs: nowMs });
+    retiredReasons.delete(incoming.id);
+  };
+
+  return {
+    applyOps(ops, atEvent, nowMs = Date.now()) {
+      const result: GalleryApplyResult = { created: [], refreshed: [], retired: [], ignored: 0 };
+
+      // 1. Survivors of the previous packet graduate fresh → active.
+      for (const entry of entries.values()) {
+        if (entry.artifact.status === 'fresh') {
+          setStatus(entry.artifact.id, 'active');
+        }
+      }
+
+      // 2. Apply ops.
+      for (const op of ops) {
+        if (op.op === 'create') {
+          upsert(op.artifact, atEvent, nowMs, 'create');
+          result.created.push(op.artifact.id);
+        } else if (op.op === 'refresh') {
+          const known = entries.has(op.artifact.id);
+          upsert(op.artifact, atEvent, nowMs, 'refresh');
+          (known ? result.refreshed : result.created).push(op.artifact.id);
+        } else {
+          const entry = entries.get(op.artifactId);
+          if (!entry) {
+            result.ignored += 1;
+            // Still record the reason so the packet does not re-suggest it.
+            retiredReasons.set(op.artifactId, op.reason);
+            continue;
+          }
+          entry.artifact = {
+            ...entry.artifact,
+            status: 'retired',
+            retirementReason: op.reason,
+          };
+          retiredReasons.set(op.artifactId, op.reason);
+          result.retired.push(op.artifactId);
+        }
+      }
+
+      // 3. Recompute staleness against the new event/time position.
+      refreshStaleness(atEvent, nowMs);
+      return result;
+    },
+
+    getArtifacts() {
+      return [...entries.values()]
+        .map((e) => e.artifact)
+        .sort((a, b) => {
+          const ar = a.status === 'retired' ? 1 : 0;
+          const br = b.status === 'retired' ? 1 : 0;
+          if (ar !== br) return ar - br;
+          return b.relevance - a.relevance;
+        });
+    },
+
+    getActive() {
+      return [...entries.values()]
+        .map((e) => e.artifact)
+        .filter((a) => a.status !== 'retired')
+        .sort((a, b) => b.relevance - a.relevance);
+    },
+
+    getRetired() {
+      return [...entries.values()].map((e) => e.artifact).filter((a) => a.status === 'retired');
+    },
+
+    getRetiredSummaries() {
+      return [...retiredReasons.entries()].map(([id, reason]) => ({ id, reason }));
+    },
+
+    refreshStaleness(atEvent, nowMs = Date.now()) {
+      refreshStaleness(atEvent, nowMs);
+    },
+
+    size() {
+      return entries.size;
+    },
+  };
+}

--- a/src/inference/prompt-builder.ts
+++ b/src/inference/prompt-builder.ts
@@ -18,6 +18,26 @@ import {
 } from '../shared/privacy';
 import type { TranscriptPrivacySettings } from '../shared/schema';
 
+/**
+ * One exhibit serialized for THE GALLERY section of the packet. The envelope is
+ * always present; `payloadSummary` is a one-line description of the payload
+ * (beats + thread names, node + focus, etc.) that the packager drops first when
+ * the gallery section would blow its ~15%-of-budget cap.
+ */
+export interface GalleryPacketEntry {
+  id: string;
+  exhibitType: string;
+  title: string;
+  narrative: string;
+  relevance: number;
+  decayClass: string;
+  status: string;
+  createdAtEvent: number;
+  refreshedAtEvent?: number;
+  /** One-line payload summary; omitted in envelope-only (over-budget) mode. */
+  payloadSummary?: string;
+}
+
 export interface ShadowContextPacket {
   sessionId: string;
   observedAgent: string;
@@ -28,6 +48,17 @@ export interface ShadowContextPacket {
   recentTranscript: Array<{ actor: string; text: string }>;
   fileAttention: Array<{ filePath: string; touches: number }>;
   riskSignals: Array<{ signal: string; severity: string }>;
+  /**
+   * THE GALLERY: the curator's own prior work fed back as memory. Active/stale
+   * exhibits with envelope + one-line payload summary; capped at ~15% of the
+   * packet token budget by the packager.
+   */
+  gallery?: GalleryPacketEntry[];
+  /**
+   * Ids + reasons of exhibits retired this session, one line each, so the model
+   * does not recreate what it already retired.
+   */
+  retiredGallery?: Array<{ id: string; reason: string }>;
 }
 
 export interface BuildUserMessageOptions {
@@ -97,6 +128,27 @@ export function buildUserMessage(
       `${r.signal} (severity: ${r.severity})`
     ),
   ];
+
+  const gallery = packet.gallery ?? [];
+  lines.push('', `--- THE GALLERY (${gallery.length}) ---`);
+  for (const g of gallery) {
+    lines.push(
+      `[${g.exhibitType}] ${g.id} "${sanitize(g.title)}" ` +
+        `(relevance ${g.relevance.toFixed(2)}, ${g.status}, ${g.decayClass})`
+    );
+    lines.push(`  narrative: ${sanitize(g.narrative)}`);
+    if (g.payloadSummary) {
+      lines.push(`  payload: ${sanitize(g.payloadSummary)}`);
+    }
+  }
+
+  const retired = packet.retiredGallery ?? [];
+  if (retired.length > 0) {
+    lines.push('', `--- Retired this session (${retired.length}) ---`);
+    for (const r of retired) {
+      lines.push(`${r.id}: ${sanitize(r.reason)}`);
+    }
+  }
 
   return lines.join('\n');
 }

--- a/src/inference/response-parser.ts
+++ b/src/inference/response-parser.ts
@@ -1,20 +1,66 @@
 /**
- * Response parser: converts the model's raw JSON response text into ShadowInsight[].
+ * Response parser: converts the model's raw JSON response text into the
+ * pieces the pipeline needs — legacy `ShadowInsight[]` for the existing
+ * renderer paths, plus the curator's `pulse` and `galleryOps` for the exhibit
+ * floor.
  *
- * Handles: markdown-fenced JSON, missing fields, malformed output.
- * Per the plan:
- *   phase → {kind: 'phase', confidence: phaseConfidence}
- *   riskSignals[i] → {kind: 'risk'}
- *   predictedNextAction → {kind: 'next_move'}
- *   attention.intent → {kind: 'objective'}
- *   observations[i] → {kind: 'summary'}
+ * Three shapes are tolerated so provider/prompt mismatches degrade gracefully:
+ *
+ * 1. **Curator shape (v2)** — `{ pulse: {...}, galleryOps: [...] }`. Each
+ *    op's artifact is validated against the discriminated union in
+ *    `src/renderer/exhibits/types.ts`; invalid artifacts are dropped with a
+ *    logged reason, never rendered half-formed. The legacy insight kinds are
+ *    DERIVED from this shape (see {@link deriveCuratorInsights}):
+ *      pulse.phase       → {kind: 'phase'}
+ *      pulse.riskLevel   → {kind: 'risk', severity from riskLevel}
+ *      pulse.headline    → {kind: 'objective'}
+ *      each created artifact.title+narrative → {kind: 'summary'}
+ *      momentum artifact next[0]             → {kind: 'next_move'}
+ * 2. **Legacy flat shape (v1)** — `{ phase, riskSignals, predictedNextAction,
+ *    observations, attention }`. Parsed the old way when a response carries no
+ *    `pulse`/`galleryOps`. This keeps a v1-prompted provider working.
+ * 3. **Unparseable** — returns empty results with a logged warning.
+ *
+ * Backward compatibility contract: existing renderer paths (status strip,
+ * vignette, ghost trail, ShadowPanel) consume only `ShadowInsight[]`, which
+ * both live shapes produce.
  */
 import type { ShadowInsight, InsightKind } from '../shared/schema';
-import { createLogger } from '../shared/logger';
+import { createLogger, type Logger } from '../shared/logger';
+import {
+  AUTHORED_EXHIBIT_TYPES,
+  type DecayClass,
+  type ExhibitArtifact,
+  type ExhibitStatus,
+  type ExhibitType,
+} from '../renderer/exhibits/types';
+import type { GalleryOp } from './gallery-store';
 
 const logger = createLogger({ minLevel: 'info' });
 
+/** The small always-present object that keeps the legacy renderer paths alive. */
+export interface CuratorPulse {
+  phase?: string;
+  phaseConfidence?: number;
+  riskLevel?: string;
+  headline?: string;
+}
+
+/** Everything a single curator response yields. */
+export interface CuratorParseResult {
+  /** Legacy insights derived from pulse + created/refreshed artifacts. */
+  insights: ShadowInsight[];
+  /** The pulse object, or null for the legacy flat shape. */
+  pulse: CuratorPulse | null;
+  /** Validated gallery ops (invalid artifacts already dropped). */
+  galleryOps: GalleryOp[];
+}
+
 interface ModelResponse {
+  // Curator (v2)
+  pulse?: unknown;
+  galleryOps?: unknown;
+  // Legacy flat (v1)
   phase?: string;
   phaseConfidence?: number;
   phaseReason?: string;
@@ -25,6 +71,10 @@ interface ModelResponse {
   observations?: string[];
   attention?: { primaryFile?: string | null; intent?: string };
 }
+
+const VALID_EXHIBIT_TYPES = new Set<string>([...AUTHORED_EXHIBIT_TYPES, 'live_graph']);
+const VALID_DECAY_CLASSES = new Set<string>(['fast', 'medium', 'slow']);
+const AUTHORABLE_STATUSES = new Set<string>(['fresh', 'active', 'stale']);
 
 function stripMarkdownFences(text: string): string {
   return text
@@ -115,6 +165,12 @@ function asConfidence(n: unknown): number {
   return typeof n === 'number' && Number.isFinite(n) ? clamp(n) : 0.5;
 }
 
+/** Confidence values arrive on either a 0..1 or a 0..100 scale; normalize. */
+function normalizeConfidence(n: unknown): number {
+  if (typeof n !== 'number' || !Number.isFinite(n)) return 0.5;
+  return clamp(n > 1 ? n / 100 : n);
+}
+
 function makeInsight(
   kind: InsightKind,
   summary: string,
@@ -132,27 +188,238 @@ function makeInsight(
   };
 }
 
-export function parseModelResponse(text: string): ShadowInsight[] {
-  const parsed = parseModelObject(text);
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
 
-  if (!parsed) {
-    logger.warn('inference', 'response_parser.json_parse_failed', {
-      preview: text.slice(0, 200),
-    });
-    return [];
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+/**
+ * Structural (not exhaustive) validation of one exhibit type's payload. Checks
+ * that the collections and scalars an exhibit component reads are present and
+ * of the right shape, so nothing renders half-formed. Returns true when the
+ * payload is renderable.
+ */
+function payloadIsValid(type: ExhibitType, payload: Record<string, unknown>): boolean {
+  switch (type) {
+    case 'relationship_dag':
+      return Array.isArray(payload.nodes) && Array.isArray(payload.edges);
+    case 'activity_narrative':
+      return Array.isArray(payload.beats) && Array.isArray(payload.threads);
+    case 'walkthrough':
+      return (
+        typeof payload.headline === 'string' &&
+        typeof payload.body === 'string' &&
+        Array.isArray(payload.tags) &&
+        Array.isArray(payload.satellites) &&
+        Array.isArray(payload.files)
+      );
+    case 'concern_snapshot':
+      return Array.isArray(payload.concerns) && Array.isArray(payload.flows);
+    case 'momentum':
+      return (
+        typeof payload.value === 'number' &&
+        Array.isArray(payload.stats) &&
+        Array.isArray(payload.next) &&
+        Array.isArray(payload.curation)
+      );
+    case 'seismograph':
+      return (
+        Array.isArray(payload.trace) &&
+        Array.isArray(payload.annotations) &&
+        typeof payload.windowMinutes === 'number'
+      );
+    case 'thermal_map':
+      return Array.isArray(payload.cells) && isRecord(payload.hottest) && typeof payload.hottest.path === 'string';
+    case 'live_graph':
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Validate + normalize a raw artifact against the discriminated union in
+ * `src/renderer/exhibits/types.ts`. Envelope fields (id, exhibitType, title,
+ * narrative, payload) and per-type payload required fields are checked
+ * structurally; envelope scalars (relevance, decayClass, status, event stamps)
+ * are coerced to sane defaults rather than causing a drop, since the gallery
+ * store re-stamps status/events on apply anyway. Returns null (and logs) when
+ * the artifact could not be made renderable.
+ */
+export function validateExhibitArtifact(raw: unknown, log: Logger = logger): ExhibitArtifact | null {
+  if (!isRecord(raw)) {
+    log.warn('inference', 'response_parser.artifact_invalid', { reason: 'not_an_object' });
+    return null;
+  }
+  const { id, exhibitType, title, narrative, payload } = raw;
+  if (!nonEmptyString(id)) {
+    log.warn('inference', 'response_parser.artifact_invalid', { reason: 'missing_id' });
+    return null;
+  }
+  if (typeof exhibitType !== 'string' || !VALID_EXHIBIT_TYPES.has(exhibitType)) {
+    log.warn('inference', 'response_parser.artifact_invalid', { reason: 'bad_exhibit_type', id, exhibitType });
+    return null;
+  }
+  if (!nonEmptyString(title)) {
+    log.warn('inference', 'response_parser.artifact_invalid', { reason: 'missing_title', id });
+    return null;
+  }
+  if (!nonEmptyString(narrative)) {
+    log.warn('inference', 'response_parser.artifact_invalid', { reason: 'missing_narrative', id });
+    return null;
+  }
+  if (!isRecord(payload)) {
+    log.warn('inference', 'response_parser.artifact_invalid', { reason: 'missing_payload', id });
+    return null;
+  }
+  const type = exhibitType as ExhibitType;
+  if (!payloadIsValid(type, payload)) {
+    log.warn('inference', 'response_parser.artifact_invalid', { reason: 'bad_payload', id, exhibitType });
+    return null;
   }
 
+  const relevance = typeof raw.relevance === 'number' && Number.isFinite(raw.relevance) ? clamp(raw.relevance) : 0.5;
+  const decayClass: DecayClass = VALID_DECAY_CLASSES.has(raw.decayClass as string)
+    ? (raw.decayClass as DecayClass)
+    : 'medium';
+  const status: ExhibitStatus = AUTHORABLE_STATUSES.has(raw.status as string)
+    ? (raw.status as ExhibitStatus)
+    : 'fresh';
+  const createdAtEvent =
+    typeof raw.createdAtEvent === 'number' && Number.isFinite(raw.createdAtEvent) ? raw.createdAtEvent : 0;
+  const refreshedAtEvent =
+    typeof raw.refreshedAtEvent === 'number' && Number.isFinite(raw.refreshedAtEvent)
+      ? raw.refreshedAtEvent
+      : undefined;
+
+  // The discriminated union is keyed by exhibitType; the structural checks
+  // above guarantee the payload matches. Assemble a normalized envelope.
+  return {
+    id,
+    exhibitType: type,
+    title,
+    narrative,
+    relevance,
+    decayClass,
+    status,
+    createdAtEvent,
+    ...(refreshedAtEvent !== undefined ? { refreshedAtEvent } : {}),
+    payload,
+  } as ExhibitArtifact;
+}
+
+function parsePulse(raw: unknown): CuratorPulse | null {
+  if (!isRecord(raw)) return null;
+  const pulse: CuratorPulse = {};
+  if (typeof raw.phase === 'string') pulse.phase = raw.phase;
+  if (typeof raw.phaseConfidence === 'number') pulse.phaseConfidence = raw.phaseConfidence;
+  if (typeof raw.riskLevel === 'string') pulse.riskLevel = raw.riskLevel;
+  if (typeof raw.headline === 'string') pulse.headline = raw.headline;
+  return pulse;
+}
+
+function parseGalleryOps(raw: unknown, log: Logger): GalleryOp[] {
+  if (!Array.isArray(raw)) return [];
+  const ops: GalleryOp[] = [];
+  for (const entry of raw) {
+    if (!isRecord(entry)) {
+      log.warn('inference', 'response_parser.op_invalid', { reason: 'not_an_object' });
+      continue;
+    }
+    const op = entry.op;
+    if (op === 'create' || op === 'refresh') {
+      const artifact = validateExhibitArtifact(entry.artifact, log);
+      if (artifact) {
+        ops.push({ op, artifact });
+      }
+      // validateExhibitArtifact already logged the drop reason.
+    } else if (op === 'retire') {
+      if (nonEmptyString(entry.artifactId)) {
+        ops.push({
+          op: 'retire',
+          artifactId: entry.artifactId,
+          reason: typeof entry.reason === 'string' ? entry.reason : 'Retired by the curator.',
+        });
+      } else {
+        log.warn('inference', 'response_parser.op_invalid', { reason: 'retire_missing_id' });
+      }
+    } else {
+      log.warn('inference', 'response_parser.op_invalid', { reason: 'unknown_op', op });
+    }
+  }
+  return ops;
+}
+
+const RISK_SEVERITY: Record<string, string> = {
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  critical: 'high',
+};
+const RISK_CONFIDENCE: Record<string, number> = {
+  low: 0.5,
+  medium: 0.6,
+  high: 0.8,
+  critical: 0.9,
+};
+
+/**
+ * Derive the legacy `ShadowInsight[]` from the curator's pulse + ops so the
+ * existing renderer paths (status strip, vignette, ghost trail, ShadowPanel)
+ * keep working unchanged during the transition to the exhibit floor.
+ */
+export function deriveCuratorInsights(pulse: CuratorPulse | null, ops: GalleryOp[]): ShadowInsight[] {
+  const insights: ShadowInsight[] = [];
+
+  if (pulse?.phase) {
+    insights.push(
+      makeInsight('phase', `Phase: ${pulse.phase}`, asConfidence(pulse.phaseConfidence), { phase: pulse.phase })
+    );
+  }
+  if (pulse?.riskLevel) {
+    const level = pulse.riskLevel.toLowerCase();
+    insights.push(
+      makeInsight('risk', `Risk level: ${pulse.riskLevel}`, RISK_CONFIDENCE[level] ?? 0.6, {
+        riskLevel: pulse.riskLevel,
+        severity: RISK_SEVERITY[level] ?? 'medium',
+      })
+    );
+  }
+  if (pulse?.headline) {
+    insights.push(makeInsight('objective', pulse.headline, asConfidence(pulse.phaseConfidence)));
+  }
+
+  for (const op of ops) {
+    if (op.op === 'create') {
+      const { title, narrative, relevance } = op.artifact;
+      insights.push(makeInsight('summary', `${title} — ${narrative}`, relevance));
+    }
+    // next_move comes from momentum artifacts (created or refreshed).
+    if ((op.op === 'create' || op.op === 'refresh') && op.artifact.exhibitType === 'momentum') {
+      const next = (op.artifact.payload as { next?: Array<{ title?: string; confidence?: number }> }).next;
+      const first = Array.isArray(next) ? next[0] : undefined;
+      if (first && nonEmptyString(first.title)) {
+        insights.push(makeInsight('next_move', first.title, normalizeConfidence(first.confidence)));
+      }
+    }
+  }
+
+  return insights;
+}
+
+/** Parse the legacy flat (v1) response shape into insights. */
+function parseLegacyFlat(parsed: ModelResponse): ShadowInsight[] {
   const insights: ShadowInsight[] = [];
 
   // Phase
   if (parsed.phase) {
     insights.push(
-      makeInsight(
-        'phase',
-        parsed.phaseReason ?? `Phase: ${parsed.phase}`,
-        asConfidence(parsed.phaseConfidence),
-        { phase: parsed.phase }
-      )
+      makeInsight('phase', parsed.phaseReason ?? `Phase: ${parsed.phase}`, asConfidence(parsed.phaseConfidence), {
+        phase: parsed.phase,
+      })
     );
   }
 
@@ -165,35 +432,22 @@ export function parseModelResponse(text: string): ShadowInsight[] {
     const rs = raw as { signal?: string; severity?: string; confidence?: number };
     if (!rs.signal) continue;
     insights.push(
-      makeInsight(
-        'risk',
-        rs.signal,
-        asConfidence(rs.confidence),
-        { severity: rs.severity ?? 'medium', riskLevel: parsed.riskLevel ?? 'low' }
-      )
+      makeInsight('risk', rs.signal, asConfidence(rs.confidence), {
+        severity: rs.severity ?? 'medium',
+        riskLevel: parsed.riskLevel ?? 'low',
+      })
     );
   }
 
   // Predicted next action
   if (parsed.predictedNextAction) {
-    insights.push(
-      makeInsight(
-        'next_move',
-        parsed.predictedNextAction,
-        asConfidence(parsed.predictedNextConfidence)
-      )
-    );
+    insights.push(makeInsight('next_move', parsed.predictedNextAction, asConfidence(parsed.predictedNextConfidence)));
   }
 
   // Attention intent → objective
   if (parsed.attention?.intent) {
     insights.push(
-      makeInsight(
-        'objective',
-        parsed.attention.intent,
-        0.7,
-        { primaryFile: parsed.attention.primaryFile ?? null }
-      )
+      makeInsight('objective', parsed.attention.intent, 0.7, { primaryFile: parsed.attention.primaryFile ?? null })
     );
   }
 
@@ -205,6 +459,45 @@ export function parseModelResponse(text: string): ShadowInsight[] {
     insights.push(makeInsight('summary', obs, 0.6));
   }
 
-  logger.debug('inference', 'response_parser.parsed', { insightCount: insights.length });
   return insights;
+}
+
+/**
+ * Full curator parse: returns insights + pulse + validated gallery ops. Detects
+ * the curator (v2) shape by the presence of `pulse` or `galleryOps`; otherwise
+ * falls back to the legacy flat (v1) parse so a v1-prompted provider degrades
+ * gracefully.
+ */
+export function parseCuratorResponse(text: string, log: Logger = logger): CuratorParseResult {
+  const parsed = parseModelObject(text);
+  if (!parsed) {
+    log.warn('inference', 'response_parser.json_parse_failed', { preview: text.slice(0, 200) });
+    return { insights: [], pulse: null, galleryOps: [] };
+  }
+
+  const isCurator = isRecord(parsed.pulse) || Array.isArray(parsed.galleryOps);
+  if (!isCurator) {
+    const insights = parseLegacyFlat(parsed);
+    log.debug('inference', 'response_parser.parsed', { shape: 'legacy', insightCount: insights.length });
+    return { insights, pulse: null, galleryOps: [] };
+  }
+
+  const pulse = parsePulse(parsed.pulse);
+  const galleryOps = parseGalleryOps(parsed.galleryOps, log);
+  const insights = deriveCuratorInsights(pulse, galleryOps);
+  log.debug('inference', 'response_parser.parsed', {
+    shape: 'curator',
+    insightCount: insights.length,
+    opCount: galleryOps.length,
+  });
+  return { insights, pulse, galleryOps };
+}
+
+/**
+ * Legacy entry point: returns only the derived `ShadowInsight[]`. Retained so
+ * existing callers (replay checkpoint scoring, tests) keep their signature.
+ * Handles all three shapes via {@link parseCuratorResponse}.
+ */
+export function parseModelResponse(text: string): ShadowInsight[] {
+  return parseCuratorResponse(text).insights;
 }

--- a/src/inference/shadow-inference-engine.ts
+++ b/src/inference/shadow-inference-engine.ts
@@ -15,22 +15,31 @@ import { createLogger } from '../shared/logger';
 import { DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS } from '../shared/privacy';
 import { buildContextPacket } from './context-packager';
 import { buildInferenceRequest } from './prompt-builder';
-import { parseModelResponse } from './response-parser';
+import { parseCuratorResponse } from './response-parser';
+import { createGalleryStore } from './gallery-store';
 import { createInferenceTrigger, type TriggerConfig } from './trigger';
 import { createInferenceClient } from './inference-client-factory';
 import { loadCredentials } from './auth';
 import type { InferenceClient } from './inference-client';
 import type { EventBufferLike } from './inference-client';
+import type { ExhibitArtifact } from '../renderer/exhibits/types';
 
 const logger = createLogger({ minLevel: 'info' });
 const INFERENCE_CONSUMER_ID = 'inference-trigger';
 
 export type InsightCallback = (insights: ShadowInsight[]) => void;
+export type GalleryCallback = (artifacts: ExhibitArtifact[]) => void;
 
 export interface InferenceEngineOptions {
   buffer: EventBufferLike;
   getState: () => DerivedState | Promise<DerivedState>;
   onInsights: InsightCallback;
+  /**
+   * Called after each curator response with the full current gallery (active,
+   * stale, and retired). Wire this to the session manager so the exhibit floor
+   * reflects the model's curation.
+   */
+  onGallery?: GalleryCallback;
   triggerConfig?: Partial<TriggerConfig>;
   privacy?: TranscriptPrivacySettings;
   client?: InferenceClient;
@@ -56,6 +65,7 @@ function isCheckpointedEventBuffer(buffer: EventBufferLike): buffer is Checkpoin
 export function createInferenceEngine(opts: InferenceEngineOptions): InferenceEngine {
   const { buffer, getState, onInsights } = opts;
   const privacy = opts.privacy ?? DEFAULT_TRANSCRIPT_PRIVACY_SETTINGS;
+  const galleryStore = createGalleryStore();
   let client: InferenceClient | null = null;
   let inflight = false;
   let pendingTrigger = false;
@@ -75,7 +85,14 @@ export function createInferenceEngine(opts: InferenceEngineOptions): InferenceEn
     try {
       const state = await getState();
       const events = await buffer.getAll();
-      const packet = buildContextPacket(state, events);
+      // Feed the current gallery back in as the curator's memory. Refresh
+      // staleness against the current event position first so the model sees
+      // accurate statuses.
+      galleryStore.refreshStaleness(events.length);
+      const packet = buildContextPacket(state, events, {
+        gallery: galleryStore.getActive(),
+        retiredGallery: galleryStore.getRetiredSummaries(),
+      });
       const request = buildInferenceRequest(packet, {
         delivery: 'off-host',
         privacy
@@ -83,12 +100,23 @@ export function createInferenceEngine(opts: InferenceEngineOptions): InferenceEn
 
       logger.info('inference', 'engine.run_start', { eventCount: events.length });
       const inferenceResponse = await client.infer(request);
-      const insights = parseModelResponse(inferenceResponse.text);
+      const { insights, galleryOps } = parseCuratorResponse(inferenceResponse.text);
+
+      // Apply the curator's ops as of the current event index, then expose the
+      // resulting gallery to the renderer.
+      const applied = galleryStore.applyOps(galleryOps, events.length);
 
       logger.info('inference', 'engine.run_done', {
         latencyMs: inferenceResponse.latencyMs,
         insights: insights.length,
+        created: applied.created.length,
+        refreshed: applied.refreshed.length,
+        retired: applied.retired.length,
       });
+
+      if (opts.onGallery && galleryOps.length > 0) {
+        opts.onGallery(galleryStore.getArtifacts());
+      }
 
       if (insights.length > 0) {
         onInsights(insights);

--- a/src/inference/trigger.ts
+++ b/src/inference/trigger.ts
@@ -2,11 +2,17 @@
  * Inference trigger: decides when to run the inference engine.
  *
  * Trigger conditions (any one fires):
- *   - At least minEventsBetween (10) new events since last inference
- *   - At least timeBetweenMs (30 s) since last inference
+ *   - At least minEventsBetween (25) new events since last inference
+ *   - At least timeBetweenMs (120 s) since last inference
  *   - maxEventsBetween (50) events forces a trigger regardless of timer
  *   - Risk escalation: derived risk level rises to 'medium' or above
  *   - Specific event kinds: tool_failed, agent_completed always trigger immediately
+ *
+ * Cadence (2026-07-23, curator design — docs/plans/plan-exhibit-floor.md): the
+ * curator makes fewer, bigger calls. The immediate paths (agent_completed,
+ * tool_failed) fire on turn boundaries and failures; the normal-path floor is
+ * raised to 25 events / 120 s so routine 10-event dribbles no longer trigger a
+ * call. maxEventsBetween stays at 50 as the hard ceiling.
  */
 import type { CanonicalEvent, EventKind } from '../shared/schema';
 import { createLogger } from '../shared/logger';
@@ -17,14 +23,14 @@ const logger = createLogger({ minLevel: 'info' });
 const IMMEDIATE_KINDS = new Set<EventKind>(['tool_failed', 'agent_completed']);
 
 export interface TriggerConfig {
-  minEventsBetween: number;   // default 10
-  timeBetweenMs: number;       // default 30_000
+  minEventsBetween: number;   // default 25
+  timeBetweenMs: number;       // default 120_000
   maxEventsBetween: number;    // default 50
 }
 
 const DEFAULT_CONFIG: TriggerConfig = {
-  minEventsBetween: 10,
-  timeBetweenMs: 30_000,
+  minEventsBetween: 25,
+  timeBetweenMs: 120_000,
   maxEventsBetween: 50,
 };
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -503,7 +503,10 @@ export default function App({ host }: ShadowAgentAppProps) {
 
         {ExhibitStageSurface ? (
           <section className="exhibit-surface">
-            <ExhibitStageSurface liveGraph={liveGraphNode} />
+            {/* Live/replay snapshots carry the curator's gallery; the boot/
+                fixture snapshot leaves it undefined so the stage shows its
+                hand-authored fixture gallery. */}
+            <ExhibitStageSurface artifacts={snapshot?.gallery} liveGraph={liveGraphNode} />
           </section>
         ) : null}
 

--- a/src/replay/replay-runner.ts
+++ b/src/replay/replay-runner.ts
@@ -39,9 +39,11 @@ import {
 } from '../inference/trigger';
 import { buildContextPacket } from '../inference/context-packager';
 import { buildInferenceRequest } from '../inference/prompt-builder';
-import { parseModelResponse } from '../inference/response-parser';
+import { parseCuratorResponse } from '../inference/response-parser';
+import { createGalleryStore } from '../inference/gallery-store';
 import { createInferenceClient } from '../inference/inference-client-factory';
 import type { InferenceClient } from '../inference/inference-client';
+import type { ExhibitArtifact } from '../renderer/exhibits/types';
 import { createLogger, type Logger } from '../shared/logger';
 
 export type InferMode = 'none' | 'live';
@@ -63,6 +65,8 @@ export interface ReplayOptions {
   exportReplayPath?: string;
   /** Write the JSON report here. */
   reportPath?: string;
+  /** Write the final curator gallery (JSON array of ExhibitArtifact) here. */
+  galleryOutPath?: string;
   /** Injected client for tests; live mode uses the provider chain when absent. */
   inferenceClient?: InferenceClient;
   logger?: Logger;
@@ -87,6 +91,13 @@ export interface TriggerRecord {
   phase: string;
   risks: string[];
   insightSummaries: string[];
+  /** Per-firing curator gallery ops: counts + affected artifact ids. */
+  galleryOps?: {
+    create: number;
+    refresh: number;
+    retire: number;
+    ids: string[];
+  };
   /** True when a live inference was already in flight and this firing was coalesced. */
   coalesced?: boolean;
   error?: string;
@@ -128,6 +139,8 @@ export interface ReplayReport {
     bufferDepthMax: number;
   };
   checkpoints: CheckpointResult[];
+  /** The final exhibit-floor gallery the curator authored (empty in `none` mode). */
+  gallery: ExhibitArtifact[];
 }
 
 /** One (virtual time, insight) observation, fed to the checkpoint scorer. */
@@ -454,6 +467,9 @@ export async function runReplay(options: ReplayOptions): Promise<ReplayReport> {
   const triggerFirings: Array<{ eventIndex: number; reason: TriggerReason }> = [];
   const triggerRecords: TriggerRecord[] = [];
   const observations: InsightObservation[] = [];
+  // The curator's gallery accumulates across firings, fed back into each packet
+  // (its memory) and serialized into the report at the end.
+  const galleryStore = createGalleryStore();
   let bufferDepthMax = 0;
   let seq = 0;
 
@@ -482,7 +498,12 @@ export async function runReplay(options: ReplayOptions): Promise<ReplayReport> {
     inflight = true;
     const snapshot = released.slice();
     const state = deriveState(snapshot, title);
-    const packet = buildContextPacket(state, snapshot);
+    // Feed the accumulated gallery back in as the curator's memory.
+    galleryStore.refreshStaleness(snapshot.length);
+    const packet = buildContextPacket(state, snapshot, {
+      gallery: galleryStore.getActive(),
+      retiredGallery: galleryStore.getRetiredSummaries(),
+    });
     const request = buildInferenceRequest(packet, {
       delivery: 'off-host',
       privacy: { allowRawTranscriptStorage: true, allowOffHostInference: true },
@@ -493,7 +514,8 @@ export async function runReplay(options: ReplayOptions): Promise<ReplayReport> {
     const promise = activeClient
       .infer(request)
       .then((response) => {
-        const insights = parseModelResponse(response.text);
+        const { insights, galleryOps } = parseCuratorResponse(response.text);
+        const applied = galleryStore.applyOps(galleryOps, released.length);
         const landVirtualMs = clock.now();
         record.wallLatencyMs = Date.now() - wallStart;
         record.insightVirtualTimeMs = landVirtualMs;
@@ -502,6 +524,12 @@ export async function runReplay(options: ReplayOptions): Promise<ReplayReport> {
         record.phase = state.activePhase;
         record.risks = state.riskSignals;
         record.insightSummaries = insightSummaries(insights);
+        record.galleryOps = {
+          create: applied.created.length,
+          refresh: applied.refreshed.length,
+          retire: applied.retired.length,
+          ids: [...applied.created, ...applied.refreshed, ...applied.retired],
+        };
         for (const insight of insights) {
           observations.push({ virtualMs: landVirtualMs, insight });
         }
@@ -644,6 +672,7 @@ export async function runReplay(options: ReplayOptions): Promise<ReplayReport> {
       bufferDepthMax,
     },
     checkpoints: scoreCheckpoints(DEFAULT_CHECKPOINTS, observations),
+    gallery: galleryStore.getArtifacts(),
   };
 
   // --- side outputs --------------------------------------------------------
@@ -657,6 +686,9 @@ export async function runReplay(options: ReplayOptions): Promise<ReplayReport> {
   }
   if (options.reportPath) {
     await writeFile(options.reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  }
+  if (options.galleryOutPath) {
+    await writeFile(options.galleryOutPath, `${JSON.stringify(report.gallery, null, 2)}\n`, 'utf8');
   }
 
   return report;

--- a/src/shared/schema.ts
+++ b/src/shared/schema.ts
@@ -161,6 +161,14 @@ export interface RendererInput {
 
 export interface SnapshotPayload extends RendererInput {
   captureQueue?: EventQueueMetrics;
+  /**
+   * The current exhibit-floor gallery for live/replay snapshots, produced by
+   * the shadow curator (see src/inference/gallery-store.ts). Undefined for the
+   * boot/fixture snapshot — the renderer's ExhibitStage falls back to its
+   * hand-authored fixture gallery in that case. Type-only import: erased at
+   * runtime, so the shared layer carries no dependency on the renderer.
+   */
+  gallery?: import('../renderer/exhibits/types').ExhibitArtifact[];
 }
 
 export interface ExportResult {

--- a/tests/inference/context-packager-gallery.test.ts
+++ b/tests/inference/context-packager-gallery.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { buildContextPacket, packContext } from '../../src/inference/context-packager';
+import { buildUserMessage } from '../../src/inference/prompt-builder';
+import type { DerivedState } from '../../src/shared/schema';
+import type { ExhibitArtifact } from '../../src/renderer/exhibits/types';
+
+function state(): DerivedState {
+  return {
+    sessionId: 'sess',
+    title: 'T',
+    currentObjective: 'Observe',
+    activePhase: 'debugging',
+    agentNodes: [],
+    timeline: [],
+    transcript: [],
+    fileAttention: [],
+    riskSignals: [],
+    nextMoves: [],
+    shadowInsights: [],
+  };
+}
+
+function narrative(id: string, overrides: Partial<ExhibitArtifact> = {}): ExhibitArtifact {
+  return {
+    id,
+    exhibitType: 'activity_narrative',
+    title: `Story ${id}`,
+    narrative: `Why ${id} matters right now.`,
+    relevance: 0.6,
+    decayClass: 'medium',
+    createdAtEvent: 1,
+    status: 'active',
+    payload: {
+      threads: [{ id: 'plan', label: 'plan pivot' }],
+      beats: [
+        { at: '08:39', title: 'b1', body: 'x', side: 'top', thread: 'plan' },
+        { at: '09:04', title: 'b2', body: 'y', side: 'bottom', thread: 'plan' },
+      ],
+    },
+    ...overrides,
+  } as ExhibitArtifact;
+}
+
+describe('context packager — THE GALLERY section', () => {
+  it('serializes each active exhibit with envelope + one-line payload summary', () => {
+    const packet = buildContextPacket(state(), [], {
+      gallery: [narrative('a'), narrative('b', { relevance: 0.9 })],
+    });
+    expect(packet.gallery).toHaveLength(2);
+    // Sorted by relevance (b first).
+    expect(packet.gallery!.map((g) => g.id)).toEqual(['b', 'a']);
+    expect(packet.gallery![0].payloadSummary).toContain('2 beats across threads: plan pivot');
+  });
+
+  it('includes retired-this-session ids + reasons', () => {
+    const packet = buildContextPacket(state(), [], {
+      gallery: [narrative('a')],
+      retiredGallery: [{ id: 'old', reason: 'Superseded by the recovery walkthrough.' }],
+    });
+    expect(packet.retiredGallery).toEqual([{ id: 'old', reason: 'Superseded by the recovery walkthrough.' }]);
+  });
+
+  it('caps the gallery at ~15% of the token budget — drops payload summaries when over', () => {
+    // Many exhibits with long narratives blow the full-entry budget.
+    const big = Array.from({ length: 30 }, (_, i) =>
+      narrative(`x${i}`, { narrative: 'A deliberately long interpretive narrative. '.repeat(12) })
+    );
+    const { packet } = packContext(state(), [], { gallery: big, tokenBudget: 2_000 });
+    // Over budget → envelope-only mode: no payload summaries survive.
+    expect(packet.gallery!.every((g) => g.payloadSummary === undefined)).toBe(true);
+    // And the section itself stays within the 15% cap.
+    const cap = Math.floor(2_000 * 0.15);
+    const sectionTokens = Math.ceil(
+      JSON.stringify({ gallery: packet.gallery, retiredGallery: packet.retiredGallery ?? [] }).length / 4
+    );
+    expect(sectionTokens).toBeLessThanOrEqual(cap);
+  });
+
+  it('prioritizes the most relevant exhibits when pruning to fit', () => {
+    const big = Array.from({ length: 40 }, (_, i) =>
+      narrative(`x${i}`, { relevance: i / 40, narrative: 'long narrative '.repeat(20) })
+    );
+    const { packet } = packContext(state(), [], { gallery: big, tokenBudget: 1_500 });
+    const ids = packet.gallery!.map((g) => g.id);
+    // Whatever survived, the highest-relevance exhibit (x39) must be among them.
+    expect(ids).toContain('x39');
+    // The lowest-relevance exhibit (x0) must have been pruned first.
+    expect(ids).not.toContain('x0');
+  });
+});
+
+describe('prompt builder — gallery rendering', () => {
+  it('renders THE GALLERY and Retired sections in the user message', () => {
+    const packet = buildContextPacket(state(), [], {
+      gallery: [narrative('a')],
+      retiredGallery: [{ id: 'old', reason: 'Cold now.' }],
+    });
+    const message = buildUserMessage(packet);
+    expect(message).toContain('--- THE GALLERY (1) ---');
+    expect(message).toContain('[activity_narrative] a "Story a"');
+    expect(message).toContain('narrative: Why a matters right now.');
+    expect(message).toContain('--- Retired this session (1) ---');
+    expect(message).toContain('old: Cold now.');
+  });
+});

--- a/tests/inference/curator-response-parser.test.ts
+++ b/tests/inference/curator-response-parser.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseCuratorResponse,
+  parseModelResponse,
+  validateExhibitArtifact,
+} from '../../src/inference/response-parser';
+import { createTestLogger } from '../../src/shared/logger';
+
+const momentumArtifact = {
+  id: 'session-momentum',
+  exhibitType: 'momentum',
+  title: 'Momentum: parked mid-path',
+  narrative: 'Real progress on primitives, zero delivered outcomes.',
+  relevance: 0.9,
+  decayClass: 'medium',
+  status: 'fresh',
+  payload: {
+    value: 44,
+    label: 'Parked mid-path',
+    stats: [{ label: 'PG18 image', value: 'complete', tone: 'positive' }],
+    next: [{ title: 'Rotate FORGEJO token', evidence: 'exposed in-session', confidence: 88 }],
+    curation: [],
+  },
+};
+
+function curatorResponse(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    pulse: { phase: 'debugging', phaseConfidence: 0.8, riskLevel: 'high', headline: 'Circling a 403 it cannot see past.' },
+    galleryOps: [{ op: 'create', artifact: momentumArtifact }],
+    ...overrides,
+  });
+}
+
+describe('parseCuratorResponse — curator (v2) shape', () => {
+  it('parses pulse and validated gallery ops', () => {
+    const { pulse, galleryOps } = parseCuratorResponse(curatorResponse());
+    expect(pulse).toEqual({
+      phase: 'debugging',
+      phaseConfidence: 0.8,
+      riskLevel: 'high',
+      headline: 'Circling a 403 it cannot see past.',
+    });
+    expect(galleryOps).toHaveLength(1);
+    expect(galleryOps[0]).toMatchObject({ op: 'create', artifact: { id: 'session-momentum', exhibitType: 'momentum' } });
+  });
+
+  it('derives the legacy insight kinds from pulse + ops', () => {
+    const { insights } = parseCuratorResponse(curatorResponse());
+    const byKind = (k: string) => insights.filter((i) => i.kind === k);
+
+    // pulse.phase → phase
+    expect(byKind('phase')[0]).toMatchObject({ confidence: 0.8, structuredPayload: { phase: 'debugging' } });
+    // pulse.riskLevel → risk (severity derived from riskLevel)
+    expect(byKind('risk')[0]?.structuredPayload).toMatchObject({ riskLevel: 'high', severity: 'high' });
+    // pulse.headline → objective
+    expect(byKind('objective')[0]?.summary).toBe('Circling a 403 it cannot see past.');
+    // created artifact title + narrative → summary
+    expect(byKind('summary')[0]?.summary).toContain('Momentum: parked mid-path');
+    expect(byKind('summary')[0]?.summary).toContain('Real progress on primitives');
+    // momentum next[0] → next_move (0..100 confidence normalized to 0..1)
+    expect(byKind('next_move')[0]).toMatchObject({ summary: 'Rotate FORGEJO token' });
+    expect(byKind('next_move')[0]?.confidence).toBeCloseTo(0.88, 5);
+
+    expect(insights.every((i) => i.source === 'model')).toBe(true);
+  });
+
+  it('parses retire ops with a reason', () => {
+    const { galleryOps } = parseCuratorResponse(
+      curatorResponse({ galleryOps: [{ op: 'retire', artifactId: 'old', reason: 'Superseded by the recovery walkthrough.' }] })
+    );
+    expect(galleryOps).toEqual([{ op: 'retire', artifactId: 'old', reason: 'Superseded by the recovery walkthrough.' }]);
+  });
+
+  it('treats an empty galleryOps as a legitimate no-op answer', () => {
+    const { galleryOps, pulse } = parseCuratorResponse(curatorResponse({ galleryOps: [] }));
+    expect(galleryOps).toEqual([]);
+    expect(pulse?.phase).toBe('debugging');
+  });
+
+  it('drops invalid artifacts with a logged warning, keeping valid ones', () => {
+    const log = createTestLogger();
+    const response = JSON.stringify({
+      pulse: { phase: 'implementation', phaseConfidence: 0.6 },
+      galleryOps: [
+        { op: 'create', artifact: { ...momentumArtifact, id: 'good' } },
+        { op: 'create', artifact: { ...momentumArtifact, id: 'no-narrative', narrative: '' } },
+        { op: 'create', artifact: { ...momentumArtifact, id: 'bad-type', exhibitType: 'hologram' } },
+        { op: 'create', artifact: { ...momentumArtifact, id: 'bad-payload', payload: { label: 'x' } } },
+      ],
+    });
+    const { galleryOps } = parseCuratorResponse(response, log);
+    expect(galleryOps.map((o) => (o.op === 'create' ? o.artifact.id : ''))).toEqual(['good']);
+
+    const drops = log.getRecent().filter((e) => e.event === 'response_parser.artifact_invalid');
+    expect(drops.length).toBe(3);
+    expect(drops.map((d) => d.context?.reason)).toEqual(
+      expect.arrayContaining(['missing_narrative', 'bad_exhibit_type', 'bad_payload'])
+    );
+  });
+});
+
+describe('parseCuratorResponse — legacy (v1) fallback', () => {
+  it('parses the old flat shape when no pulse/galleryOps present', () => {
+    const legacy = JSON.stringify({
+      phase: 'implementation',
+      phaseConfidence: 0.85,
+      riskLevel: 'low',
+      riskSignals: [{ signal: 'Repeated reads', severity: 'medium', confidence: 0.6 }],
+      predictedNextAction: 'Run tests',
+      observations: ['Created 3 files'],
+      attention: { primaryFile: 'src/x.ts', intent: 'Add feature' },
+    });
+    const { insights, pulse, galleryOps } = parseCuratorResponse(legacy);
+    expect(pulse).toBeNull();
+    expect(galleryOps).toEqual([]);
+    expect(insights.some((i) => i.kind === 'phase')).toBe(true);
+    expect(insights.some((i) => i.kind === 'risk')).toBe(true);
+    expect(insights.find((i) => i.kind === 'next_move')?.summary).toBe('Run tests');
+    expect(insights.find((i) => i.kind === 'objective')?.summary).toBe('Add feature');
+  });
+
+  it('parseModelResponse delegates to the curator parse and returns only insights', () => {
+    const insights = parseModelResponse(curatorResponse());
+    expect(insights.some((i) => i.kind === 'phase')).toBe(true);
+    expect(insights.some((i) => i.kind === 'next_move')).toBe(true);
+  });
+
+  it('returns empty results for unparseable output', () => {
+    expect(parseCuratorResponse('not json')).toEqual({ insights: [], pulse: null, galleryOps: [] });
+  });
+});
+
+describe('validateExhibitArtifact', () => {
+  const dag = {
+    id: 'd',
+    exhibitType: 'relationship_dag',
+    title: 'Map',
+    narrative: 'The shape of the session.',
+    relevance: 0.7,
+    decayClass: 'slow',
+    status: 'active',
+    payload: { nodes: [], edges: [], focusNodeId: 'x' },
+  };
+
+  it('accepts a structurally valid artifact and normalizes the envelope', () => {
+    const a = validateExhibitArtifact(dag)!;
+    expect(a).not.toBeNull();
+    expect(a.exhibitType).toBe('relationship_dag');
+    expect(a.relevance).toBe(0.7);
+  });
+
+  it('defaults out-of-range/missing envelope scalars rather than dropping', () => {
+    const a = validateExhibitArtifact({ ...dag, relevance: 5, decayClass: 'glacial', status: 'retired' })!;
+    expect(a.relevance).toBe(1); // clamped
+    expect(a.decayClass).toBe('medium'); // invalid → default
+    expect(a.status).toBe('fresh'); // 'retired' is not model-authorable
+  });
+
+  it('rejects an unknown exhibit type', () => {
+    expect(validateExhibitArtifact({ ...dag, exhibitType: 'nope' })).toBeNull();
+  });
+
+  it('rejects a payload missing required collections', () => {
+    expect(validateExhibitArtifact({ ...dag, payload: { focusNodeId: 'x' } })).toBeNull();
+  });
+
+  it('rejects missing id / title / narrative', () => {
+    expect(validateExhibitArtifact({ ...dag, id: '' })).toBeNull();
+    expect(validateExhibitArtifact({ ...dag, title: '' })).toBeNull();
+    expect(validateExhibitArtifact({ ...dag, narrative: '' })).toBeNull();
+  });
+});

--- a/tests/inference/gallery-store.test.ts
+++ b/tests/inference/gallery-store.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import { createGalleryStore, STALENESS_THRESHOLDS, type GalleryOp } from '../../src/inference/gallery-store';
+import type { DecayClass, ExhibitArtifact } from '../../src/renderer/exhibits/types';
+
+function artifact(id: string, overrides: Partial<ExhibitArtifact> = {}): ExhibitArtifact {
+  return {
+    id,
+    exhibitType: 'activity_narrative',
+    title: `Exhibit ${id}`,
+    narrative: `Why ${id} is on the floor.`,
+    relevance: 0.5,
+    decayClass: 'medium',
+    createdAtEvent: 0,
+    status: 'fresh',
+    payload: { beats: [], threads: [] },
+    ...overrides,
+  } as ExhibitArtifact;
+}
+
+const create = (a: ExhibitArtifact): GalleryOp => ({ op: 'create', artifact: a });
+const refresh = (a: ExhibitArtifact): GalleryOp => ({ op: 'refresh', artifact: a });
+const retire = (artifactId: string, reason: string): GalleryOp => ({ op: 'retire', artifactId, reason });
+
+describe('GalleryStore — op application', () => {
+  it('creates artifacts as fresh, stamping create/refresh event', () => {
+    const store = createGalleryStore();
+    const result = store.applyOps([create(artifact('a')), create(artifact('b'))], 7, 0);
+
+    expect(result.created).toEqual(['a', 'b']);
+    const active = store.getActive();
+    expect(active.map((x) => x.id).sort()).toEqual(['a', 'b']);
+    const a = active.find((x) => x.id === 'a')!;
+    expect(a.status).toBe('fresh');
+    expect(a.createdAtEvent).toBe(7);
+    expect(a.refreshedAtEvent).toBe(7);
+  });
+
+  it('promotes surviving fresh exhibits to active on the next packet', () => {
+    const store = createGalleryStore();
+    store.applyOps([create(artifact('a'))], 0, 0);
+    expect(store.getActive()[0].status).toBe('fresh');
+
+    store.applyOps([], 1, 0); // a subsequent packet with no ops
+    expect(store.getActive()[0].status).toBe('active');
+  });
+
+  it('refresh replaces by id, preserves createdAtEvent, re-stamps refreshedAtEvent, returns to active', () => {
+    const store = createGalleryStore();
+    store.applyOps([create(artifact('a', { relevance: 0.4 }))], 3, 0);
+    const result = store.applyOps(
+      [refresh(artifact('a', { relevance: 0.9, narrative: 'Updated read.' }))],
+      12,
+      0
+    );
+
+    expect(result.refreshed).toEqual(['a']);
+    const a = store.getActive()[0];
+    expect(a.createdAtEvent).toBe(3);
+    expect(a.refreshedAtEvent).toBe(12);
+    expect(a.relevance).toBe(0.9);
+    expect(a.narrative).toBe('Updated read.');
+    expect(a.status).toBe('active');
+  });
+
+  it('tolerates a refresh of an unknown id as a create', () => {
+    const store = createGalleryStore();
+    const result = store.applyOps([refresh(artifact('ghost'))], 5, 0);
+    expect(result.created).toEqual(['ghost']);
+    expect(store.getActive().map((x) => x.id)).toEqual(['ghost']);
+  });
+
+  it('sorts active exhibits by relevance descending', () => {
+    const store = createGalleryStore();
+    store.applyOps(
+      [create(artifact('lo', { relevance: 0.2 })), create(artifact('hi', { relevance: 0.95 }))],
+      0,
+      0
+    );
+    expect(store.getActive().map((x) => x.id)).toEqual(['hi', 'lo']);
+  });
+});
+
+describe('GalleryStore — retire / archive', () => {
+  it('retires an artifact, keeping it with its reason off the active floor', () => {
+    const store = createGalleryStore();
+    store.applyOps([create(artifact('a'))], 0, 0);
+    const result = store.applyOps([retire('a', 'Storyline resolved at 16:26.')], 4, 0);
+
+    expect(result.retired).toEqual(['a']);
+    expect(store.getActive()).toHaveLength(0);
+    const retired = store.getRetired();
+    expect(retired).toHaveLength(1);
+    expect(retired[0].status).toBe('retired');
+    expect(retired[0].retirementReason).toBe('Storyline resolved at 16:26.');
+    expect(store.getRetiredSummaries()).toEqual([{ id: 'a', reason: 'Storyline resolved at 16:26.' }]);
+  });
+
+  it('getArtifacts lists retired after active', () => {
+    const store = createGalleryStore();
+    store.applyOps([create(artifact('a', { relevance: 0.3 })), create(artifact('b', { relevance: 0.8 }))], 0, 0);
+    store.applyOps([retire('b', 'Superseded.')], 1, 0);
+    const all = store.getArtifacts();
+    expect(all.map((x) => x.status)).toEqual(['active', 'retired']);
+    expect(all.map((x) => x.id)).toEqual(['a', 'b']);
+  });
+
+  it('records a retire of an unknown id as ignored but keeps the reason as feedback', () => {
+    const store = createGalleryStore();
+    const result = store.applyOps([retire('never-existed', 'n/a')], 2, 0);
+    expect(result.ignored).toBe(1);
+    expect(result.retired).toEqual([]);
+    expect(store.getRetiredSummaries()).toEqual([{ id: 'never-existed', reason: 'n/a' }]);
+  });
+});
+
+describe('GalleryStore — staleness by decayClass', () => {
+  const stale = (decayClass: DecayClass, atEvent: number, nowMs: number): string => {
+    const store = createGalleryStore();
+    store.applyOps([create(artifact('a', { decayClass }))], 0, 0);
+    store.applyOps([], 1, 0); // promote fresh → active
+    store.refreshStaleness(atEvent, nowMs);
+    return store.getActive()[0].status;
+  };
+
+  it('marks a fast exhibit stale past its event budget', () => {
+    expect(stale('fast', STALENESS_THRESHOLDS.fast.events + 1, 0)).toBe('stale');
+    expect(stale('fast', STALENESS_THRESHOLDS.fast.events - 1, 0)).toBe('active');
+  });
+
+  it('marks a fast exhibit stale past its minute budget even with no new events', () => {
+    const overMinutes = (STALENESS_THRESHOLDS.fast.minutes + 1) * 60_000;
+    expect(stale('fast', 2, overMinutes)).toBe('stale');
+  });
+
+  it('keeps a slow exhibit active where a fast one would have staled', () => {
+    const atEvent = STALENESS_THRESHOLDS.fast.events + 5;
+    expect(stale('fast', atEvent, 0)).toBe('stale');
+    expect(stale('slow', atEvent, 0)).toBe('active');
+  });
+
+  it('never stales a still-fresh exhibit', () => {
+    const store = createGalleryStore();
+    store.applyOps([create(artifact('a', { decayClass: 'fast' }))], 0, 0);
+    store.refreshStaleness(9999, 9_999_999); // fresh is exempt until promoted
+    expect(store.getActive()[0].status).toBe('fresh');
+  });
+
+  it('a refresh un-stales an aged exhibit', () => {
+    const store = createGalleryStore();
+    store.applyOps([create(artifact('a', { decayClass: 'fast' }))], 0, 0);
+    store.applyOps([], 1, 0);
+    store.refreshStaleness(STALENESS_THRESHOLDS.fast.events + 2, 0);
+    expect(store.getActive()[0].status).toBe('stale');
+    store.applyOps([refresh(artifact('a', { decayClass: 'fast' }))], STALENESS_THRESHOLDS.fast.events + 2, 0);
+    expect(store.getActive()[0].status).toBe('active');
+  });
+});

--- a/tests/inference/shadow-inference-engine.test.ts
+++ b/tests/inference/shadow-inference-engine.test.ts
@@ -54,6 +54,31 @@ function validResponse(overrides: Record<string, unknown> = {}): string {
   });
 }
 
+/** A curator (v2) response that authors one exhibit via a create op. */
+function curatorResponse(artifactId = 'session-story', ops?: unknown[]): string {
+  return JSON.stringify({
+    pulse: { phase: 'debugging', phaseConfidence: 0.7, riskLevel: 'medium', headline: 'Circling a 403.' },
+    galleryOps: ops ?? [
+      {
+        op: 'create',
+        artifact: {
+          id: artifactId,
+          exhibitType: 'activity_narrative',
+          title: 'The database session, as a story',
+          narrative: 'A pivot to database-only recovery that ends unfinished.',
+          relevance: 0.9,
+          decayClass: 'slow',
+          status: 'fresh',
+          payload: {
+            threads: [{ id: 'plan', label: 'plan pivot' }],
+            beats: [{ at: '08:39', title: 'scope narrows', body: 'x', side: 'top', thread: 'plan' }],
+          },
+        },
+      },
+    ],
+  });
+}
+
 /**
  * Non-checkpoint event buffer: subscribers are called directly on push().
  */
@@ -334,6 +359,54 @@ describe('createInferenceEngine — orchestrator integration', () => {
       expect(client.calls.length).toBe(1);
     });
     expect(onInsights).toHaveBeenCalled();
+    engine.stop();
+  });
+
+  it('applies curator gallery ops, exposes the gallery, and feeds it into the next packet', async () => {
+    const onInsights = vi.fn();
+    const onGallery = vi.fn();
+    const buffer = new FakeEventBuffer();
+    client.enqueue({ text: curatorResponse('session-story'), model: 'fake/1', latencyMs: 5 });
+    client.enqueue({ text: curatorResponse('session-story', []), model: 'fake/1', latencyMs: 5 });
+
+    const engine = createInferenceEngine({
+      buffer,
+      getState: async () => derivedState(),
+      onInsights,
+      onGallery,
+      client,
+      privacy: ALLOWED_PRIVACY,
+    });
+
+    await engine.start();
+
+    // First firing authors an exhibit.
+    buffer.push(makeEvent('e1', 'tool_failed'));
+    await vi.waitFor(() => {
+      expect(client.calls.length).toBe(1);
+    });
+
+    // The gallery is exposed to the renderer with the created artifact.
+    expect(onGallery).toHaveBeenCalledOnce();
+    const exposed: Array<{ id: string; status: string }> = onGallery.mock.calls[0]?.[0] ?? [];
+    expect(exposed.some((a) => a.id === 'session-story')).toBe(true);
+
+    // Derived legacy insights still flow (phase from pulse, summary from the created artifact).
+    const insights: ShadowInsight[] = onInsights.mock.calls[0]?.[0] ?? [];
+    expect(insights.some((i) => i.kind === 'phase')).toBe(true);
+    expect(insights.some((i) => i.kind === 'summary')).toBe(true);
+
+    // Second firing: the packet fed to the model now contains THE GALLERY with
+    // the prior exhibit — the gallery is the curator's memory.
+    buffer.push(makeEvent('e2', 'tool_failed'));
+    await vi.waitFor(() => {
+      expect(client.calls.length).toBe(2);
+    });
+    const secondPacket = client.calls[1]!.userMessage;
+    expect(secondPacket).toContain('--- THE GALLERY');
+    expect(secondPacket).toContain('session-story');
+    expect(secondPacket).toContain('The database session, as a story');
+
     engine.stop();
   });
 

--- a/tests/inference/trigger-thresholds.test.ts
+++ b/tests/inference/trigger-thresholds.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Trigger cadence for the curator design (docs/plans/plan-exhibit-floor.md):
+ * fewer, bigger normal-path calls. The immediate paths (agent_completed,
+ * tool_failed) are unchanged; the normal-path floor is raised to 25 events /
+ * 120s. These tests pin the *default* thresholds (no config override) so a
+ * silent loosening would fail.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { createInferenceTrigger } from '../../src/inference/trigger';
+import { createVirtualClock } from '../../src/shared/clock';
+import type { CanonicalEvent } from '../../src/shared/schema';
+
+const makeEvent = (kind: CanonicalEvent['kind'] = 'message'): CanonicalEvent => ({
+  id: Math.random().toString(),
+  kind,
+  timestamp: new Date().toISOString(),
+  source: 'claude-transcript',
+  sessionId: 'sess',
+  actor: 'assistant',
+  payload: {},
+});
+
+describe('createInferenceTrigger — raised default thresholds (curator cadence)', () => {
+  it('immediate paths still fire on tool_failed and agent_completed', () => {
+    for (const kind of ['tool_failed', 'agent_completed'] as const) {
+      const cb = vi.fn();
+      const trigger = createInferenceTrigger(cb);
+      trigger.onEvents([makeEvent(kind)]);
+      expect(cb).toHaveBeenCalledTimes(1);
+      trigger.stop();
+    }
+  });
+
+  it('does NOT fire the normal path below the 25-event floor even after 120s', () => {
+    const cb = vi.fn();
+    const clock = createVirtualClock(0);
+    const trigger = createInferenceTrigger(cb, {}, clock);
+    clock.advanceTo(200_000); // 200s elapsed, well past the 120s time gate
+    trigger.onEvents(Array.from({ length: 24 }, () => makeEvent()));
+    clock.drain();
+    expect(cb).not.toHaveBeenCalled();
+    trigger.stop();
+  });
+
+  it('does NOT fire the normal path before 120s even with 25 events', () => {
+    const cb = vi.fn();
+    const clock = createVirtualClock(0);
+    const trigger = createInferenceTrigger(cb, {}, clock);
+    clock.advanceTo(100_000); // 100s elapsed, below the 120s time gate
+    trigger.onEvents(Array.from({ length: 25 }, () => makeEvent()));
+    clock.drain();
+    expect(cb).not.toHaveBeenCalled();
+    trigger.stop();
+  });
+
+  it('fires the normal path once 25 events AND 120s are both satisfied', () => {
+    const cb = vi.fn();
+    const clock = createVirtualClock(0);
+    const trigger = createInferenceTrigger(cb, {}, clock);
+    clock.advanceTo(120_000);
+    trigger.onEvents(Array.from({ length: 25 }, () => makeEvent()));
+    clock.drain(); // flush the 200ms debounce on virtual time
+    expect(cb).toHaveBeenCalledTimes(1);
+    trigger.stop();
+  });
+
+  it('still forces a trigger at the 50-event ceiling regardless of the timer', () => {
+    const cb = vi.fn();
+    const clock = createVirtualClock(0);
+    const trigger = createInferenceTrigger(cb, {}, clock);
+    trigger.onEvents(Array.from({ length: 50 }, () => makeEvent()));
+    expect(cb).toHaveBeenCalledTimes(1); // max_events fires immediately, no debounce
+    trigger.stop();
+  });
+});


### PR DESCRIPTION
## **User description**
## PR-C: the curator pipeline

Builds on the exhibit component library (PR-B) to make the shadow LLM the
**curator** of the exhibit floor. Implements the accepted design in
`docs/plans/plan-exhibit-floor.md` using the verbatim prompt in
`docs/plans/curator-prompt-v2.md`.

### What lands

- **Prompt v2** — `SHADOW_SYSTEM_PROMPT` is the exhibit curator: `{ pulse,
  galleryOps }` over the seven-type vocabulary, THE GALLERY fed back as memory,
  curation over completeness. Installed verbatim; doc comment rewritten with a
  2026-07-23 iteration-log milestone.
- **Response parser** — `parseCuratorResponse` handles the curator (v2) shape,
  the legacy flat (v1) shape, and unparseable output. `validateExhibitArtifact`
  checks each artifact against the discriminated union in
  `src/renderer/exhibits/types.ts` (envelope + exhibitType membership + per-type
  payload required fields); invalid artifacts are dropped with a logged reason.
  The legacy `ShadowInsight` kinds are derived FROM the new shape, so the status
  strip, vignette, ghost trail, and ShadowPanel keep working unchanged.
- **GalleryStore** — holds the current `ExhibitArtifact` map: create/refresh/
  retire, fresh→active promotion on subsequent packets, and dual-gated staleness
  by `decayClass` (fast/medium/slow → stale after N events OR M minutes).
- **THE GALLERY packet section** — each active/stale exhibit (envelope + one-line
  payload summary) plus retired-this-session ids+reasons, capped at ~15% of the
  packet token budget (envelopes-only, then relevance-pruned, when over).
- **Renderer wiring** — the engine exposes the gallery via `onGallery`; the
  session manager rides it on `SnapshotPayload.gallery` through the existing
  dirty-refresh path; `App` passes it to `ExhibitStage`. The fixture gallery
  stays the boot/fixture-only fallback; live/replay show the curator's floor.
- **Replay** — the runner carries the gallery back into each packet, records a
  per-firing galleryOps summary (counts + ids), includes the final gallery in
  the report, and gains a `--gallery-out` flag.
- **Trigger tuning** — normal-path floor raised to 25 events / 120s (immediate
  paths unchanged; ceiling stays 50) for fewer, bigger curator calls.

### Tests

New suites cover the parser (new/legacy shapes, invalid-artifact dropping,
legacy-insight derivation), gallery store (ops, staleness, retire/archive),
packager gallery section (present, capped, retired lines), engine integration
(ops applied → gallery exposed → next packet contains THE GALLERY), and the new
trigger thresholds. Full `npm test` (tsc --noEmit && vitest run) is green: 531
tests across 60 files, plus the 3 live-session tests in the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9EpjZNoWaXLzfG93tdvTU


___

## **CodeAnt-AI Description**
**Add a curator gallery to inference, replay, and the live exhibit floor**

### What Changed
- The shadow now returns a curator-style response that can create, refresh, and retire gallery exhibits instead of only producing flat insights
- The live app and replay report now carry the current gallery forward, show it in the exhibit stage, and can export the final gallery to JSON
- The context sent to the model now includes THE GALLERY plus retired exhibit reasons, while keeping that section within a small share of the packet budget
- Replay and trigger timing were adjusted so inference runs less often on the normal path, with tests covering the new gallery flow and cadence

### Impact
`✅ Live exhibit floor now shows curated gallery updates`
`✅ Fewer noisy inference calls during routine activity`
`✅ Replay reports can include the final gallery`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
